### PR TITLE
Include count outputs with histograms / timers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quantiles 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quantiles 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "quantiles"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Brian L. Troutwine <blt@postmates.com>"]
 build = "build.rs"
 
 [dependencies]
-quantiles = "0.1.4"
+quantiles = "0.1.5"
 hyper = "0.9.6"
 lru-cache = "0.0.7"
 mime = "0.2.0"

--- a/src/sinks/librato.rs
+++ b/src/sinks/librato.rs
@@ -69,7 +69,7 @@ impl Librato {
 
         for (key, value) in self.aggrs.counters().iter() {
             counters.push(LCounter {
-                name: key.as_ref().to_string(),
+                name: format!("{}", key),
                 value: *value,
             });
         }


### PR DESCRIPTION
Previously we relied on the wavefront backend to accept all points
and that this would allow us to get percentile information in
addition to counts. That's not true. A previous commit put us back
on a good foot with regard to counts and this puts us in a good
place with regard to counts.

Resolves #65 and #64 

Signed-off-by: Brian L. Troutwine blt@postmates.com
