### PR TITLE
Do not panic on failed librato send.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cernan"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.9.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cernan"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Brian L. Troutwine <blt@postmates.com>"]
 build = "build.rs"
 

--- a/src/backends/librato.rs
+++ b/src/backends/librato.rs
@@ -135,7 +135,7 @@ impl Backend for Librato {
         debug!("librato - {}", payload);
         let mime: Mime = "application/json".parse().unwrap();
         let uri = url::Url::parse(&(self.host)).expect("malformed url");
-        client.post(uri)
+        let res = client.post(uri)
             .body(&payload)
             .header(ContentType(mime))
             .header(Authorization(Basic {
@@ -143,8 +143,11 @@ impl Backend for Librato {
                 password: Some(self.auth_token.clone()),
             }))
             .header(Connection::keep_alive())
-            .send()
-            .unwrap();
+            .send();
+        match res {
+            Ok(_) => trace!("Successfully wrote librato payload"),
+            Err(e) => debug!("Could not write librato payload with error {}", e),
+        }
     }
 }
 


### PR DESCRIPTION
This commit ensures that if a librato write fails we merely log
out the error and move on. Librato only aggregates so we'd end
up skipping some points but would not lose any real data.

Signed-off-by: Brian L. Troutwine blt@postmates.com
