### PR TITLE
Don't pollute debug log messages

### DIFF
--- a/src/mpsc/receiver.rs
+++ b/src/mpsc/receiver.rs
@@ -95,7 +95,7 @@ impl<T> Iterator for Receiver<T>
         // written to. It's safe for the Receiver to declare the log done by
         // deleting it and moving on to the next file.
         while (*syn).writes_to_read > 0 {
-            debug!("[{}] writes to read: {}", self.name, (*syn).writes_to_read);
+            trace!("[{}] writes to read: {}", self.name, (*syn).writes_to_read);
             match self.fp.read_exact(&mut sz_buf) {
                 Ok(()) => {
                     let payload_size_in_bytes = u8tou32abe(&sz_buf);


### PR DESCRIPTION
The MPSC receiver emits many thousands of log lines in debug mode
on account of what should be a trace message. It is now a trace
message.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>