### PR TITLE
Correct librato args regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cernan"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -671,4 +671,3 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "winapi-build"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cernan"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Brian L. Troutwine <blt@postmates.com>"]
 build = "build.rs"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 
 const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Args {
     pub statsd_port: u16,
     pub graphite_port: u16,
@@ -112,9 +112,11 @@ pub fn parse_args() -> Args {
     };
 
     let (luser, lhost, ltoken) = if mk_librato {
-        (Some(args.value_of("librato-username").unwrap().to_string()),
-         Some(args.value_of("librato-token").unwrap().to_string()),
-         Some(args.value_of("librato-host").unwrap().to_string()))
+        (
+            Some(args.value_of("librato-username").unwrap().to_string()),
+            Some(args.value_of("librato-host").unwrap().to_string()),
+            Some(args.value_of("librato-token").unwrap().to_string()),
+        )
     } else {
         (None, None, None)
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ fn main() {
     // No sense of why.
     let _ = fern::init_global_logger(logger_config, log::LogLevelFilter::Trace);
 
+    debug!("ARGS: {:?}", args);
     info!("cernan - {}", args.version);
 
     trace!("trace messages enabled");


### PR DESCRIPTION
This commit fixes a regression wherein the host and token for
librato were confused. This only impacts hosts shipping metrics
to librato.

Signed-off-by: Brian L. Troutwine blt@postmates.com
