### PR TITLE
Remove lru_cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,11 +7,11 @@ dependencies = [
  "clap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dns-lookup 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lru-cache 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 2.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quantiles 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -221,6 +221,11 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fnv"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fsevent"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,22 +411,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "log"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "lru-cache"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "linked-hash-map 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "matches"
@@ -1121,6 +1113,7 @@ dependencies = [
 "checksum fern 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4d2f58d053ad7791bfaad58a3f3541fe2d2aecc564dd82aee7f92fa402c054b2"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
 "checksum fixedbitset 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c59882225c22dfcd2db6f0fce45dabe334e64ffa5efacb785b7ffb5af690cc6f"
+"checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum fsevent 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "740a52ca589381d87dd0d9960555de3320aa6d408326659e3bae88be9f71a125"
 "checksum fsevent-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "72e33a926306442d961595c3a325864326ca4287795e106dae8993afe484ede6"
 "checksum gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "91ecd03771effb0c968fd6950b37e89476a578aaf1c70297d8e92b6516ec3312"
@@ -1142,9 +1135,7 @@ dependencies = [
 "checksum lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49247ec2a285bb3dcb23cbd9c35193c025e7251bfce77c1d5da97e6362dffe7f"
 "checksum libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "408014cace30ee0f767b1c4517980646a573ec61a57957aeeabcac8ac0a02e8d"
 "checksum libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cbc058951ab6a3ef35ca16462d7642c4867e6403520811f28537a4e2f2db3e71"
-"checksum linked-hash-map 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "83f7ff3baae999fdf921cccf54b61842bb3b26868d50d02dff48052ebec8dd79"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
-"checksum lru-cache 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "42d50dcb5d9f145df83b1043207e1ac0c37c9c779c4e128ca4655abc3f3cbf8c"
 "checksum matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "15305656809ce5a4805b1ff2946892810992197ce1270ff79baded852187942e"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5c93a4bd787ddc6e7833c519b73a50883deb5863d76d9b71eb8216fb7f94e66"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ doc = false
 
 [dependencies]
 quantiles = "0.1.5"
-lru-cache = "0.0.7"
 chrono = "0.2"
 lalrpop-util = "0.12.0"
 string_cache = "0.2.21"
@@ -25,6 +24,7 @@ serde = "0.8"
 serde_json = "0.8"
 bincode = "0.6.0"
 lazy_static = "0.2.1"
+fnv = "1.0.5"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/benches/buckets.rs
+++ b/benches/buckets.rs
@@ -13,7 +13,37 @@ use cernan::buckets;
 use cernan::metric::{Metric,MetricKind};
 
 #[bench]
-fn bench_counters(b: &mut Bencher) {
+fn bench_single_timer(b: &mut Bencher) {
+    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+
+    b.iter(|| {
+        let mut bucket = buckets::Buckets::default();
+
+        bucket.add(Metric::new_with_time(Atom::from("a"),
+                                         1.0,
+                                         Some(dt_0),
+                                         MetricKind::Timer,
+                                         None));
+    });
+}
+
+#[bench]
+fn bench_single_histogram(b: &mut Bencher) {
+    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+
+    b.iter(|| {
+        let mut bucket = buckets::Buckets::default();
+
+        bucket.add(Metric::new_with_time(Atom::from("a"),
+                                         1.0,
+                                         Some(dt_0),
+                                         MetricKind::Histogram,
+                                         None));
+    });
+}
+
+#[bench]
+fn bench_multi_counters(b: &mut Bencher) {
     let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
     let dt_1 = UTC.ymd(1972, 12, 14).and_hms_milli(5, 40, 56, 0).timestamp();
 
@@ -21,9 +51,9 @@ fn bench_counters(b: &mut Bencher) {
     b.iter(|| {
         let mut bucket = buckets::Buckets::default();
 
-        for name in &["a", "aa", "aaa", "aaaa", "aaaaa"] {
-            for i in &[-1.0, 0.0, 1.0] {
-                for r in &[-1.0, 0.0, 1.0] {
+        for name in &["a", "aa", "aaa", "aaaa", "aaaaa", "aaaaaa", "aaaaaa"] {       // 7
+            for i in &[-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0] { // 11
+                for r in &[-1.0, 0.0, 1.0] {                                         // 3
                     bucket.add(Metric::new_with_time(Atom::from(*name),
                                                      *i,
                                                      Some(dt_0),
@@ -37,19 +67,35 @@ fn bench_counters(b: &mut Bencher) {
                 }
             }
         }
+        // total inserts 7 * 11 * 2 * 3 = 462
     });
 }
 
 #[bench]
-fn bench_gauges(b: &mut Bencher) {
+fn bench_single_counter(b: &mut Bencher) {
+    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+
+    b.iter(|| {
+        let mut bucket = buckets::Buckets::default();
+
+        bucket.add(Metric::new_with_time(Atom::from("a"),
+                                         1.0,
+                                         Some(dt_0),
+                                         MetricKind::Counter(1.0),
+                                         None));
+    });
+}
+
+#[bench]
+fn bench_multi_gauges(b: &mut Bencher) {
     let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
     let dt_1 = UTC.ymd(1972, 12, 14).and_hms_milli(5, 40, 56, 0).timestamp();
 
     b.iter(|| {
         let mut bucket = buckets::Buckets::default();
 
-        for name in &["a", "aa", "aaa", "aaaa", "aaaaa"] {
-            for i in &[-1.0, 0.0, 1.0] {
+        for name in &["a", "aa", "aaa", "aaaa", "aaaaa", "aaaaaa", "aaaaaa"] {       // 7
+            for i in &[-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0] { // 11
                 bucket.add(Metric::new_with_time(Atom::from(*name),
                                                  *i,
                                                  Some(dt_0),
@@ -62,5 +108,21 @@ fn bench_gauges(b: &mut Bencher) {
                                                  None));
             }
         }
+        // total inserts 7 * 11 * 2 = 154
+    });
+}
+
+#[bench]
+fn bench_single_gauge(b: &mut Bencher) {
+    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+
+    b.iter(|| {
+        let mut bucket = buckets::Buckets::default();
+
+        bucket.add(Metric::new_with_time(Atom::from("a"),
+                                         1.0,
+                                         Some(dt_0),
+                                         MetricKind::Gauge,
+                                         None));
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 extern crate toml;
 extern crate clap;
 extern crate chrono;
+extern crate fnv;
 extern crate quantiles;
-extern crate lru_cache;
 extern crate string_cache;
 extern crate dns_lookup;
 extern crate notify;

--- a/src/sinks/wavefront.rs
+++ b/src/sinks/wavefront.rs
@@ -366,11 +366,10 @@ mod test {
 
         println!("{:?}", lines);
         assert_eq!(4, lines.len());
-        assert_eq!(lines[0],
-                   "test.some_other_gauge 1 645185471 source=test-src");
-        assert_eq!(lines[1], "test.gauge 1 645185471 source=test-src");
-        assert_eq!(lines[2], "test.gauge 3 645185473 source=test-src");
-        assert_eq!(lines[3], "test.gauge 5 645185475 source=test-src");
+        assert!(lines.contains(&"test.gauge 1 645185471 source=test-src"));
+        assert!(lines.contains(&"test.gauge 3 645185473 source=test-src"));
+        assert!(lines.contains(&"test.gauge 5 645185475 source=test-src"));
+        assert!(lines.contains(&"test.some_other_gauge 1 645185471 source=test-src"));
     }
 
     #[test]
@@ -426,11 +425,10 @@ mod test {
 
         println!("{:?}", lines);
         assert_eq!(4, lines.len());
-        assert_eq!(lines[0],
-                   "test.some_other_counter 1 645185471 source=test-src");
-        assert_eq!(lines[1], "test.counter 1 645185471 source=test-src");
-        assert_eq!(lines[2], "test.counter 3 645185473 source=test-src");
-        assert_eq!(lines[3], "test.counter 5 645185475 source=test-src");
+        assert!(lines.contains(&"test.counter 1 645185471 source=test-src"));
+        assert!(lines.contains(&"test.counter 3 645185473 source=test-src"));
+        assert!(lines.contains(&"test.counter 5 645185475 source=test-src"));
+        assert!(lines.contains(&"test.some_other_counter 1 645185471 source=test-src"));
     }
 
     #[test]


### PR DESCRIPTION
We no longer need aggregates to guard against possible swamping by
adversarial clients. That means we can move to a fast hashmap
instead of using the lru_cache.

We use the entry API of hashmap to insert elements now, saving some
branch mis-predictions, at the expense of not being able to use
hashset. Ah well.

Signed-off-by: Brian L. Troutwine blt@postmates.com
