### PR TITLE
Ensure that flush timer and file sources run

### DIFF
--- a/example-config.toml
+++ b/example-config.toml
@@ -1,5 +1,7 @@
 data-directory = "data/"
 
+flush-interval = 10
+
 # cernan listens on two telemetry protocols, statsd and graphite. The following
 # two configuration items set the ports cernan will listen on.
 [statsd]

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -137,7 +137,7 @@ fn main() {
             let fp_sends = sends.clone();
             let ftags = args.tags.clone();
             joins.push(thread::spawn(move || {
-                cernan::source::FileServer::new(fp_sends, lf, ftags);
+                cernan::source::FileServer::new(fp_sends, lf, ftags).run();
             }));
         }
     }
@@ -148,7 +148,7 @@ fn main() {
     let flush_interval = args.flush_interval;
     let flush_interval_sends = sends.clone();
     joins.push(thread::spawn(move || {
-        cernan::source::FlushTimer::new(flush_interval_sends, flush_interval);
+        cernan::source::FlushTimer::new(flush_interval_sends, flush_interval).run();
     }));
 
     joins.push(thread::spawn(move || {

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -107,14 +107,14 @@ impl Sink for Wavefront {
         let mut attempts = 0;
         loop {
             if attempts > 0 {
-                debug!("[wavefront] delivery attempts: {}", attempts);
+                debug!("delivery attempts: {}", attempts);
             }
             time::delay(attempts);
             match TcpStream::connect(self.addr) {
                 Ok(mut stream) => {
                     let res = stream.write(self.format_stats().as_bytes());
                     if res.is_ok() {
-                        trace!("[wavefront] flushed to wavefront!");
+                        trace!("flushed to wavefront!");
                         self.aggrs.reset();
                         break;
                     } else {
@@ -122,7 +122,7 @@ impl Sink for Wavefront {
                     }
                 }
                 Err(e) => {
-                    info!("[wavefront] unable to connect to proxy at addr {} with error {}",
+                    info!("unable to connect to proxy at addr {} with error {}",
                           self.addr,
                           e)
                 }

--- a/src/source/flush.rs
+++ b/src/source/flush.rs
@@ -23,6 +23,7 @@ impl FlushTimer {
 impl Source for FlushTimer {
     fn run(&mut self) {
         let duration = Duration::new(self.interval, 0);
+        debug!("flush-interval: {:?}", duration);
         loop {
             sleep(duration);
             send("flush", &mut self.chans, &metric::Event::TimerFlush);


### PR DESCRIPTION
I accidentally left off the runs for the file and flush timer.
The end result was that no metrics were able to be flushed from
cernan. Also, files would have been broken.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>