### PR TITLE
Report timers/histograms, add hyphen prefix support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "hyper 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ mime = "0.2.0"
 rustc-serialize = "0.3.19"
 time = "0.1"
 url = "1.1.1"
+regex = "0.1"
 
 [profile.release]
 lto = true

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -31,8 +31,10 @@ pub fn factory(console: &bool,
                                                          metric_source)));
     }
     if *librato {
-        backends.push(Box::new(librato::Librato::new(librato_username, librato_token,
-                                                     metric_source, librato_host)));
+        backends.push(Box::new(librato::Librato::new(librato_username,
+                                                     librato_token,
+                                                     metric_source,
+                                                     librato_host)));
     }
     backends.into_boxed_slice()
 }

--- a/src/backends/librato.rs
+++ b/src/backends/librato.rs
@@ -1,12 +1,14 @@
 use super::super::backend::Backend;
 use super::super::buckets::Buckets;
 use std::str::FromStr;
+use std::collections::BTreeMap;
 use time;
-use rustc_serialize::json;
+use rustc_serialize::json::{Json, ToJson};
 use hyper::client::Client;
 use hyper::header::{ContentType, Authorization, Basic, Connection};
 use url;
 use mime::Mime;
+use regex::Regex;
 
 #[derive(Debug)]
 pub struct Librato {
@@ -16,19 +18,53 @@ pub struct Librato {
     host: String,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug)]
