### PR TITLE
Adjust gauge behaviour, introduce DeltaGauge

### DIFF
--- a/src/metrics/statsd.lalrpop
+++ b/src/metrics/statsd.lalrpop
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use metric::{MetricKind, Metric};
+use metric::{MetricKind, MetricSign, Metric};
 use std::sync::Arc;
 use string_cache::Atom;
 
@@ -15,10 +15,16 @@ Kind: MetricKind = {
 
 MetricName: Atom = <s:r"[A-Za-z][_A-Z0-9a-z+/=\.-]*"> => Atom::from(s);
 
-Num: f64 = <s:r"[-+]?[0-9]+\.?[0-9]*"> => f64::from_str(s).unwrap();
+Sign: Option<MetricSign> = {
+    "+" => Some(MetricSign::Positive),
+    "-" => Some(MetricSign::Negative),
+};
+
+Num: f64 = <s:r"[0-9]+\.?[0-9]*"> => f64::from_str(s).unwrap();
 
 MetricLine: Arc<Metric> = {
-    <name:MetricName> ":" <val:Num> "|" <k:Kind> => Arc::new(Metric::new(name, val, k))
+    <name:MetricName> ":" <sign: Sign> <val:Num> "|" <k:Kind> => Arc::new(Metric::new(name, val, k, sign)),
+    <name:MetricName> ":" <val:Num> "|" <k:Kind> => Arc::new(Metric::new(name, val, k, None))
 };
 
 pub MetricPayload: Vec<Arc<Metric>> = { (<MetricLine>)+ };


### PR DESCRIPTION
Previously cernan treated gauges as instantaneous values and reset
these each snapshot interval. We now do two things differently:
- we persist gauges across snapshots, expiring only on the
   terms of the LRU cache all gauges sit in
- we support 'delta' points into gauges

This last is a bit goofy. Here's the deal from https://github.com/etsy/statsd/blob/master/docs/metric_types.md:

```
StatsD now also supports gauges, arbitrary values, which can be
recorded.

    gaugor:333|g

If the gauge is not updated at the next flush, it will send the
previous value. You can opt to send no metric at all for this
gauge, by setting config.deleteGauges

Adding a sign to the gauge value will change the value, rather
than setting it.

    gaugor:-10|g
    gaugor:+4|g

So if gaugor was 333, those commands would set it to 333 - 10 + 4,
or 327.
```

Note now that 'raw' metrics now do not piggy-back on gauges.

Signed-off-by: Brian L. Troutwine blt@postmates.com
