### PR TITLE
Enable DNS lookups for wavefront backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.2.4"
 dependencies = [
  "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dns-lookup 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -110,6 +111,14 @@ dependencies = [
 name = "diff"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "dns-lookup"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "docopt"
@@ -687,6 +696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a032eac705ca39214d169f83e3d3da290af06d8d1d344d1baad2fd002dca4b3"
 "checksum diff 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e48977eec6d3b7707462c2dc2e1363ad91b5dd822cf942537ccdc2085dc87587"
+"checksum dns-lookup 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "daef0c720fa2158f4cc9fba3e05a490b67d6165ad06fc2c90c6c62c0ddd0ced1"
 "checksum docopt 0.6.82 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20016093b4e545dccf6ad4a01099de0b695f9bc99b08210e68f6425db2d37d"
 "checksum fern 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4d2f58d053ad7791bfaad58a3f3541fe2d2aecc564dd82aee7f92fa402c054b2"
 "checksum fixedbitset 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c59882225c22dfcd2db6f0fce45dabe334e64ffa5efacb785b7ffb5af690cc6f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ string_cache = "0.2.21"
 clap = "2.10.0"
 fern = "0.3.5"
 log = "0.3.6"
+dns-lookup = "0.2.1"
 
 [build-dependencies]
 lalrpop = "0.12.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ extern crate url;
 extern crate regex;
 extern crate string_cache;
 extern crate fern;
+extern crate dns_lookup;
 #[macro_use]
 extern crate log;
 


### PR DESCRIPTION
These commits enable DNS resolution for the wavefront backend host. Please see individual commit messages for more details. 

Resolves #51 
