### PR TITLE
Break up config::Args into sub-structures

### DIFF
--- a/example-config.toml
+++ b/example-config.toml
@@ -27,3 +27,4 @@ bin_width = 1
 port = 2878
 host = "127.0.0.1"
 bin_width = 1
+

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -647,6 +647,8 @@ mod tests {
                 return TestResult::discard();
             } else if lhs.name != rhs.name {
                 return TestResult::discard();
+            } else if span < 1 {
+                return TestResult::discard();
             }
             let order = (lhs.time / span).cmp(&(rhs.time / span));
             assert_eq!(order, lhs.within(span, &rhs));

--- a/src/mpsc/mod.rs
+++ b/src/mpsc/mod.rs
@@ -74,7 +74,8 @@ pub struct FsSync {
 /// PRIVATE -- exposed via `Sender::new`
 pub type FSLock = Arc<Mutex<FsSync>>;
 
-/// Create a (Sender, Reciever) pair in a like fashion to [`std::sync::mpsc::channel`](https://doc.rust-lang.org/std/sync/mpsc/fn.channel.html)
+/// Create a (Sender, Reciever) pair in a like fashion to
+/// [`std::sync::mpsc::channel`](https://doc.rust-lang.org/std/sync/mpsc/fn.channel.html)
 ///
 /// This function creates a Sender and Receiver pair with name `name` whose
 /// queue files are stored in `data_dir`. The Sender is clonable.
@@ -84,7 +85,8 @@ pub fn channel<T>(name: &str, data_dir: &Path) -> (Sender<T>, Receiver<T>)
     channel_with_max_bytes(name, data_dir, 1_048_576 * 100)
 }
 
-/// Create a (Sender, Reciever) pair in a like fashion to [`std::sync::mpsc::channel`](https://doc.rust-lang.org/std/sync/mpsc/fn.channel.html)
+/// Create a (Sender, Reciever) pair in a like fashion to
+/// [`std::sync::mpsc::channel`](https://doc.rust-lang.org/std/sync/mpsc/fn.channel.html)
 ///
 /// This function creates a Sender and Receiver pair with name `name` whose
 /// queue files are stored in `data_dir`. The Sender is clonable.

--- a/src/mpsc/receiver.rs
+++ b/src/mpsc/receiver.rs
@@ -52,7 +52,7 @@ impl<T> Receiver<T>
             let path = fname.unwrap().path();
             let id = path.file_name().unwrap().to_str().unwrap().parse::<usize>().unwrap();
             let full_path =
