### PR TITLE
Snapshot and buffer raws correctly

### DIFF
--- a/src/metric.rs
+++ b/src/metric.rs
@@ -24,7 +24,7 @@ impl MetricQOS {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum MetricKind {
     Counter(f64),
     Gauge,
@@ -40,7 +40,7 @@ pub enum MetricSign {
     Negative,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Metric {
     pub kind: MetricKind,
     pub name: Atom,

--- a/src/sinks/console.rs
+++ b/src/sinks/console.rs
@@ -52,6 +52,13 @@ impl Sink for Console {
             fmt_line(key, &value);
         }
 
+        println!("  raws:");
+        for (key, value) in self.aggrs.raws() {
+            for m in value {
+                fmt_line(key, &m.value);
+            }
+        }
+
         println!("  histograms:");
         for (key, value) in self.aggrs.histograms() {
             for tup in &[("min", 0.0),


### PR DESCRIPTION
In 0.3.2 we made the distinction between raws and gauges but did
not, owing to a lack of coverage, correctly test that they were
being emitted on each snapshot. D'oh.

This commit _does_ correctly test that raws are snapshotted correctly
and resolves #86 at the same time.

Signed-off-by: Brian L. Troutwine blt@postmates.com
