### PR TITLE
Significantly reduce allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "quantiles 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -74,6 +75,14 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "debug_unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -370,6 +379,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,12 +459,29 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "solicit"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_generator 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -530,6 +570,14 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "url"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +598,11 @@ dependencies = [
 [[package]]
 name = "utf8-ranges"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ chrono = "0.2"
 url = "1.1.1"
 regex = "0.1"
 lalrpop-util = "0.11.0"
+string_cache = "0.2.21"
 
 [build-dependencies]
 lalrpop = "0.11.0"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,14 +1,13 @@
-use backends::console;
-use backends::wavefront;
-use backends::librato;
+use backends::*;
 use metric::Metric;
 
 use regex::Regex;
+use std::rc::Rc;
 
 /// A 'backend' is a sink for metrics.
 pub trait Backend {
     fn flush(&mut self) -> ();
-    fn deliver(&mut self, point: Metric) -> ();
+    fn deliver(&mut self, point: Rc<Metric>) -> ();
 }
 
 /// Creates the collection of backends based on the paraemeters
@@ -23,7 +22,7 @@ pub fn factory(console: &bool,
                librato_username: &str,
                librato_token: &str,
                librato_host: &str)
-               -> Box<[Box<Backend>]> {
+               -> Vec<Box<Backend>> {
     let mut backends: Vec<Box<Backend>> = Vec::with_capacity(3);
     if *console {
         backends.push(Box::new(console::Console::new()));
@@ -45,7 +44,7 @@ pub fn factory(console: &bool,
                                                      metric_source,
                                                      librato_host)));
     }
-    backends.into_boxed_slice()
+    backends
 }
 
 

--- a/src/backends/console.rs
+++ b/src/backends/console.rs
@@ -2,10 +2,10 @@ use backend::Backend;
 use buckets::Buckets;
 use metric::Metric;
 use chrono;
