### PR TITLE
Avoid panicing on federation hangup

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -198,7 +198,7 @@ fn handle_receiver_client(mut chans: Vec<mpsc::Sender<metric::Event>>,
                 Err(e) => panic!("Failed decoding. Skipping {:?}", e),
             }
         }
-        Err(e) => panic!("Unable to read payload: {:?}", e),
+        Err(e) => trace!("Unable to read payload: {:?}", e),
     }
 }
 


### PR DESCRIPTION
In the event that a client terminates its connection there's no
need for us to panic the receiving thread. This does not impact
the running cernan instance but does muddy up the logs some.

Signed-off-by: Brian L. Troutwine blt@postmates.com
