### PR TITLE
File source watches directories of files, files

### DIFF
--- a/src/metric.rs
+++ b/src/metric.rs
@@ -13,9 +13,11 @@ use std::ops::AddAssign;
 pub type TagMap = HashMap<String, String, BuildHasherDefault<FnvHasher>>;
 
 impl LogLine {
-    pub fn new(path: String, value: String, tags: TagMap) -> LogLine {
+    pub fn new<S>(path: S, value: String, tags: TagMap) -> LogLine
+        where S: Into<String>
+    {
         LogLine {
-            path: path,
+            path: path.into(),
             value: value,
             time: time::now(),
             tags: tags,


### PR DESCRIPTION
With this update it's possible to configure a directory to be watched
by cernan's file source. Previously this was possible but would not
work correctly unless you were very, very lucky.

It is not possible to watch only _some_ files in a directory. It's
an all-or-nothing affair.

Signed-off-by: Brian L. Troutwine blt@postmates.com