+use std::rc::Rc;
 
 pub struct Console {
     aggrs: Buckets,
-    points: Vec<Metric>,
 }
 
 impl Console {
@@ -17,10 +17,7 @@ impl Console {
     /// let cons = Console::new();
     /// ```
     pub fn new() -> Console {
-        Console {
-            aggrs: Buckets::new(),
-            points: Vec::new(),
-        }
+        Console { aggrs: Buckets::new() }
     }
 }
 
@@ -31,9 +28,8 @@ fn fmt_line(key: &str, value: &f64) {
 
 
 impl Backend for Console {
-    fn deliver(&mut self, point: Metric) {
+    fn deliver(&mut self, point: Rc<Metric>) {
         self.aggrs.add(&point);
-        self.points.push(point);
     }
 
     fn flush(&mut self) {

--- a/src/backends/librato.rs
+++ b/src/backends/librato.rs
@@ -1,5 +1,5 @@
-use super::super::backend::Backend;
-use super::super::buckets::Buckets;
+use backend::Backend;
+use buckets::Buckets;
 use std::str::FromStr;
 use rustc_serialize::json;
 use hyper::client::Client;
@@ -8,6 +8,7 @@ use url;
 use chrono;
 use mime::Mime;
 use metric::Metric;
+use std::rc::Rc;
 
 pub struct Librato {
     username: String,
@@ -18,19 +19,19 @@ pub struct Librato {
 }
 
 #[derive(Debug, RustcEncodable)]
-pub struct LCounter {
+struct LCounter {
     name: String,
     value: f64,
 }
 
 #[derive(Debug, RustcEncodable)]
-pub struct LGauge {
+struct LGauge {
     name: String,
     value: f64,
 }
 
 #[derive(Debug, RustcEncodable)]
-pub struct LPayload {
+struct LPayload {
     gauges: Vec<LGauge>,
     counters: Vec<LCounter>,
     source: String,
@@ -68,13 +69,13 @@ impl Librato {
 
         for (key, value) in self.aggrs.counters().iter() {
             counters.push(LCounter {
-                name: (*key).clone(),
+                name: key.as_ref().to_string(),
                 value: *value,
             });
         }
         for (key, value) in self.aggrs.gauges().iter() {
             gauges.push(LGauge {
-                name: (*key).clone(),
+                name: key.as_ref().to_string(),
                 value: *value,
             });
         }
@@ -122,7 +123,7 @@ impl Librato {
 }
 
 impl Backend for Librato {
-    fn deliver(&mut self, point: Metric) {
+    fn deliver(&mut self, point: Rc<Metric>) {
         self.aggrs.add(&point);
     }
 
@@ -148,17 +149,23 @@ impl Backend for Librato {
 mod test {
     use metric::{Metric, MetricKind};
     use backend::Backend;
+    use std::rc::Rc;
+    use string_cache::Atom;
     use super::*;
 
     #[test]
     fn test_format_librato_buckets_no_timers() {
         let mut librato = Librato::new("user", "token", "test-src", "http://librato.example.com");
-        librato.deliver(Metric::new("test.counter", 1.0, MetricKind::Counter(1.0)));
-        librato.deliver(Metric::new("test.gauge", 3.211, MetricKind::Gauge));
-        librato.deliver(Metric::new("src-test.gauge.2", 3.211, MetricKind::Gauge));
-        librato.deliver(Metric::new("test.timer", 12.101, MetricKind::Timer));
-        librato.deliver(Metric::new("test.timer", 1.101, MetricKind::Timer));
-        librato.deliver(Metric::new("test.timer", 3.101, MetricKind::Timer));
+        librato.deliver(Rc::new(Metric::new(Atom::from("test.counter"),
+                                            1.0,
+                                            MetricKind::Counter(1.0))));
+        librato.deliver(Rc::new(Metric::new(Atom::from("test.gauge"), 3.211, MetricKind::Gauge)));
+        librato.deliver(Rc::new(Metric::new(Atom::from("src-test.gauge.2"),
+                                            3.211,
+                                            MetricKind::Gauge)));
+        librato.deliver(Rc::new(Metric::new(Atom::from("test.timer"), 12.101, MetricKind::Timer)));
+        librato.deliver(Rc::new(Metric::new(Atom::from("test.timer"), 1.101, MetricKind::Timer)));
+        librato.deliver(Rc::new(Metric::new(Atom::from("test.timer"), 3.101, MetricKind::Timer)));
         let result = librato.format_stats(Some(10101));
 
         println!("{:?}", result);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,3 @@
-// see bench_prs comment
-// #![feature(test)]
-// #[cfg(test)]
-// extern crate test;
-
 extern crate docopt;
 extern crate quantiles;
 extern crate hyper;
@@ -12,6 +7,7 @@ extern crate rustc_serialize;
 extern crate chrono;
 extern crate url;
 extern crate regex;
+extern crate string_cache;
 
 use std::str;
 use std::sync::mpsc::channel;
@@ -81,7 +77,7 @@ fn main() {
             server::Event::TimerFlush => {
                 // TODO improve this, limit here will be backend stalling and
                 // holding up all others
-                for backend in backends.iter_mut() {
+                for backend in &mut backends {
                     backend.flush();
                 }
             }
@@ -92,7 +88,7 @@ fn main() {
                         match metric::Metric::parse(val) {
                             Some(metrics) => {
                                 for metric in &metrics {
-                                    for backend in backends.iter_mut() {
+                                    for backend in &mut backends {
                                         backend.deliver(metric.clone());
                                     }
                                 }

--- a/src/metrics/statsd.lalrpop
+++ b/src/metrics/statsd.lalrpop
@@ -1,5 +1,7 @@
 use std::str::FromStr;
 use metric::{MetricKind, Metric};
+use std::rc::Rc;
+use string_cache::Atom;
 
 grammar;
 
@@ -11,12 +13,12 @@ Kind: MetricKind = {
     "c@" <Num> => MetricKind::Counter(<>),
 };
 
-MetricName: String = <s:r"[A-Za-z][_A-Z0-9a-z+/=\.-]*"> => String::from_str(s).unwrap();
+MetricName: Atom = <s:r"[A-Za-z][_A-Z0-9a-z+/=\.-]*"> => Atom::from(s);
 
 Num: f64 = <s:r"[-+]?[0-9]+\.?[0-9]*"> => f64::from_str(s).unwrap();
 
-MetricLine: Metric = {
-    <name:MetricName> ":" <val:Num> "|" <k:Kind> => Metric::new(name, val, k)
+MetricLine: Rc<Metric> = {
+    <name:MetricName> ":" <val:Num> "|" <k:Kind> => Rc::new(Metric::new(name, val, k))
 };
 
-pub MetricPayload: Vec<Metric> = { (<MetricLine>)+ };
+pub MetricPayload: Vec<Rc<Metric>> = { (<MetricLine>)+ };

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,7 +13,7 @@ pub enum Event {
 pub fn udp_server(chan: Sender<Event>, port: u16) {
     let addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), port);
     let socket = UdpSocket::bind(addr).ok().unwrap();
-    let mut buf = [0; 2048];
+    let mut buf = [0; 8192];
     loop {
         let (len, _) = match socket.recv_from(&mut buf) {
             Ok(r) => r,


### PR DESCRIPTION
This commit makes two changes that reduce total allocations. It
uses Rc<> to surround Metrics so that these do not need to be
cloned when they enter a backend. Also, we are now making use of
servo's string_cache::Atom which forces an allocation only the
first time a string is seen. Our standard use-case will be for
many metrics of the same name to be reported over and over.

This resolves issue #6.

Signed-off-by: Brian L. Troutwine blt@postmates.com
