### PR TITLE
Samples for gauges

### DIFF
--- a/src/metric.rs
+++ b/src/metric.rs
@@ -219,6 +219,19 @@ mod tests {
     }
 
     #[test]
+    fn test_metric_sample_gauge() {
+        let res = Metric::parse_statsd("foo:1|g@0.22\nbar:101|g@2\n").unwrap();
+
+        assert_eq!(Atom::from("foo"), res[0].name);
+        assert_eq!(1.0, res[0].value);
+        assert_eq!(MetricKind::Gauge, res[0].kind);
+
+        assert_eq!(Atom::from("bar"), res[1].name);
+        assert_eq!(101.0, res[1].value);
+        assert_eq!(MetricKind::Gauge, res[1].kind);
+    }
+
+    #[test]
     fn test_metric_parse_invalid_no_name() {
         assert_eq!(None, Metric::parse_statsd(""));
     }

--- a/src/metrics/statsd.lalrpop
+++ b/src/metrics/statsd.lalrpop
@@ -7,6 +7,7 @@ grammar;
 
 Kind: MetricKind = {
     "g" => MetricKind::Gauge,
+    "g@" <Num> => MetricKind::Gauge,
     "ms" => MetricKind::Timer,
     "h" => MetricKind::Histogram,
     "c" => MetricKind::Counter(1.0),


### PR DESCRIPTION
Allow users to give a sample rate on gauges

A gague, like a counter, takes a sample value, per many client's
implementation of the protocol. I'm unsure at the present what the
gauge sample ought to mean but, here we are, able to parse.

This PR depends on #99 and that PR should be merged first. 
