### PR TITLE
Include --version flag in executable

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,7 @@ Options:
      https://metrics-api.librato.com/v1/metrics].
   --librato-token=<p>     The librato token for \
      authentication. [default: statsd].
+  --version
 ";
 
 /// Holds the parsed command line arguments
@@ -51,6 +52,7 @@ pub struct Args {
     pub flag_librato_token: String,
     pub flag_librato_host: String,
     pub flag_help: bool,
+    pub flag_version: bool,
 }
 
 pub fn parse_args() -> Args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ extern crate regex;
 use std::str;
 use std::sync::mpsc::channel;
 use std::thread;
+use std::process::exit;
 
 mod backend;
 mod buckets;
@@ -32,9 +33,15 @@ mod backends {
     pub mod wavefront;
 }
 
+const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 
 fn main() {
     let args = cli::parse_args();
+
+    if args.flag_version {
+        println!("cernan - {}", VERSION.unwrap_or("unknown"));
+        exit(0);
+    }
 
     let mut backends = backend::factory(&args.flag_console,
                                         &args.flag_wavefront,


### PR DESCRIPTION
It's been difficult when debugging cernan issues to be without
version information in the executable. This commit addresses
this issue.

Resolves #17

Signed-off-by: Brian L. Troutwine blt@postmates.com
