### PR TITLE
Emit self-metrics

### DIFF
--- a/src/metric.rs
+++ b/src/metric.rs
@@ -42,6 +42,15 @@ pub struct Metric {
 }
 
 impl Metric {
+    pub fn counter(name: &str) -> Metric {
+        Metric {
+            name: Atom::from(name),
+            value: 1.0,
+            kind: MetricKind::Counter(1.0),
+            time: UTC::now().timestamp(),
+        }
+    }
+
     /// Create a new metric
     ///
     /// Uses the Into trait to allow both str and String types.


### PR DESCRIPTION
It is valuable for users of cernan to have some notion of its health.
This commit adds time series emission from cernan which tell us how
often bad packets roll through per second and allow us to compare against
good packets in the same window.

Signed-off-by: Brian L. Troutwine blt@postmates.com
