### PR TITLE
Introduce reading a toml configuration file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -581,6 +582,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "traitobject"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,3 +680,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "winapi-build"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ string_cache = "0.2.21"
 clap = "2.9.2"
 fern = "0.3.5"
 log = "0.3.6"
+toml = "0.1.30"
 
 [build-dependencies]
 lalrpop = "0.11.0"

--- a/README.md
+++ b/README.md
@@ -40,32 +40,52 @@ and full trace output will be reported to the tty.
 
 # Usage
 
-The cernan server has options to control which ports its interfaces run on:
+The cernan server has a few command-line toggles to control its behaviour:
 
 ```
---statsd-port <port>        The UDP port to bind to for statsd traffic. [default: 8125]
---graphite-port <port>      The TCP port to bind to for graphite traffic. [default: 2003]
+-C, --config <config>    The config file to feed in.
+-v               Turn on verbose output.
+```
+
+The verbose flag `-v` allows multiples, each addition cranking up the verbosity
+by one. So:
+
+* `-v` -- error, warning
+* `-vv` -- error, warning, info
+* `-vvv` -- error, warning, info, debug
+* `-vvvv` -- error, warning, info, debug, trace
+
+The `--config` flag allows for more fine grained control of cernan via the
+config file.
+
+## Configuration
+
+The cernan server has options to control which ports its ingestion interfaces
+run on:
+
+```
+statsd-port=<INT>        The UDP port to bind to for statsd traffic. [default: 8125]
+graphite-port=<INT>      The TCP port to bind to for graphite traffic. [default: 2003]
 ```
 
 ## Changing how frequently metrics are output
 
 ```
---flush-interval=<p>  How frequently to flush metrics to the backends in seconds. [default: 10].
+flush-interval=<INT>  How frequently to flush metrics to the backends in seconds. [default: 10].
 ```
-
-On each flush interval event, derived metrics for timers are calculated. This
-duration is tracked as `statsd.processing_time`. You can use this metric to
-track how long statsd is spending generating derived metrics.
 
 ## Enabling the console or graphite backends
 
-By default no backends are enabled. In this mode the statsd server doesn't do
-that much. To backends use the CLI flags:
+By default no backends are enabled. In this mode cernan server doesn't do that
+much. Backends are configured in a `backends` table. To enable a backend with
+defaults it is sufficient to make a sub-table for it. In the following, all
+backends are enabled with their default:
 
 ```
---console             Enable the console backend.
---librato             Enable the librato backend.
---wavefront           Enable the wavefront backend.
+[backends]
+  [console]
+  [wavefront]
+  [librato]
 ```
 
 For backends which support it `cernan` can report metadata about the
@@ -74,25 +94,37 @@ terminology. In AWS you might choose to include your instance ID with each
 metric point, as well as the service name. You may set tags like so:
 
 ```
---tags=<p>     A comma separated list of tags to report to supporting backends. [default: source=cernan]
+[tags]
+source = cernan
 ```
+
+Each key / value pair will converted to the appropriate tag, depending on the
+backend.
+
+### librato
 
 The librato backend has additional options for defining authentication:
 
 ```
---librato-username=<p>        The librato username for authentication. [default: ceran].
---librato-token=<p>        The librato token for authentication. [default: cernan_totally_valid_token].
---librato-host <librato-host>       The librato host to report to. [default: https://metrics-api.librato.com/v1/metrics]
+username=<STRING>   The librato username for authentication. [default: ceran].
+token=<STRING>      The librato token for authentication. [default: cernan_totally_valid_token].
+host=<STRING>       The librato host to report to. [default: https://metrics-api.librato.com/v1/metrics]
 ```
