### PR TITLE
Admit [0-9]* in in cernan metric names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cernan"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "docopt 0.6.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "histogram 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cernan"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Brian L. Troutwine <blt@postmates.com>"]
 build = "build.rs"
 

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -72,6 +72,8 @@ mod tests {
 
     #[test]
     fn test_parse_metric_payload() {
+        assert_eq!(statsd::parse_MetricPayload("foo.bar.99:12.3|ms").unwrap(),
+                   [Metric::new("foo.bar.99", 12.3, MetricKind::Timer)]);
         assert_eq!(statsd::parse_MetricPayload("foo.bar:12.3|ms").unwrap(),
                    [Metric::new("foo.bar", 12.3, MetricKind::Timer)]);
         assert_eq!(statsd::parse_MetricPayload("first:1.1|ms\nsnd:2.2|g\n").unwrap(),

--- a/src/metrics/statsd.lalrpop
+++ b/src/metrics/statsd.lalrpop
@@ -11,7 +11,7 @@ Kind: MetricKind = {
     "c@" <Num> => MetricKind::Counter(<>),
 };
 
-MetricName: String = <s:r"[_A-Za-z\.-]+"> => String::from_str(s).unwrap();
+MetricName: String = <s:r"[A-Za-z][_A-Z0-9a-z\.-]*"> => String::from_str(s).unwrap();
 
 Num: f64 = <s:r"[-+]?[0-9]+\.?[0-9]*"> => f64::from_str(s).unwrap();
 


### PR DESCRIPTION
As pointed out by John, cernan is not able to ingest all the names
that it emits. In particular, consider foo.bar.999. Cernan would
reject this as a bad message.

This resolves #14.

Signed-off-by: Brian L. Troutwine blt@postmates.com
