### PR TITLE
Allow '@' and '%' to be in a graphite metric name

### DIFF
--- a/src/metric.rs
+++ b/src/metric.rs
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_parse_graphite() {
-        let pyld = "fst 1 101\nsnd -2.0 202\nthr 3 303\nfth@fth 4 404\n";
+        let pyld = "fst 1 101\nsnd -2.0 202\nthr 3 303\nfth@fth 4 404\nfv%fv 5 505\n";
         let prs = Metric::parse_graphite(pyld);
 
         assert!(prs.is_some());
@@ -97,6 +97,11 @@ mod tests {
         assert_eq!(prs_pyld[3].name, Atom::from("fth@fth"));
         assert_eq!(prs_pyld[3].value, 4.0);
         assert_eq!(prs_pyld[3].time, UTC.timestamp(404, 0));
+
+        assert_eq!(prs_pyld[4].kind, MetricKind::Raw);
+        assert_eq!(prs_pyld[4].name, Atom::from("fv%fv"));
+        assert_eq!(prs_pyld[4].value, 5.0);
+        assert_eq!(prs_pyld[4].time, UTC.timestamp(505, 0));
     }
 
     #[test]

--- a/src/metrics/graphite.lalrpop
+++ b/src/metrics/graphite.lalrpop
@@ -7,7 +7,7 @@ use chrono::TimeZone;
 
 grammar;
 
-MetricName: Atom = <s:r"[A-Za-z][_A-Z0-9a-z+/=\.-@]*"> => Atom::from(s);
+MetricName: Atom = <s:r"[A-Za-z][_A-Z0-9a-z+/=\.-@%]*"> => Atom::from(s);
 
 Num: f64 = <s:r"[-+]?[0-9]+\.?[0-9]*"> => f64::from_str(s).unwrap();
 


### PR DESCRIPTION
We're seeing cases of '@' being piped through from collectd into
cernan. This is part and parcel of stuffing metadata into the
metric name but we still need to support it anyway.

Signed-off-by: Brian L. Troutwine blt@postmates.com