+
+### wavefront
 
 The wavefront backend has additional options for defining where the wavefront
 proxy runs:
 
 ```
---wavefront-skip-aggrs    Send aggregate metrics to wavefront
---wavefront-port=<p>      The port wavefront proxy is running on. [default: 2878].
---wavefront-host=<p>      The host wavefront proxy is running on. [default: 127.0.0.1].
+skip-aggrs=<BOOL]  Send aggregate metrics to wavefront
+port=<INT>         The port wavefront proxy is running on. [default: 2878].
+host=<STRING>      The host wavefront proxy is running on. [default: 127.0.0.1].
 ```
+
+You may find an example configuration file in the top-level of this project,
+`example-config.toml`. The TOML specification is
+[here](https://github.com/toml-lang/toml).
 
 ## Prior Art
 

--- a/example-config.toml
+++ b/example-config.toml
@@ -1,0 +1,19 @@
+statsd-port = 8125
+graphite-port = 2003
+flush-interval = 10
+
+[tags]
+source = "cernan"
+
+[backends]
+    [console]
+
+    [wavefront]
+    port = 2878
+    host = "127.0.0.1"
+    skip-aggrs = true
+
+    [librato]
+    host = "https://metrics-api.librato.com/v1/metrics"
+    username = "statsd"
+    token = "statsd"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,7 +1,7 @@
 use backends::*;
 use metric::Metric;
 
-use cli::Args;
+use config::Args;
 
 use regex::Regex;
 use std::rc::Rc;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,158 @@
+//! Provides the CLI option parser
+//!
+//! Used to parse the argv/config file into a struct that
+//! the server can consume and use as configuration data.
+
+use clap::{Arg, App};
+use std::fs::File;
+use toml;
+use toml::Value;
+use std::io::Read;
+use std::fmt::Write;
+
+const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
+
+#[derive(Clone, Debug)]
+pub struct Args {
+    pub statsd_port: u16,
+    pub graphite_port: u16,
+    pub flush_interval: u64,
+    pub console: bool,
+    pub wavefront: bool,
+    pub librato: bool,
+    pub wavefront_port: Option<u16>,
+    pub wavefront_host: Option<String>,
+    pub wavefront_skip_aggrs: bool,
+    pub librato_username: Option<String>,
+    pub librato_host: Option<String>,
+    pub librato_token: Option<String>,
+    pub tags: String,
+    pub verbose: u64,
+    pub version: String,
+}
+
+pub fn parse_args() -> Args {
+    let args = App::new("cernan")
+        .version(VERSION.unwrap_or("unknown"))
+        .author("Brian L. Troutwine <blt@postmates.com>")
+        .about("telemetry aggregation and shipping, last up the ladder")
+        .arg(Arg::with_name("config-file")
+             .long("config")
+             .short("C")
+             .value_name("config")
+             .help("The config file to feed in.")
+             .takes_value(true))
+        .arg(Arg::with_name("verbose")
+             .short("v")
+             .multiple(true)
+             .help("Turn on verbose output."))
+        .get_matches();
+
+    let verb = if args.is_present("verbose") {
+        args.occurrences_of("verbose")
+    } else {
+        0
+    };
+
+    match args.value_of("config-file") {
+        Some(filename) => {
+            let mut fp = match File::open(filename) {
+                Err(e) => panic!("Could not open file {} with error {}", filename, e),
+                Ok(fp) => fp,
+            };
+
+            let mut buffer = String::new();
+            fp.read_to_string(&mut buffer).unwrap();
+            let value: toml::Value = buffer.parse().unwrap();
+
+            let tags = match value.lookup("tags") {
+                Some(tbl) => {
+                    let mut tags = String::new();
+                    let ttbl = tbl.as_table().unwrap();
+                    for (k,v) in (*ttbl).iter() {
+                        write!(tags, "{}={},", k, v.as_str().unwrap()).unwrap();
+                    }
+                    tags.pop();
+                    tags
+                },
+                None => "".to_string()
+            };
+
+            let mk_wavefront = value.lookup("backends.wavefront").is_some();
+            let mk_console = value.lookup("backends.console").is_some();
+            let mk_librato = value.lookup("backends.librato").is_some();
+
+            let (wport, whost, wskpaggr) = if mk_wavefront {
+                (
+                    // wavefront port
+                    value.lookup("backends.wavefront.port").unwrap_or(&Value::Integer(2878)).as_integer().map(|i| i as u16),
+                    // wavefront host
+                    value.lookup("backends.wavefront.host").unwrap_or(&Value::String("127.0.0.1".to_string())).as_str().map(|s| s.to_string()),
+                    // wavefront skip aggrs
+                    value.lookup("backends.wavefront.skip-aggrs").unwrap_or(&Value::Boolean(false)).as_bool().unwrap_or(false),
+                )
+            } else {
+                (None, None, false)
+            };
+
+            let (luser, lhost, ltoken) = if mk_librato {
+                (
+                    // librato username
+                    value.lookup("backends.librato.username").unwrap_or(&Value::String("statsd".to_string())).as_str().map(|s| s.to_string()),
+                    // librato token
+                    value.lookup("backends.librato.token").unwrap_or(&Value::String("statsd".to_string())).as_str().map(|s| s.to_string()),
+                    // librato host
+                    value.lookup("backends.librato.host").unwrap_or(&Value::String("https://metrics-api.librato.com/v1/metrics".to_string())).as_str().map(|s| s.to_string()),
+                )
+            } else {
+                (None, None, None)
+            };
+
+            Args {
+                statsd_port: value.lookup("statsd-port")
+                    .unwrap_or(&Value::Integer(8125))
+                    .as_integer()
+                    .expect("statsd-port must be integer") as u16,
+                graphite_port: value.lookup("graphite-port")
+                    .unwrap_or(&Value::Integer(2003))
+                    .as_integer()
+                    .expect("graphite-port must be integer") as u16,
+                flush_interval: value.lookup("flush-interval")
+                    .unwrap_or(&Value::Integer(10))
+                    .as_integer()
+                    .expect("flush-interval must be integer") as u64,
+                console: mk_console,
+                wavefront: mk_wavefront,
+                librato: mk_librato,
+                wavefront_port: wport,
+                wavefront_host: whost,
+                wavefront_skip_aggrs: wskpaggr,
+                librato_username: luser,
+                librato_host: lhost,
+                librato_token: ltoken,
+                tags: tags,
+                verbose: verb,
+                version: VERSION.unwrap().to_string(),
+            }
+        }
+        None => {
+            Args {
+                statsd_port: 8125,
+                graphite_port: 2003,
+                flush_interval: 10,
+                console: false,
+                wavefront: false,
+                librato: false,
+                wavefront_port: None,
+                wavefront_host: None,
+                wavefront_skip_aggrs: true,
+                librato_username: None,
+                librato_host: None,
+                librato_token: None,
+                tags: "source=cernan".to_string(),
+                verbose: verb,
+                version: VERSION.unwrap().to_string(),
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+extern crate toml;
 extern crate clap;
 extern crate quantiles;
 extern crate hyper;
@@ -19,7 +20,7 @@ use chrono::UTC;
 
 mod backend;
 mod buckets;
-mod cli;
+mod config;
 mod metric;
 mod metrics {
     pub mod statsd;
@@ -33,7 +34,7 @@ mod backends {
 }
 
 fn main() {
-    let args = cli::parse_args();
+    let args = config::parse_args();
 
     let level = match args.verbose {
         0 => log::LogLevelFilter::Error,
@@ -60,6 +61,7 @@ fn main() {
     let _ = fern::init_global_logger(logger_config, log::LogLevelFilter::Trace);
 
     debug!("ARGS: {:?}", args);
+
     info!("cernan - {}", args.version);
 
     trace!("trace messages enabled");


### PR DESCRIPTION
This commit introduces reading cernan configuration from a toml
file, replacing much of the original CLI flags with configs.
The README has been updated and it's hoped that this will make
use by end-users more simple.

This resolves #37 .

Signed-off-by: Brian L. Troutwine blt@postmates.com
