### PR TITLE
Reduce default flush interval to one second

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ graphite-port=<INT>      The TCP port to bind to for graphite traffic. [default:
 ## Changing how frequently metrics are output
 
 ```
-flush-interval=<INT>  How frequently to flush metrics to the sinks in seconds. [default: 10].
+flush-interval=<INT>  How frequently to flush metrics to the sinks in seconds. [default: 1].
 ```
 
 ## Enabling the console or graphite sinks

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,7 +59,7 @@ pub fn parse_args() -> Args {
              .value_name("interval")
              .help("How frequently to flush metrics to the sinks in seconds.")
              .takes_value(true)
-             .default_value("10"))
+             .default_value("1"))
         .arg(Arg::with_name("console")
              .long("console")
              .help("Enable the console sink."))
@@ -190,7 +190,7 @@ pub fn parse_args() -> Args {
                     .as_integer()
                     .expect("graphite-port must be integer") as u16,
                 flush_interval: value.lookup("flush-interval")
-                    .unwrap_or(&Value::Integer(10))
+                    .unwrap_or(&Value::Integer(1))
                     .as_integer()
                     .expect("flush-interval must be \
                              integer") as u64,


### PR DESCRIPTION
In lieu of ongoing work to accomodate wavefront's subsecond averaging
recalcitrance we should temporarily reduce the default flush interval
to one second, from 10. Aggregations moving forward can then bucket
at once-per-second granularity and deliver N payloads that map directly
to future flush intervals.

Signed-off-by: Tom Santero tom.santero@postmates.com