-                data_dir.join(format!("{}", path.file_name().unwrap().to_str().unwrap()));
+                data_dir.join(path.file_name().unwrap().to_str().unwrap());
             if id != seq_num {
                 fs::remove_file(full_path).expect("could not remove index file");
             }

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -8,14 +8,25 @@ pub struct Console {
 }
 
 impl Console {
-    pub fn new(bin_width: i64) -> Console {
-        Console { aggrs: Buckets::new(bin_width) }
+    pub fn new(config: ConsoleConfig) -> Console {
+        Console { aggrs: Buckets::new(config.bin_width) }
     }
 }
 
 impl Default for Console {
-    fn default() -> Self {
-        Self::new(1)
+    fn default() -> Console {
+        Self::new(ConsoleConfig::default())
+    }
+}
+
+#[derive(Debug)]
+pub struct ConsoleConfig {
+    pub bin_width: i64,
+}
+
+impl Default for ConsoleConfig {
+    fn default() -> ConsoleConfig {
+        ConsoleConfig { bin_width: 1 }
     }
 }
 

--- a/src/sink/federation_transmitter.rs
+++ b/src/sink/federation_transmitter.rs
@@ -16,11 +16,17 @@ pub struct FederationTransmitter {
     buffer: Vec<metric::Event>,
 }
 
+#[derive(Debug)]
+pub struct FederationTransmitterConfig {
+    pub port: u16,
+    pub host: String,
+}
+
 impl FederationTransmitter {
-    pub fn new(port: u16, host: String) -> FederationTransmitter {
+    pub fn new(config: FederationTransmitterConfig) -> FederationTransmitter {
         FederationTransmitter {
-            port: port,
-            host: host,
+            port: config.port,
+            host: config.host,
             buffer: Vec::new(),
         }
     }

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -8,11 +8,11 @@ mod firehose;
 mod null;
 mod wavefront;
 
-pub use self::console::Console;
-pub use self::federation_transmitter::FederationTransmitter;
+pub use self::console::{Console, ConsoleConfig};
+pub use self::federation_transmitter::{FederationTransmitter, FederationTransmitterConfig};
 pub use self::firehose::Firehose;
-pub use self::null::Null;
-pub use self::wavefront::Wavefront;
+pub use self::null::{Null, NullConfig};
+pub use self::wavefront::{Wavefront, WavefrontConfig};
 
 /// A 'sink' is a sink for metrics.
 pub trait Sink {

--- a/src/sink/null.rs
+++ b/src/sink/null.rs
@@ -5,14 +5,24 @@ pub struct Null {
 }
 
 impl Null {
-    pub fn new() -> Null {
+    pub fn new(_config: NullConfig) -> Null {
         Null {}
     }
 }
 
 impl Default for Null {
     fn default() -> Self {
-        Self::new()
+        Self::new(NullConfig::default())
+    }
+}
+
+#[derive(Debug)]
+pub struct NullConfig {
+}
+
+impl Default for NullConfig {
+    fn default() -> NullConfig {
+        NullConfig {}
     }
 }
 

--- a/src/source/federation_receiver.rs
+++ b/src/source/federation_receiver.rs
@@ -20,19 +20,22 @@ pub struct FederationReceiver {
     tags: metric::TagMap,
 }
 
+#[derive(Debug)]
+pub struct FederationReceiverConfig {
+    pub ip: String,
+    pub port: u16,
+    pub tags: metric::TagMap,
+}
+
 impl FederationReceiver {
-    pub fn new<S>(chans: Vec<mpsc::Sender<metric::Event>>,
-                  ip: S,
-                  port: u16,
-                  tags: metric::TagMap)
-                  -> FederationReceiver
-        where S: Into<String>
-    {
+    pub fn new(chans: Vec<mpsc::Sender<metric::Event>>,
+               config: FederationReceiverConfig)
+               -> FederationReceiver {
         FederationReceiver {
             chans: chans,
-            ip: ip.into(),
-            port: port,
-            tags: tags,
+            ip: config.ip,
+            port: config.port,
+            tags: config.tags,
         }
     }
 }
@@ -84,7 +87,9 @@ fn handle_stream(mut chans: Vec<mpsc::Sender<metric::Event>>,
                                 metric::Event::Graphite(m) => {
                                     metric::Event::Graphite(m.merge_tags_from_map(&tags))
                                 }
-                                _ => continue, // we refuse to accept any non-telemetry forward for now
+                                // we refuse to accept any non-telemetry forward
+                                // for now
+                                _ => continue,
                             };
                             send("receiver", &mut chans, &ev);
                         }

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -23,15 +23,18 @@ pub struct FileServer {
     tags: metric::TagMap,
 }
 
+#[derive(Debug)]
+pub struct FileServerConfig {
+    pub path: PathBuf,
+    pub tags: metric::TagMap,
+}
+
 impl FileServer {
-    pub fn new(chans: Vec<mpsc::Sender<metric::Event>>,
-               path: PathBuf,
-               tags: metric::TagMap)
-               -> FileServer {
+    pub fn new(chans: Vec<mpsc::Sender<metric::Event>>, config: FileServerConfig) -> FileServer {
         FileServer {
             chans: chans,
-            path: path,
-            tags: tags,
+            path: config.path,
+            tags: config.tags,
         }
     }
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -11,11 +11,11 @@ mod file;
 mod flush;
 mod federation_receiver;
 
-pub use self::graphite::Graphite;
-pub use self::statsd::Statsd;
-pub use self::file::FileServer;
+pub use self::graphite::{Graphite, GraphiteConfig};
+pub use self::statsd::{Statsd, StatsdConfig};
+pub use self::file::{FileServer, FileServerConfig};
 pub use self::flush::FlushTimer;
-pub use self::federation_receiver::FederationReceiver;
+pub use self::federation_receiver::{FederationReceiver, FederationReceiverConfig};
 
 #[inline]
 pub fn send<S>(ctx: S, chans: &mut Vec<mpsc::Sender<metric::Event>>, event: &metric::Event)


### PR DESCRIPTION
This commit starts on down the road of having a Filter concept. To
make that happen effectively we're going to need to have more
specific notions of configuring individual sources / sinks. To that
end, sources / sinks now are obligated to provide some kind of
Config object so that config.rs can stuff values down. A handy
side-effect is that we no longer have to copy config::Args.

This is a situation where inheritance would come in handy. Oh well.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>