### PR TITLE
Adjust wording from 'backend' to 'sink'

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,24 +71,24 @@ graphite-port=<INT>      The TCP port to bind to for graphite traffic. [default:
 ## Changing how frequently metrics are output
 
 ```
-flush-interval=<INT>  How frequently to flush metrics to the backends in seconds. [default: 10].
+flush-interval=<INT>  How frequently to flush metrics to the sinks in seconds. [default: 10].
 ```
 
-## Enabling the console or graphite backends
+## Enabling the console or graphite sinks
 
-By default no backends are enabled. In this mode cernan server doesn't do that
-much. Backends are configured in a `backends` table. To enable a backend with
+By default no sinks are enabled. In this mode cernan server doesn't do that
+much. Sinks are configured in a `sinks` table. To enable a sink with
 defaults it is sufficient to make a sub-table for it. In the following, all
-backends are enabled with their default:
+sinks are enabled with their default:
 
 ```
-[backends]
+[sinks]
   [console]
   [wavefront]
   [librato]
 ```
 
-For backends which support it `cernan` can report metadata about the
+For sinks which support it `cernan` can report metadata about the
 metric. These are called "tags" by some aggregators and `cernan` uses this
 terminology. In AWS you might choose to include your instance ID with each
 metric point, as well as the service name. You may set tags like so:
@@ -99,11 +99,11 @@ source = cernan
 ```
 
 Each key / value pair will converted to the appropriate tag, depending on the
-backend.
+sink.
 
 ### librato
 
-The librato backend has additional options for defining authentication:
+The librato sink has additional options for defining authentication:
 
 ```
 username=<STRING>   The librato username for authentication. [default: ceran].
@@ -113,7 +113,7 @@ host=<STRING>       The librato host to report to. [default: https://metrics-api
 
 ### wavefront
 
-The wavefront backend has additional options for defining where the wavefront
+The wavefront sink has additional options for defining where the wavefront
 proxy runs:
 
 ```

--- a/example-config.toml
+++ b/example-config.toml
@@ -5,7 +5,7 @@ flush-interval = 10
 [tags]
 source = "cernan"
 
-[backends]
+[sinks]
     [console]
 
     [wavefront]

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,18 +58,18 @@ pub fn parse_args() -> Args {
         .arg(Arg::with_name("flush-interval")
              .long("flush-interval")
              .value_name("interval")
-             .help("How frequently to flush metrics to the backends in seconds.")
+             .help("How frequently to flush metrics to the sinks in seconds.")
              .takes_value(true)
              .default_value("10"))
         .arg(Arg::with_name("console")
              .long("console")
-             .help("Enable the console backend."))
+             .help("Enable the console sink."))
         .arg(Arg::with_name("wavefront")
              .long("wavefront")
-             .help("Enable the wavefront backend."))
+             .help("Enable the wavefront sink."))
         .arg(Arg::with_name("librato")
              .long("librato")
-             .help("Enable the librato backend."))
+             .help("Enable the librato sink."))
         .arg(Arg::with_name("wavefront-port")
              .long("wavefront-port")
              .help("The port wavefront proxy is running on")
@@ -100,7 +100,7 @@ pub fn parse_args() -> Args {
              .default_value("statsd"))
         .arg(Arg::with_name("tags")
              .long("tags")
-             .help("A comma separated list of tags to report to supporting backends.")
+             .help("A comma separated list of tags to report to supporting sinks.")
              .takes_value(true)
              .use_delimiter(false)
              .default_value("source=cernan"))
@@ -141,23 +141,23 @@ pub fn parse_args() -> Args {
                 None => "".to_string(),
             };
 
-            let mk_wavefront = value.lookup("backends.wavefront").is_some();
-            let mk_console = value.lookup("backends.console").is_some();
-            let mk_librato = value.lookup("backends.librato").is_some();
+            let mk_wavefront = value.lookup("sinks.wavefront").is_some();
+            let mk_console = value.lookup("sinks.console").is_some();
+            let mk_librato = value.lookup("sinks.librato").is_some();
 
             let (wport, whost, wskpaggr) = if mk_wavefront {
                 (// wavefront port
-                 value.lookup("backends.wavefront.port")
+                 value.lookup("sinks.wavefront.port")
                     .unwrap_or(&Value::Integer(2878))
                     .as_integer()
                     .map(|i| i as u16),
                  // wavefront host
-                 value.lookup("backends.wavefront.host")
+                 value.lookup("sinks.wavefront.host")
                     .unwrap_or(&Value::String("127.0.0.1".to_string()))
                     .as_str()
                     .map(|s| s.to_string()),
                  // wavefront skip aggrs
-                 value.lookup("backends.wavefront.skip-aggrs")
+                 value.lookup("sinks.wavefront.skip-aggrs")
                     .unwrap_or(&Value::Boolean(false))
                     .as_bool()
                     .unwrap_or(false))
@@ -167,17 +167,17 @@ pub fn parse_args() -> Args {
 
             let (luser, lhost, ltoken) = if mk_librato {
                 (// librato username
-                 value.lookup("backends.librato.username")
+                 value.lookup("sinks.librato.username")
                     .unwrap_or(&Value::String("statsd".to_string()))
                     .as_str()
                     .map(|s| s.to_string()),
                  // librato token
-                 value.lookup("backends.librato.token")
+                 value.lookup("sinks.librato.token")
                     .unwrap_or(&Value::String("statsd".to_string()))
                     .as_str()
                     .map(|s| s.to_string()),
                  // librato host
-                 value.lookup("backends.librato.host")
+                 value.lookup("sinks.librato.host")
                     .unwrap_or(&Value::String("https://metrics-api.librato.com/v1/metrics"
                         .to_string()))
                     .as_str()

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -1,4 +1,4 @@
-use backend::Backend;
+use sink::Sink;
 use buckets::Buckets;
 use metric::Metric;
 use chrono;
@@ -27,7 +27,7 @@ fn fmt_line(key: &str, value: &f64) {
 }
 
 
-impl Backend for Console {
+impl Sink for Console {
     fn deliver(&mut self, point: Arc<Metric>) {
         debug!("console deliver");
         self.aggrs.add(&point);

--- a/src/sinks/librato.rs
+++ b/src/sinks/librato.rs
@@ -1,4 +1,4 @@
-use backend::Backend;
+use sink::Sink;
 use buckets::Buckets;
 use std::str::FromStr;
 use rustc_serialize::json;
@@ -122,7 +122,7 @@ impl Librato {
     }
 }
 
-impl Backend for Librato {
+impl Sink for Librato {
     fn deliver(&mut self, point: Arc<Metric>) {
         debug!("librato deliver");
         self.aggrs.add(&point);
@@ -154,7 +154,7 @@ impl Backend for Librato {
 #[cfg(test)]
 mod test {
     use metric::{Metric, MetricKind};
-    use backend::Backend;
+    use sink::Sink;
     use std::sync::Arc;
     use string_cache::Atom;
     use super::*;

--- a/src/sinks/wavefront.rs
+++ b/src/sinks/wavefront.rs
@@ -4,7 +4,7 @@ use std::io::Write as IoWrite;
 use chrono;
 use metric::Metric;
 use buckets::Buckets;
-use backend::Backend;
+use sink::Sink;
 use std::sync::Arc;
 use dns_lookup;
 
@@ -116,7 +116,7 @@ impl Wavefront {
     }
 }
 
-impl Backend for Wavefront {
+impl Sink for Wavefront {
     fn flush(&mut self) {
         match TcpStream::connect(self.addr) {
             Ok(mut stream) => {
@@ -147,7 +147,7 @@ impl Backend for Wavefront {
 #[cfg(test)]
 mod test {
     use metric::{Metric, MetricKind};
-    use backend::Backend;
+    use sink::Sink;
     use chrono::{UTC, TimeZone};
     use std::sync::Arc;
     use string_cache::Atom;


### PR DESCRIPTION
For a good long while now I've been talking about cernan in terms
of 'sources' and 'sinks'. The 'sinks' are what the codebase called
'backends' and this was starting to get very confusing.

The 'sources' concept is still implicit, given that we only support
the graphite / statsd protocols.

Signed-off-by: Brian L. Troutwine blt@postmates.com
