### PR TITLE
Make use of environmental controlled quickcheck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 2.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quantiles 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.4.0 (git+https://github.com/burntsushi/quickcheck.git?rev=570f6a84de55706257ca302ab76c16879f6b2af5)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -541,8 +541,8 @@ dependencies = [
 
 [[package]]
 name = "quickcheck"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.4.0"
+source = "git+https://github.com/burntsushi/quickcheck.git?rev=570f6a84de55706257ca302ab76c16879f6b2af5#570f6a84de55706257ca302ab76c16879f6b2af5"
 dependencies = [
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1024,7 +1024,7 @@ dependencies = [
 "checksum quantiles 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58546e197383b53a50fa00289227758f29fa6831f97645281f4e8e914c6aa642"
 "checksum quasi 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94a532453b931a4483a5b2e40f0fe04aee35b6bc2c0eeec876f1bd2358a134d3"
 "checksum quasi_codegen 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb4a9a5410fdbdacbeda8063ddb8add9838dfd4cf50ac486db98abb762d8bd6"
-"checksum quickcheck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ee4649d5e823e7a9e5a128a6bfa884e132f93668c64274d865d9f94a0f2574ca"
+"checksum quickcheck 0.4.0 (git+https://github.com/burntsushi/quickcheck.git?rev=570f6a84de55706257ca302ab76c16879f6b2af5)" = "<none>"
 "checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
 "checksum regex 0.1.77 (registry+https://github.com/rust-lang/crates.io-index)" = "64b03446c466d35b42f2a8b203c8e03ed8b91c0f17b56e1f84f7210a257aa665"
 "checksum regex-syntax 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279401017ae31cf4e15344aa3f085d0e2e5c1e70067289ef906906fdbe92c8fd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ toml = "0.2.0"
 
 [dev-dependencies]
 tempdir = "0.3"
-quickcheck = "0.3"
+quickcheck = { git = "https://github.com/burntsushi/quickcheck.git", rev = "570f6a84de55706257ca302ab76c16879f6b2af5" }
 
 [build-dependencies]
 serde_codegen = "0.8"

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -145,20 +145,6 @@ mod test {
     use std::collections::{HashSet, HashMap};
     use chrono::{UTC, TimeZone};
     use std::cmp::Ordering;
-    use rand::{thread_rng, Rng};
-    use std::env;
-
-    // NOTE working to contribute this upstream so we can have this everywhere
-    fn qc_tests() -> usize {
-        match env::var("QC_TESTS") {
-            Ok(val) => val.parse().expect("could not convert to number"),
-            Err(_) => 1000,
-        }
-    }
-
-    fn max_qc_tests() -> usize {
-        qc_tests() * 100
-    }
 
     fn within(width: i64, lhs: i64, rhs: i64) -> bool {
         (lhs / width) == (rhs / width)
@@ -197,63 +183,6 @@ mod test {
 
         let v = bkt.gauges().get("lO").unwrap();
         assert_eq!(3, v.len());
-    }
-
-
-    #[test]
-    fn shuffled_variable_size_bins() {
-        fn inner(bin_width: u16, ms: Vec<Metric>) -> TestResult {
-            let bin_width: i64 = bin_width as i64;
-            if bin_width == 0 {
-                return TestResult::discard();
-            }
-
-            let mut bkt0 = Buckets::new(bin_width);
-            let mut bkt1 = Buckets::new(bin_width);
-            for m in ms.clone() {
-                bkt0.add(m);
-            }
-            let mut rng = thread_rng();
-            let mut shfl_ms = ms.clone();
-            rng.shuffle(&mut shfl_ms[..]);
-            for m in shfl_ms {
-                bkt1.add(m);
-            }
-
-            let mut ms0: Vec<(&String, &Vec<Metric>)> = bkt0.gauges()
-                .iter()
-                .chain(bkt0.counters().iter())
-                .chain(bkt0.raws().iter())
-                .chain(bkt0.histograms().iter())
-                .chain(bkt0.timers().iter())
-                .collect();
-            let mut ms1: Vec<(&String, &Vec<Metric>)> = bkt1.gauges()
-                .iter()
-                .chain(bkt1.counters().iter())
-                .chain(bkt1.raws().iter())
-                .chain(bkt1.histograms().iter())
-                .chain(bkt1.timers().iter())
-                .collect();
-            ms0.sort_by_key(|m| m.0);
-            ms1.sort_by_key(|m| m.0);
-
-            for (x, y) in ms0.iter().zip(ms1.iter()) {
-                let xv = x.1;
-                let yv = y.1;
-                for (i, a) in xv.iter().enumerate() {
-                    assert_eq!(a.name, yv[i].name);
-                    assert_eq!(a.kind, yv[i].kind);
-                    assert_eq!(a.query(1.0), yv[i].query(1.0));
-                    assert_eq!(a.query(0.5), yv[i].query(0.5));
-                    assert_eq!(a.query(0.0), yv[i].query(0.0));
-                }
-            }
-            TestResult::passed()
-        }
-        QuickCheck::new()
-            .tests(qc_tests())
-            .max_tests(max_qc_tests())
-            .quickcheck(inner as fn(u16, Vec<Metric>) -> TestResult);
     }
 
     #[test]
@@ -311,10 +240,7 @@ mod test {
             }
             TestResult::passed()
         }
-        QuickCheck::new()
-            .tests(qc_tests())
-            .max_tests(max_qc_tests())
-            .quickcheck(inner as fn(u16, Vec<Metric>) -> TestResult);
+        QuickCheck::new().quickcheck(inner as fn(u16, Vec<Metric>) -> TestResult);
     }
 
     #[test]
@@ -565,10 +491,7 @@ mod test {
 
             TestResult::passed()
         }
-        QuickCheck::new()
-            .tests(qc_tests())
-            .max_tests(max_qc_tests())
-            .quickcheck(qos_ret as fn(Vec<Metric>) -> TestResult);
+        QuickCheck::new().quickcheck(qos_ret as fn(Vec<Metric>) -> TestResult);
     }
 
     #[test]
@@ -598,10 +521,7 @@ mod test {
 
             TestResult::passed()
         }
-        QuickCheck::new()
-            .tests(qc_tests())
-            .max_tests(max_qc_tests())
-            .quickcheck(qos_ret as fn(Vec<Metric>) -> TestResult);
+        QuickCheck::new().quickcheck(qos_ret as fn(Vec<Metric>) -> TestResult);
     }
 
     #[test]
@@ -656,10 +576,7 @@ mod test {
 
             TestResult::passed()
         }
-        QuickCheck::new()
-            .tests(qc_tests())
-            .max_tests(max_qc_tests())
-            .quickcheck(inner as fn(Vec<Metric>) -> TestResult);
+        QuickCheck::new().quickcheck(inner as fn(Vec<Metric>) -> TestResult);
     }
 
     #[test]
