### PR TITLE
Move from docopts to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "cernan"
 version = "0.1.6"
 dependencies = [
  "chrono 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 0.6.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -23,6 +23,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ansi_term"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "atty"
@@ -54,6 +59,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -64,6 +74,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -490,6 +514,11 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strsim"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "tempdir"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +533,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term_size"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -565,6 +602,11 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +640,11 @@ dependencies = [
 [[package]]
 name = "utf8-ranges"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Brian L. Troutwine <blt@postmates.com>"]
 build = "build.rs"
 
 [dependencies]
-docopt = "0.6.80"
 quantiles = "0.1.4"
 hyper = "0.9.6"
 lru-cache = "0.0.7"
@@ -16,6 +15,7 @@ url = "1.1.1"
 regex = "0.1"
 lalrpop-util = "0.11.0"
 string_cache = "0.2.21"
+clap = "2.9.2"
 
 [build-dependencies]
 lalrpop = "0.11.0"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -3,6 +3,8 @@ use metric::Metric;
 
 use regex::Regex;
 use std::rc::Rc;
+use clap::ArgMatches;
+use std::str::FromStr;
 
 /// A 'backend' is a sink for metrics.
 pub trait Backend {
@@ -12,113 +14,29 @@ pub trait Backend {
 
 /// Creates the collection of backends based on the paraemeters
 ///
-pub fn factory(console: &bool,
-               wavefront: &bool,
-               librato: &bool,
-               tags: &str,
-               wavefront_host: &str,
-               wavefront_port: &u16,
-               wavefront_skip_aggrs: &bool,
-               librato_username: &str,
-               librato_token: &str,
-               librato_host: &str)
-               -> Vec<Box<Backend>> {
+pub fn factory(args: &ArgMatches) -> Vec<Box<Backend>> {
     let mut backends: Vec<Box<Backend>> = Vec::with_capacity(3);
-    if *console {
+
+    let tags = args.value_of("tags").unwrap();
+    if args.value_of("console").is_some() {
         backends.push(Box::new(console::Console::new()));
     }
-    if *wavefront {
+    if args.value_of("wavefront").is_some() {
         let wf_tags: String = tags.replace(",", " ");
-        backends.push(Box::new(wavefront::Wavefront::new(wavefront_host,
-                                                         *wavefront_port,
-                                                         *wavefront_skip_aggrs,
+        backends.push(Box::new(wavefront::Wavefront::new(args.value_of("wavefront-host").unwrap(),
+                                                         u16::from_str(args.value_of("wavefront-port").unwrap()).unwrap(),
+                                                         args.value_of("wavefront-skip-aggrs").is_some(),
                                                          wf_tags)));
     }
-    if *librato {
+    if args.value_of("librato").is_some() {
         let re = Regex::new(r"(?x)(source=(?P<source>.*),+)?").unwrap();
         let metric_source = re.captures(tags).unwrap().name("source").unwrap_or("cernan");
         // librato does not support arbitrary tags, only a 'source' tag. We have
         // to parse the source tag--if it exists--out and ship only that.
-        backends.push(Box::new(librato::Librato::new(librato_username,
-                                                     librato_token,
+        backends.push(Box::new(librato::Librato::new(args.value_of("librato-username").unwrap(),
+                                                     args.value_of("librato-token").unwrap(),
                                                      metric_source,
-                                                     librato_host)));
+                                                     args.value_of("librato-host").unwrap())));
     }
     backends
-}
-
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use regex::Regex;
-
-    #[test]
-    fn wavefront_tag_munging() {
-        let tags = "source=s,host=h,service=srv";
-        let re = Regex::new(r",").unwrap();
-        let wf_tags: String = re.replace_all(tags, " ");
-
-        assert_eq!("source=s host=h service=srv", wf_tags);
-    }
-
-    #[test]
-    fn factory_makes_wavefront() {
-        let backends = factory(&false,
-                               &true,
-                               &false,
-                               "source=src",
-                               "127.0.0.1",
-                               &2878,
-                               &false,
-                               "username",
-                               "token",
-                               "http://librato.example.com/");
-        assert_eq!(1, backends.len());
-    }
-
-    #[test]
-    fn factory_makes_librato() {
-        let backends = factory(&false,
-                               &false,
-                               &true,
-                               "source=src,host=h,service=s",
-                               "127.0.0.1",
-                               &2878,
-                               &false,
-                               "username",
-                               "token",
-                               "http://librato.example.com/");
-        assert_eq!(1, backends.len());
-    }
-
-    #[test]
-    fn factory_makes_console() {
-        let backends = factory(&true,
-                               &false,
-                               &false,
-                               "source=src",
-                               "127.0.0.1",
-                               &2878,
-                               &false,
-                               "username",
-                               "token",
-                               "http://librato.example.com/");
-        assert_eq!(1, backends.len());
-    }
-
-    #[test]
-    fn factory_makes_all() {
-        let backends = factory(&true,
-                               &true,
-                               &true,
-                               "source=src",
-                               "127.0.0.1",
-                               &2878,
-                               &false,
-                               "username",
-                               "token",
-                               "http://librato.example.com/");
-        assert_eq!(3, backends.len());
-    }
 }


### PR DESCRIPTION
docopts is really lovely but it's limited in terms of some user
ergonomics. With clap it's easier to build something better for
the user but the internal datastructure we have to pass around
is hard to build.

I've nuked some tests as a result. I feel kind of bad about that.
Abstracting this would be possible but passing the exact structure
lets us avoid some allocations on startup.

Dunno. Feel of two minds about nuking those tests.

Signed-off-by: Brian L. Troutwine blt@postmates.com
