### PR TITLE
Perform fewer syscalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "fern 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 2.6.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rusoto = {version = "0.16.0", features = ["firehose"]}
 serde = "0.8"
 serde_json = "0.8"
 bincode = "0.6.0"
+lazy_static = "0.2.1"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -110,6 +110,10 @@ fn main() {
         cernan::server::flush_timer_loop(flush_interval_sends, flush_interval);
     }));
 
+    joins.push(thread::spawn(move || {
+        cernan::time::update_time();
+    }));
+
     if let Some(log_files) = args.files {
         for lf in log_files {
             let fp_sends = sends.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,15 @@ extern crate serde;
 extern crate log;
 extern crate serde_json;
 extern crate rusoto;
+#[macro_use]
+extern crate lazy_static;
 
 pub mod mpsc;
 pub mod sink;
 pub mod buckets;
 pub mod config;
 pub mod metric;
+pub mod time;
 pub mod metrics {
     pub mod statsd;
     pub mod graphite;

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1,5 +1,5 @@
 use metrics::*;
-use chrono::UTC;
+use time::now;
 use string_cache::Atom;
 
 include!(concat!(env!("OUT_DIR"), "/serde_types.rs"));
@@ -9,7 +9,7 @@ impl LogLine {
         LogLine {
             path: path,
             value: value,
-            time: UTC::now().timestamp(),
+            time: now(),
         }
     }
 }
@@ -47,7 +47,7 @@ impl Metric {
             name: Atom::from(name),
             value: 1.0,
             kind: MetricKind::Counter(1.0),
-            time: UTC::now().timestamp(),
+            time: now(),
         }
     }
 
@@ -80,7 +80,7 @@ impl Metric {
             name: name,
             value: value,
             kind: kind,
-            time: UTC::now().timestamp(),
+            time: now(),
         }
     }
 
@@ -94,7 +94,7 @@ impl Metric {
             name: name,
             value: value,
             kind: kind,
-            time: time.unwrap_or(UTC::now().timestamp()),
+            time: time.unwrap_or(now()),
         }
     }
 

--- a/src/metrics/graphite.lalrpop
+++ b/src/metrics/graphite.lalrpop
@@ -1,8 +1,6 @@
-use std::str::FromStr;
 use metric::{MetricKind, Metric};
+use std::str::FromStr;
 use string_cache::Atom;
-use chrono::UTC;
-use chrono::TimeZone;
 
 grammar;
 
@@ -11,7 +9,7 @@ MetricName: Atom = <s:r"[A-Za-z][_A-Z0-9a-z+/=\.@%-]*"> => Atom::from(s);
 Num: f64 = <s:r"[-+]?[0-9]+\.?[0-9]*"> => f64::from_str(s).unwrap();
 
 MetricLine: Metric = {
-    <name:MetricName> <val:Num> <t:Num> => Metric::new_with_time(name, val, Some(UTC.timestamp(t as i64, 0).timestamp()), MetricKind::Raw, None)
+    <name:MetricName> <val:Num> <t:Num> => Metric::new_with_time(name, val, Some(t as i64), MetricKind::Raw, None)
 };
 
 pub MetricPayload: Vec<Metric> = { (<MetricLine>)+ };

--- a/src/mpsc.rs
+++ b/src/mpsc.rs
@@ -16,7 +16,7 @@
 //! filled up with monotonically increasing files. The on-disk structure looks
 //! like this:
 //!
-//! ```
+//! ```text
 //! data-dir/
 //!    sink-name0/
 //!       0

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,20 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize,Ordering};
+use chrono::UTC;
+use std::{time,thread};
+
+lazy_static! {
+    static ref NOW: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(UTC::now().timestamp() as usize));
+}
+
+pub fn now() -> i64 {
+    NOW.load(Ordering::Relaxed) as i64
+}
+
+pub fn update_time() {
+    let dur = time::Duration::from_millis(500);
+    loop {
+        thread::sleep(dur);
+        NOW.store(UTC::now().timestamp() as usize, Ordering::Relaxed);
+    }
+}


### PR DESCRIPTION
This commit reduces the number of times we must call out to system
to get the current timestamp by doing ye olde trick of storing this
information at the require resolution in an atomic value.

This will make parsing faster.

Signed-off-by: Brian L. Troutwine blt@postmates.com