@@ -689,10 +606,7 @@ mod test {
 
             TestResult::passed()
         }
-        QuickCheck::new()
-            .tests(qc_tests())
-            .max_tests(max_qc_tests())
-            .quickcheck(qos_ret as fn(Vec<Metric>) -> TestResult);
+        QuickCheck::new().quickcheck(qos_ret as fn(Vec<Metric>) -> TestResult);
     }
 
     #[test]
@@ -722,10 +636,7 @@ mod test {
 
             TestResult::passed()
         }
-        QuickCheck::new()
-            .tests(qc_tests())
-            .max_tests(max_qc_tests())
-            .quickcheck(qos_ret as fn(Vec<Metric>) -> TestResult);
+        QuickCheck::new().quickcheck(qos_ret as fn(Vec<Metric>) -> TestResult);
     }
 
     #[test]
@@ -746,10 +657,7 @@ mod test {
 
             TestResult::passed()
         }
-        QuickCheck::new()
-            .tests(qc_tests())
-            .max_tests(max_qc_tests())
-            .quickcheck(qos_ret as fn(Vec<Metric>) -> TestResult);
+        QuickCheck::new().quickcheck(qos_ret as fn(Vec<Metric>) -> TestResult);
     }
 
     #[test]
@@ -822,10 +730,7 @@ mod test {
 
             TestResult::passed()
         }
-        QuickCheck::new()
-            .tests(qc_tests())
-            .max_tests(max_qc_tests())
-            .quickcheck(qos_ret as fn(Vec<Metric>) -> TestResult);
+        QuickCheck::new().quickcheck(qos_ret as fn(Vec<Metric>) -> TestResult);
     }
 
     #[test]
@@ -874,9 +779,6 @@ mod test {
 
             TestResult::passed()
         }
-        QuickCheck::new()
-            .tests(qc_tests())
-            .max_tests(max_qc_tests())
-            .quickcheck(inner as fn(Vec<Metric>) -> TestResult);
+        QuickCheck::new().quickcheck(inner as fn(Vec<Metric>) -> TestResult);
     }
 }

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -102,10 +102,19 @@ impl PartialOrd for MetricKind {
 impl AddAssign for Metric {
     fn add_assign(&mut self, rhs: Metric) {
         match rhs.kind {
-            MetricKind::DeltaGauge | MetricKind::Gauge => self.kind = rhs.kind,
-            _ => assert_eq!(self.kind, rhs.kind),
-        };
-        self.value += rhs.value;
+            MetricKind::DeltaGauge => {
+                self.kind = rhs.kind;
+                self.value += rhs.value;
+            }
+            MetricKind::Gauge => {
+                self.kind = rhs.kind;
+                self.value = rhs.value;
+            } 
+            _ => {
+                self.value += rhs.value;
+                assert_eq!(self.kind, rhs.kind);
+            }
+        }
     }
 }
 

--- a/src/mpsc/receiver.rs
+++ b/src/mpsc/receiver.rs
@@ -51,8 +51,7 @@ impl<T> Receiver<T>
         for fname in fs::read_dir(data_dir).unwrap() {
             let path = fname.unwrap().path();
             let id = path.file_name().unwrap().to_str().unwrap().parse::<usize>().unwrap();
-            let full_path =
-                data_dir.join(path.file_name().unwrap().to_str().unwrap());
+            let full_path = data_dir.join(path.file_name().unwrap().to_str().unwrap());
             if id != seq_num {
                 fs::remove_file(full_path).expect("could not remove index file");
             }


### PR DESCRIPTION
This commit uses the specific sha of rust quickcheck that has my
environmental controls in it _and_ resolves a couple of issues with
the bucket implementation. Both were discovered by running:

    QUICKCHECK_TESTS=10000 QUICKCHECK_GENERATOR_SIZE=1000 cargo test buckets::test::

In particular:

  * DeltaGauge + Gauge + DeltaGauge did not reset correctly
  * Buckets inserts are not communicative on account of Gauge

Signed-off-by: Brian L. Troutwine <blt@postmates.com>