+#[derive(Debug)]
 pub struct LCounter {
     name: String,
     value: f64,
+    source: Option<String>,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug)]
+impl ToJson for LCounter {
+    fn to_json(&self) -> Json {
+        let mut d = BTreeMap::new();
+        d.insert("name".to_string(), self.name.to_json());
+        d.insert("value".to_string(), self.value.to_json());
+        match self.source {
+            Some(ref src) => {
+                d.insert("source".to_string(), src.to_json());
+                ()
+            }
+            None => (),
+        };
+        Json::Object(d)
+    }
+}
+
+#[derive(Debug)]
 pub struct LGuage {
     name: String,
     value: f64,
+    source: Option<String>,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug)]
+impl ToJson for LGuage {
+    fn to_json(&self) -> Json {
+        let mut d = BTreeMap::new();
+        d.insert("name".to_string(), self.name.to_json());
+        d.insert("value".to_string(), self.value.to_json());
+        match self.source {
+            Some(ref src) => {
+                d.insert("source".to_string(), src.to_json());
+                ()
+            }
+            None => (),
+        };
+        Json::Object(d)
+    }
+}
+
+#[derive(Debug)]
 pub struct LPayload {
     guages: Vec<LGuage>,
     counters: Vec<LCounter>,
@@ -36,6 +72,16 @@ pub struct LPayload {
     measure_time: i64,
 }
 
+impl ToJson for LPayload {
+    fn to_json(&self) -> Json {
+        let mut d = BTreeMap::new();
+        d.insert("guages".to_string(), self.guages.to_json());
+        d.insert("counters".to_string(), self.counters.to_json());
+        d.insert("source".to_string(), self.source.to_json());
+        d.insert("measure_time".to_string(), self.measure_time.to_json());
+        Json::Object(d)
+    }
+}
 
 impl Librato {
     /// Create a Librato formatter
@@ -62,37 +108,128 @@ impl Librato {
             None => time::get_time().sec,
         };
 
+        let re = Regex::new(r"(?x)
+((?P<source>.*)-)?  # the source
+(?P<metric>.*) # the metric
+")
+            .unwrap();
+
         let mut guages = vec![];
         let mut counters = vec![];
 
         counters.push(LCounter {
             name: "cernan.bad_messages".to_string(),
             value: buckets.bad_messages() as f64,
+            source: None,
         });
         counters.push(LCounter {
             name: "cernan.total_messages".to_string(),
             value: buckets.total_messages() as f64,
+            source: None,
         });
 
         for (key, value) in buckets.counters().iter() {
+            let caps = re.captures(&key).unwrap();
             counters.push(LCounter {
-                name: key.to_string(),
+                name: caps.name("metric").unwrap().to_string(),
                 value: *value,
+                source: caps.name("source").map(|x| x.to_string()),
             });
         }
         for (key, value) in buckets.gauges().iter() {
+            let caps = re.captures(&key).unwrap();
             guages.push(LGuage {
-                name: key.to_string(),
+                name: caps.name("metric").unwrap().to_string(),
                 value: *value,
+                source: caps.name("source").map(|x| x.to_string()),
             });
         }
+
+        for (key, value) in buckets.histograms().iter() {
+            let caps = re.captures(&key).unwrap();
+            guages.push(LGuage {
+                name: format!("{}.min", caps.name("metric").unwrap().to_string()),
+                value: value.min().unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+            guages.push(LGuage {
+                name: format!("{}.max", caps.name("metric").unwrap().to_string()),
+                value: value.max().unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+            guages.push(LGuage {
+                name: format!("{}.mean", caps.name("metric").unwrap().to_string()),
+                value: value.mean().unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+            guages.push(LGuage {
+                name: format!("{}.50", caps.name("metric").unwrap().to_string()),
+                value: value.percentile(50.0).unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+            guages.push(LGuage {
+                name: format!("{}.90", caps.name("metric").unwrap().to_string()),
+                value: value.percentile(90.0).unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+            guages.push(LGuage {
+                name: format!("{}.99", caps.name("metric").unwrap().to_string()),
+                value: value.percentile(99.0).unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+            guages.push(LGuage {
+                name: format!("{}.999", caps.name("metric").unwrap().to_string()),
+                value: value.percentile(99.9).unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+        }
+
+        for (key, value) in buckets.timers().iter() {
+            let caps = re.captures(&key).unwrap();
+            guages.push(LGuage {
+                name: format!("{}.min", caps.name("metric").unwrap().to_string()),
+                value: value.min().unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+            guages.push(LGuage {
+                name: format!("{}.max", caps.name("metric").unwrap().to_string()),
+                value: value.max().unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+            guages.push(LGuage {
+                name: format!("{}.mean", caps.name("metric").unwrap().to_string()),
+                value: value.mean().unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+            guages.push(LGuage {
+                name: format!("{}.50", caps.name("metric").unwrap().to_string()),
+                value: value.percentile(50.0).unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+            guages.push(LGuage {
+                name: format!("{}.90", caps.name("metric").unwrap().to_string()),
+                value: value.percentile(90.0).unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+            guages.push(LGuage {
+                name: format!("{}.99", caps.name("metric").unwrap().to_string()),
+                value: value.percentile(99.0).unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+            guages.push(LGuage {
+                name: format!("{}.999", caps.name("metric").unwrap().to_string()),
+                value: value.percentile(99.9).unwrap(),
+                source: caps.name("source").map(|x| x.to_string()),
+            });
+        }
+
         let obj = LPayload {
             guages: guages,
             counters: counters,
             source: self.source.clone(),
             measure_time: start,
         };
-        json::encode(&obj).unwrap()
+        obj.to_json().to_string()
     }
 }
 
@@ -121,12 +258,14 @@ impl Backend for Librato {
 mod test {
     use super::super::super::metric::{Metric, MetricKind};
     use super::super::super::buckets::Buckets;
+    use regex::Regex;
     use super::*;
 
     fn make_buckets() -> Buckets {
         let mut buckets = Buckets::new();
         let m1 = Metric::new("test.counter", 1.0, MetricKind::Counter(1.0));
         let m2 = Metric::new("test.gauge", 3.211, MetricKind::Gauge);
+        let m6 = Metric::new("src-test.gauge.2", 3.211, MetricKind::Gauge);
 
         let m3 = Metric::new("test.timer", 12.101, MetricKind::Timer);
         let m4 = Metric::new("test.timer", 1.101, MetricKind::Timer);
@@ -136,7 +275,32 @@ mod test {
         buckets.add(&m3);
         buckets.add(&m4);
         buckets.add(&m5);
+        buckets.add(&m6);
         buckets
+    }
+
+    #[test]
+    fn test_our_regex_with_source() {
+        let re = Regex::new(r"(?x)
+((?P<source>.*)-)?  # the source
+(?P<metric>.*) # the metric
+")
+            .unwrap();
+        let caps = re.captures("source-foo.bar.baz").unwrap();
+        assert_eq!(Some("source"), caps.name("source"));
+        assert_eq!(Some("foo.bar.baz"), caps.name("metric"));
+    }
+
+    #[test]
+    fn test_our_regex_no_source() {
+        let re = Regex::new(r"(?x)
+((?P<source>.*)-)?  # the source
+(?P<metric>.*) # the metric
+")
+            .unwrap();
+        let caps = re.captures("foo.bar.baz").unwrap();
+        assert_eq!(None, caps.name("source"));
+        assert_eq!(Some("foo.bar.baz"), caps.name("metric"));
     }
 
     #[test]
@@ -145,10 +309,15 @@ mod test {
         let librato = Librato::new("user", "token", "test-src", "http://librato.example.com");
         let result = librato.format_stats(&buckets, Some(10101));
 
-        assert!(result ==
-                "{\"guages\":[{\"name\":\"test.gauge\",\"value\":3.211}],\"counters\":[{\"name\":\
-                 \"cernan.bad_messages\",\"value\":0.0},{\"name\":\"cernan.total_messages\",\
-                 \"value\":5.0},{\"name\":\"test.counter\",\"value\":1.0}],\"source\":\
-                 \"test-src\",\"measure_time\":10101}");
+        assert_eq!("{\"counters\":[{\"name\":\"cernan.bad_messages\",\"value\":0.0},{\"name\":\
+                    \"cernan.total_messages\",\"value\":6.0},{\"name\":\"test.counter\",\
+                    \"value\":1.0}],\"guages\":[{\"name\":\"test.gauge\",\"value\":3.211},\
+                    {\"name\":\"test.gauge.2\",\"source\":\"src\",\"value\":3.211},{\"name\":\
+                    \"test.timer.min\",\"value\":1.1},{\"name\":\"test.timer.max\",\"value\":12.\
+                    1},{\"name\":\"test.timer.mean\",\"value\":5.43},{\"name\":\"test.timer.50\",\
+                    \"value\":12.1},{\"name\":\"test.timer.90\",\"value\":12.1},{\"name\":\"test.\
+                    timer.99\",\"value\":12.1},{\"name\":\"test.timer.999\",\"value\":12.1}],\
+                    \"measure_time\":10101,\"source\":\"test-src\"}",
+                   result);
     }
 }

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -64,7 +64,8 @@ impl Buckets {
                 if !self.counters.contains_key(&name) {
                     let _ = self.counters.insert(value.name.to_owned(), 0.0);
                 };
-                let counter = self.counters.get_mut(&name).expect("shouldn't happen but did, counter");
+                let counter =
+                    self.counters.get_mut(&name).expect("shouldn't happen but did, counter");
                 *counter = *counter + value.value * (1.0 / rate);
             }
             MetricKind::Gauge => {
@@ -74,7 +75,8 @@ impl Buckets {
                 if !self.histograms.contains_key(&name) {
                     let _ = self.histograms.insert(value.name.to_owned(), Histogram::new());
                 };
-                let hist = self.histograms.get_mut(&name).expect("shouldn't happen but did, histogram");
+                let hist =
+                    self.histograms.get_mut(&name).expect("shouldn't happen but did, histogram");
                 let _ = (*hist).increment(value.value);
             }
             MetricKind::Timer => {
@@ -228,7 +230,8 @@ mod test {
         assert!(buckets.timers.contains_key("some.metric"),
                 "Should contain the metric key");
 
-        assert_eq!(Result::Ok(11.5), buckets.timers.get_mut("some.metric").expect("hwhap").min());
+        assert_eq!(Result::Ok(11.5),
+                   buckets.timers.get_mut("some.metric").expect("hwhap").min());
 
         let metric_two = Metric::new("some.metric", 99.5, MetricKind::Timer);
         buckets.add(&metric_two);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,23 +5,35 @@
 
 use docopt::Docopt;
 
-static USAGE: &'static str = "
+static USAGE: &'static str =
+    "
 Usage: cernan [options]
        cernan --help
 
 Options:
-  -h, --help              Print help information.
+  -h, --help              Print help \
+     information.
   -p, --port=<p>          The UDP port to bind to [default: 8125].
-  --flush-interval=<p>    How frequently to flush metrics to the backends in seconds. [default: 10].
+  \
+     --flush-interval=<p>    How frequently to flush metrics to the backends in seconds. \
+     [default: 10].
   --console               Enable the console backend.
-  --wavefront             Enable the wavefront backend.
+  --wavefront             \
+     Enable the wavefront backend.
   --librato               Enable the librato backend.
-  --metric-source=<p>     The source that will be reported to supporting backends. [default: cernan]
+  \
+     --metric-source=<p>     The source that will be reported to supporting backends. [default: \
+     cernan]
   --wavefront-port=<p>    The port wavefront proxy is running on. [default: 2878].
-  --wavefront-host=<p>    The host wavefront proxy is running on. [default: 127.0.0.1].
-  --librato-username=<p>  The librato username for authentication. [default: statsd].
-  --librato-host=<p>      The librato host to report to. [default: https://metrics-api.librato.com/v1/metrics].
-  --librato-token=<p>     The librato token for authentication. [default: statsd].
+  \
+     --wavefront-host=<p>    The host wavefront proxy is running on. [default: 127.0.0.1].
+  \
+     --librato-username=<p>  The librato username for authentication. [default: statsd].
+  \
+     --librato-host=<p>      The librato host to report to. [default: \
+     https://metrics-api.librato.com/v1/metrics].
+  --librato-token=<p>     The librato token for \
+     authentication. [default: statsd].
 ";
 
 /// Holds the parsed command line arguments

--- a/src/hist.rs
+++ b/src/hist.rs
@@ -25,25 +25,29 @@ impl Histogram {
         self.inner_hist.increment(u64_val)
     }
 
-    pub fn percentile(&self, percent: f64) ->  Result<f64, &'static str> {
+    pub fn percentile(&self, percent: f64) -> Result<f64, &'static str> {
         match self.inner_hist.percentile(percent) {
-            Result::Ok(val) => Result::Ok( (((val as f64) / self.scaling_factor) * 100.0).round() / 100.0 ),
-            Result::Err(why) => Result::Err(why)
+            Result::Ok(val) => {
+                Result::Ok((((val as f64) / self.scaling_factor) * 100.0).round() / 100.0)
+            }
+            Result::Err(why) => Result::Err(why),
         }
     }
 
-    pub fn min(&self) ->  Result<f64, &'static str> {
+    pub fn min(&self) -> Result<f64, &'static str> {
         self.percentile(0.0)
     }
 
-    pub fn max(&self) ->  Result<f64, &'static str> {
+    pub fn max(&self) -> Result<f64, &'static str> {
         self.percentile(100.0)
     }
 
     pub fn mean(&self) -> Result<f64, &'static str> {
         match self.inner_hist.mean() {
-            Result::Ok(val) => Result::Ok( (((val as f64) / self.scaling_factor) * 100.0).round() / 100.0 ),
-            Result::Err(why) => Result::Err(why)
+            Result::Ok(val) => {
+                Result::Ok((((val as f64) / self.scaling_factor) * 100.0).round() / 100.0)
+            }
+            Result::Err(why) => Result::Err(why),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ extern crate mime;
 extern crate rustc_serialize;
 extern crate time;
 extern crate url;
+extern crate regex;
 
 use backend::Backend;
 use std::str;


### PR DESCRIPTION
In existing postmates systems there is a need to parse metrics with
names like

```
source.machine-metric.name
```

as being a metric named 'metric.name' with source 'source.machine'.
The etsy/statsd backend has been modified to take a regex to fiddle
with this but I've hard coded it in the expectation that future
backends will be programmable by the end-user.

This commit:
- Fixes #4
- Fixes #7

Signed-off-by: Brian L. Troutwine blt@postmates.com
