### PR TITLE
update install instructions for OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Recent versions of OSX may have some goofy OpenSSL issues, which can be resolved
 by issuing
 
     > brew install openssl
-    > brew link --force openssl
+    > export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include
+    > export DEP_OPENSSL_INCLUDE=/usr/local/opt/openssl/include
 
 and following the onscreen instructions. Run
 


### PR DESCRIPTION
The latest release of homebrew no longer allows users to link openssl, even when
passing the `--force` flag. Installing OpenSSL via homebrew is still valid, but
you need to specify the include dirs in your PATH.
