### PR TITLE
Cernan will now accept arbitrary metadata tags on CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ that much. To backends use the CLI flags:
 --wavefront           Enable the wavefront backend.
 ```
 
-For backends which support it `cernan` can report the source of the metric. In
-AWS you might choose to set this to the instance ID. You may set the source like
-so:
+For backends which support it `cernan` can report metadata about the
+metric. These are called "tags" by some aggregators and `cernan` uses this
+terminology. In AWS you might choose to include your instance ID with each
+metric point, as well as the service name. You may set tags like so:
 
 ```
---metric-source=<p>     The source that will be reported to supporting backends. [default: cernan]
+--tags=<p>     A comma separated list of tags to report to supporting backends. [default: source=cernan]
 ```
 
 The librato backend has additional options for defining authentication:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,8 +22,7 @@ Options:
      Enable the wavefront backend.
   --librato               Enable the librato backend.
   \
-     --metric-source=<p>     The source that will be reported to supporting backends. [default: \
-     cernan]
+  --tags=<p>     A comma separated list of tags to report to supporting backends. [default: source=cernan]
   --wavefront-port=<p>    The port wavefront proxy is running on. [default: 2878].
   \
      --wavefront-host=<p>    The host wavefront proxy is running on. [default: 127.0.0.1].
@@ -44,7 +43,7 @@ pub struct Args {
     pub flag_console: bool,
     pub flag_wavefront: bool,
     pub flag_librato: bool,
-    pub flag_metric_source: String,
+    pub flag_tags: String,
     pub flag_wavefront_port: u16,
     pub flag_wavefront_host: String,
     pub flag_librato_username: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
     let mut backends = backend::factory(&args.flag_console,
                                         &args.flag_wavefront,
                                         &args.flag_librato,
-                                        &args.flag_metric_source,
+                                        &args.flag_tags,
                                         &args.flag_wavefront_host,
                                         &args.flag_wavefront_port,
                                         &args.flag_librato_username,


### PR DESCRIPTION
This update allows the user to specify a comma separated list of
metadata tags on cernan startup. This supplants --metric_source in
favor of tags. Old cernan default behaviour can be achieved by
setting

```
--tags source=cernan
```

If you wish to have the above and include a metadata tag foo=bar this
would look like

```
--tags source=cernan,foo=bar
--tags foo=bar,source=cernan
```

Resolves #16 

Signed-off-by: Brian L. Troutwine blt@postmates.com
