### PR TITLE
Avoid crashing if WF tcp connection rests, update 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cernan"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -14,7 +14,7 @@ dependencies = [
  "quantiles 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -671,3 +671,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "winapi-build"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cernan"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Brian L. Troutwine <blt@postmates.com>"]
 build = "build.rs"
 


### PR DESCRIPTION
This is a somewhat ahead-of-schedule commit to stop
cernan crashing in the event that the wavefront proxy
TCP connection fails. Curious thing is that it's been
happening more and more. Dunno why.

Signed-off-by: Brian L. Troutwine blt@postmates.com
