### PR TITLE
Don't be lazy with regard to time computation

### DIFF
--- a/src/metric.rs
+++ b/src/metric.rs
@@ -42,7 +42,7 @@ impl Metric {
             name: name,
             value: value,
             kind: kind,
-            time: time.unwrap_or_else(UTC::now),
+            time: time.unwrap_or(UTC::now()),
         }
     }
 


### PR DESCRIPTION
Guess what is lazy in its argument! Turns out, unwrap_or_else does
not evaluate its closure immediately but only at-need. This means
that when we have a back-up in reporting we do not backfill
correctly.

Womp womp

Signed-off-by: Brian L. Troutwine blt@postmates.com
