### PR TITLE
Incorporate code-smell fixes via clippy

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -28,8 +28,7 @@ pub fn factory(console: &bool,
         backends.push(Box::new(console::Console::new()));
     }
     if *wavefront {
-        let re = Regex::new(r",").unwrap();
-        let wf_tags: String = re.replace_all(tags, " ");
+        let wf_tags: String = tags.replace(",", " ");
         backends.push(Box::new(wavefront::Wavefront::new(wavefront_host,
                                                          *wavefront_port,
                                                          wf_tags)));

--- a/src/backends/console.rs
+++ b/src/backends/console.rs
@@ -42,23 +42,22 @@ impl Backend for Console {
 
         println!("  counters:");
         for (key, value) in self.aggrs.counters() {
-            fmt_line(&key, &value);
+            fmt_line(key, value);
         }
 
         println!("  gauges:");
         for (key, value) in self.aggrs.gauges() {
-            fmt_line(&key, &value);
+            fmt_line(key, value);
         }
 
         println!("  histograms:");
         for (key, value) in self.aggrs.histograms() {
-            for tup in [("min", 0.0),
-                        ("max", 1.0),
-                        ("50", 0.5),
-                        ("90", 0.90),
-                        ("99", 0.99),
-                        ("999", 0.999)]
-                .iter() {
+            for tup in &[("min", 0.0),
+                         ("max", 1.0),
+                         ("50", 0.5),
+                         ("90", 0.90),
+                         ("99", 0.99),
+                         ("999", 0.999)] {
                 let stat: &str = tup.0;
                 let quant: f64 = tup.1;
                 println!("    {}: {} {}", key, stat, value.query(quant).unwrap().1);
@@ -67,13 +66,12 @@ impl Backend for Console {
 
         println!("  timers:");
         for (key, value) in self.aggrs.timers() {
-            for tup in [("min", 0.0),
-                        ("max", 1.0),
-                        ("50", 0.5),
-                        ("90", 0.90),
-                        ("99", 0.99),
-                        ("999", 0.999)]
-                .iter() {
+            for tup in &[("min", 0.0),
+                         ("max", 1.0),
+                         ("50", 0.5),
+                         ("90", 0.90),
+                         ("99", 0.99),
+                         ("999", 0.999)] {
                 let stat: &str = tup.0;
                 let quant: f64 = tup.1;
                 println!("    {}: {} {}", key, stat, value.query(quant).unwrap().1);

--- a/src/backends/librato.rs
+++ b/src/backends/librato.rs
@@ -80,13 +80,12 @@ impl Librato {
         }
 
         for (key, value) in self.aggrs.histograms().iter() {
-            for tup in [("min", 0.0),
-                        ("max", 1.0),
-                        ("50", 0.5),
-                        ("90", 0.90),
-                        ("99", 0.99),
-                        ("999", 0.999)]
-                .iter() {
+            for tup in &[("min", 0.0),
+                         ("max", 1.0),
+                         ("50", 0.5),
+                         ("90", 0.90),
+                         ("99", 0.99),
+                         ("999", 0.999)] {
                 let stat: &str = tup.0;
                 let quant: f64 = tup.1;
                 gauges.push(LGauge {
@@ -97,13 +96,12 @@ impl Librato {
         }
 
         for (key, value) in self.aggrs.timers().iter() {
-            for tup in [("min", 0.0),
-                        ("max", 1.0),
-                        ("50", 0.5),
-                        ("90", 0.90),
-                        ("99", 0.99),
-                        ("999", 0.999)]
-                .iter() {
+            for tup in &[("min", 0.0),
+                         ("max", 1.0),
+                         ("50", 0.5),
+                         ("90", 0.90),
+                         ("99", 0.99),
+                         ("999", 0.999)] {
                 let stat: &str = tup.0;
                 let quant: f64 = tup.1;
                 gauges.push(LGauge {
@@ -132,7 +130,7 @@ impl Backend for Librato {
         let client = Client::new();
         let payload = self.format_stats(None);
         let mime: Mime = "application/json".parse().unwrap();
-        let uri = url::Url::parse(&(self.host)).ok().expect("malformed url");
+        let uri = url::Url::parse(&(self.host)).expect("malformed url");
         client.post(uri)
             .body(&payload)
             .header(ContentType(mime))

--- a/src/backends/wavefront.rs
+++ b/src/backends/wavefront.rs
@@ -25,7 +25,7 @@ impl Wavefront {
     /// let wave = Wavefront::new(host, port, source);
     /// ```
     pub fn new(host: &str, port: u16, tags: String) -> Wavefront {
-        let ip = Ipv4Addr::from_str(&host).unwrap();
+        let ip = Ipv4Addr::from_str(host).unwrap();
         let addr = SocketAddrV4::new(ip, port);
         Wavefront {
             addr: addr,
@@ -53,13 +53,12 @@ impl Wavefront {
         }
 
         for (key, value) in self.aggrs.histograms().iter() {
-            for tup in [("min", 0.0),
-                        ("max", 1.0),
-                        ("50", 0.5),
-                        ("90", 0.9),
-                        ("99", 0.99),
-                        ("999", 0.999)]
-                .iter() {
+            for tup in &[("min", 0.0),
+                         ("max", 1.0),
+                         ("50", 0.5),
+                         ("90", 0.9),
+                         ("99", 0.99),
+                         ("999", 0.999)] {
                 let stat: &str = tup.0;
                 let quant: f64 = tup.1;
                 write!(stats,
@@ -74,13 +73,12 @@ impl Wavefront {
         }
 
         for (key, value) in self.aggrs.timers().iter() {
-            for tup in [("min", 0.0),
-                        ("max", 1.0),
-                        ("50", 0.5),
-                        ("90", 0.9),
-                        ("99", 0.99),
-                        ("999", 0.999)]
-                .iter() {
+            for tup in &[("min", 0.0),
+                         ("max", 1.0),
+                         ("50", 0.5),
+                         ("90", 0.9),
+                         ("99", 0.99),
+                         ("999", 0.999)] {
                 let stat: &str = tup.0;
                 let quant: f64 = tup.1;
                 write!(stats,
@@ -94,7 +92,7 @@ impl Wavefront {
             }
         }
 
-        for m in self.points.iter() {
+        for m in &self.points {
             write!(stats,
                    "{} {} {} {}\n",
                    m.name,

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -67,14 +67,14 @@ impl Buckets {
                 };
                 let hist =
                     self.histograms.get_mut(&name).expect("shouldn't happen but did, histogram");
-                let _ = (*hist).insert(value.value);
+                (*hist).insert(value.value);
             }
             MetricKind::Timer => {
                 if !self.timers.contains_key(&name) {
                     let _ = self.timers.insert(value.name.to_owned(), CKMS::new(0.001));
                 };
                 let tm = self.timers.get_mut(&name).expect("shouldn't happen but did, timer");
-                let _ = (*tm).insert(value.value);
+                (*tm).insert(value.value);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,9 +88,9 @@ fn main() {
             server::Event::UdpMessage(buf) => {
                 str::from_utf8(&buf)
                     .map(|val| {
-                        match metric::Metric::parse(&val) {
+                        match metric::Metric::parse(val) {
                             Some(metrics) => {
-                                for metric in metrics.iter() {
+                                for metric in &metrics {
                                     for backend in backends.iter_mut() {
                                         backend.deliver(metric.clone());
                                     }

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -35,7 +35,7 @@ impl Metric {
             name: name.into(),
             value: value,
             kind: kind,
-            time: time.unwrap_or(UTC::now()),
+            time: time.unwrap_or_else(UTC::now),
             source: source.map(|x| x.into()),
         }
     }


### PR DESCRIPTION
We run clippy through cargo, `cargo clippy`. It recommends what
changes ought to be made to the system. The statsd.rs generated
from lalrpop is problematic as clippy complains bitterly about
it. That'll be addressed in a future version of lalrpop.

For now, clippy is run ocassionally.

Signed-off-by: Brian L. Troutwine blt@postmates.com
