### PR TITLE
Update cernan to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,11 +1,11 @@
 [root]
 name = "cernan"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "chrono 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -168,7 +168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.9.6"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cernan"
-version = "0.1.6"
+version = "0.2.0"
 authors = ["Brian L. Troutwine <blt@postmates.com>"]
 build = "build.rs"
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Recent versions of OSX may have some goofy OpenSSL issues, which can be resolved
 by issuing
 
     > brew install openssl
+    > brew link --force openssl
 
 and following the onscreen instructions. Run
 


### PR DESCRIPTION
cernan is now a stable graphite and statsd telemetry server. It
does not allocate memory with abandon and uses an internal string
cache to avoid allocations where possible. Initial logging support
has been added to aid in debugging systems that send telemetry to
cernan.

Signed-off-by: Brian L. Troutwine blt@postmates.com
