### PR TITLE
Correct interpretation of skip aggregate flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cernan"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Brian L. Troutwine <blt@postmates.com>"]
 build = "build.rs"
 

--- a/src/backends/wavefront.rs
+++ b/src/backends/wavefront.rs
@@ -32,7 +32,7 @@ impl Wavefront {
         Wavefront {
             addr: addr,
             tags: tags,
-            mk_aggrs: !skip_aggrs,
+            mk_aggrs: skip_aggrs,
             aggrs: Buckets::new(),
             points: Vec::new(),
         }
@@ -141,7 +141,7 @@ mod test {
 
     #[test]
     fn test_format_wavefront() {
-        let mut wavefront = Wavefront::new("127.0.0.1", 2003, false, "source=test-src".to_string());
+        let mut wavefront = Wavefront::new("127.0.0.1", 2003, true, "source=test-src".to_string());
         let dt = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 11, 12);
         wavefront.deliver(Rc::new(Metric::new_with_time(Atom::from("test.counter"),
                                                         1.0,
@@ -185,7 +185,7 @@ mod test {
 
     #[test]
     fn test_format_wavefront_skip_aggrs() {
-        let mut wavefront = Wavefront::new("127.0.0.1", 2003, true, "source=test-src".to_string());
+        let mut wavefront = Wavefront::new("127.0.0.1", 2003, false, "source=test-src".to_string());
         let dt = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 11, 12);
         wavefront.deliver(Rc::new(Metric::new_with_time(Atom::from("test.counter"),
                                                         1.0,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,7 +71,7 @@ pub fn parse_args() -> Args {
              .default_value("127.0.0.1"))
         .arg(Arg::with_name("wavefront-skip-aggrs")
              .long("wavefront-skip-aggrs")
-             .help("Send aggregate metrics to wavefront")) // default false
+             .help("Skip sending aggregate metrics to wavefront")) // default false
         .arg(Arg::with_name("librato-username")
              .long("librato-username")
              .help("The librato username for authentication.")


### PR DESCRIPTION
This commit corrects the negation of the skip aggregate flag,
an unfortunate goof given that this was _just_ flipped on in
production. Such are the wages of a lack of integration testing.

Signed-off-by: Brian L. Troutwine blt@postmates.com
