### PR TITLE
Normalize counter snapshot to 1 / sec.

### DIFF
--- a/src/sinks/wavefront.rs
+++ b/src/sinks/wavefront.rs
@@ -56,7 +56,7 @@ impl Wavefront {
 
         if (self.tot_snapshots % self.qos.counter) == 0 {
             for (key, value) in self.aggrs.counters().iter() {
-                write!(stats, "{} {} {} {}\n", key, value, start, self.tags).unwrap();
+                write!(stats, "{} {} {} {}\n", key, value / (self.qos.counter as f64), start, self.tags).unwrap();
             }
         }
 


### PR DESCRIPTION
This commit adjusts the way counter snapshots work. Previously
we would sum in a bucket one counter QOS wide and report this out.
What we _wanted_ to do was sum in a QOS wide bucket and report
out a value normalized to 1 / sec. We do this now by dividing by
the bucket width.

Signed-off-by: Brian L. Troutwine blt@postmates.com
