### PR TITLE
Add an option to skip aggregate gen. for wavefront

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -19,6 +19,7 @@ pub fn factory(console: &bool,
                tags: &str,
                wavefront_host: &str,
                wavefront_port: &u16,
+               wavefront_skip_aggrs: &bool,
                librato_username: &str,
                librato_token: &str,
                librato_host: &str)
@@ -31,6 +32,7 @@ pub fn factory(console: &bool,
         let wf_tags: String = tags.replace(",", " ");
         backends.push(Box::new(wavefront::Wavefront::new(wavefront_host,
                                                          *wavefront_port,
+                                                         *wavefront_skip_aggrs,
                                                          wf_tags)));
     }
     if *librato {
@@ -69,6 +71,7 @@ mod test {
                                "source=src",
                                "127.0.0.1",
                                &2878,
+                               &false,
                                "username",
                                "token",
                                "http://librato.example.com/");
@@ -83,6 +86,7 @@ mod test {
                                "source=src,host=h,service=s",
                                "127.0.0.1",
                                &2878,
+                               &false,
                                "username",
                                "token",
                                "http://librato.example.com/");
@@ -97,6 +101,7 @@ mod test {
                                "source=src",
                                "127.0.0.1",
                                &2878,
+                               &false,
                                "username",
                                "token",
                                "http://librato.example.com/");
@@ -111,6 +116,7 @@ mod test {
                                "source=src",
                                "127.0.0.1",
                                &2878,
+                               &false,
                                "username",
                                "token",
                                "http://librato.example.com/");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,12 +28,14 @@ Options:
      2878].
   --wavefront-host=<p>    The host wavefront proxy is running on. [default: \
      127.0.0.1].
-  --librato-username=<p>  The librato username for authentication. [default: \
-     statsd].
-  --librato-host=<p>      The librato host to report to. [default: \
-     https://metrics-api.librato.com/v1/metrics].
-  --librato-token=<p>     The librato token for \
+  --wavefront-skip-aggrs   Send aggregate metrics to wavefront (librato \
+     compatibility)
+  --librato-username=<p>  The librato username for \
      authentication. [default: statsd].
+  --librato-host=<p>      The librato host to report to. \
+     [default: https://metrics-api.librato.com/v1/metrics].
+  --librato-token=<p>     The librato \
+     token for authentication. [default: statsd].
   --version
 ";
 
@@ -48,6 +50,7 @@ pub struct Args {
     pub flag_tags: String,
     pub flag_wavefront_port: u16,
     pub flag_wavefront_host: String,
+    pub flag_wavefront_skip_aggrs: bool,
     pub flag_librato_username: String,
     pub flag_librato_token: String,
     pub flag_librato_host: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ fn main() {
                                         &args.flag_tags,
                                         &args.flag_wavefront_host,
                                         &args.flag_wavefront_port,
+                                        &args.flag_wavefront_skip_aggrs,
                                         &args.flag_librato_username,
                                         &args.flag_librato_token,
                                         &args.flag_librato_host);


### PR DESCRIPTION
In some systems we have no desire to ship aggregates to wavefront
for rollup. The long term ambition is to never ship aggregates,
done now for rough compatability with librato.

Signed-off-by: Brian L. Troutwine blt@postmates.com
