### PR TITLE
Integrate hard-coded filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "quantiles 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.4.0 (git+https://github.com/burntsushi/quickcheck.git?rev=570f6a84de55706257ca302ab76c16879f6b2af5)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.77 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_codegen 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.3.6"
 notify = "2.6.3"
 quantiles = "0.2.0"
 rand = "0.3"
+regex = "0.1"
 rusoto = {version = "0.17.0", features = ["firehose"]}
 serde = "0.8"
 serde_json = "0.8"

--- a/src/filter/collectd_scrub.rs
+++ b/src/filter/collectd_scrub.rs
@@ -1,0 +1,98 @@
+use filter;
+use metric;
+use mpsc;
+
+use regex;
+
+pub struct CollectdScrub {
+    scrub_pattern: regex::Regex,
+}
+
+impl Default for filter::collectd_scrub::CollectdScrub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CollectdScrub {
+    pub fn new() -> CollectdScrub {
+        CollectdScrub {
+            scrub_pattern: regex::Regex::new(r"^(collectd)[@|.]([[:alnum:]_-]+)(.*)").unwrap(),
+        }
+    }
+
+    pub fn extract(&self, orig: &str) -> Option<String> {
+        self.scrub_pattern
+            .captures(orig.into())
+            .map(|caps| format!("{}{}", caps.at(1).unwrap(), caps.at(3).unwrap()))
+    }
+}
+
+impl filter::Filter for CollectdScrub {
+    fn process<'a>(&mut self,
+                   event: &'a mut metric::Event,
+                   chans: &'a mut Vec<mpsc::Sender<metric::Event>>)
+                   -> Vec<(&'a mut mpsc::Sender<metric::Event>, Vec<metric::Event>)> {
+        trace!("received event: {:?}", event);
+        let event = event.clone();
+        match event {
+            metric::Event::Graphite(mut m) => {
+                if let Some(new_name) = self.extract(&m.name) {
+                    m.name = new_name;
+                }
+                debug!("adjusted name: {}", m.name);
+                let new_event = metric::Event::Graphite(m);
+                debug!("new_event: {:?}", new_event);
+                let mut emitts = Vec::new();
+                for chan in chans {
+                    emitts.push((chan, vec![new_event.clone()]))
+                }
+                emitts
+            }
+            other => {
+                let mut emitts = Vec::new();
+                for chan in chans {
+                    emitts.push((chan, vec![other.clone()]))
+                }
+                emitts
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collectd_ip_extraction() {
+        let cs = CollectdScrub::new();
+
+        let orig = "collectd.ip-10-1-21-239.interface-lo.if_errors.tx 0 1478751126";
+        let filtered = cs.extract(orig);
+
+        assert_eq!(Some("collectd.interface-lo.if_errors.tx 0 1478751126".into()),
+                   filtered);
+    }
+
+    #[test]
+    fn test_collectd_non_ip_extraction() {
+        let cs = CollectdScrub::new();
+
+        let orig = "collectd.totally_fine.interface-lo.if_errors.tx 0 1478751126";
+        let filtered = cs.extract(orig);
+
+        assert_eq!(Some("collectd.interface-lo.if_errors.tx 0 1478751126".into()),
+                   filtered);
+    }
+
+    #[test]
+    fn test_non_collectd_extraction() {
+        let cs = CollectdScrub::new();
+
+        let orig = "totally_fine.interface-lo.if_errors.tx 0 1478751126";
+        let filtered = cs.extract(orig);
+
+        assert_eq!(None, filtered);
+    }
+}

--- a/src/filter/id.rs
+++ b/src/filter/id.rs
@@ -1,0 +1,23 @@
+use filter;
+use metric;
+use mpsc;
+
+#[derive(Default)]
+pub struct Id {
+}
+
+impl Id {
+    pub fn new() -> Id {
+        Id {}
+    }
+}
+
+impl filter::Filter for Id {
+    fn process<'a>(&mut self,
+                   event: &'a mut metric::Event,
+                   chans: &'a mut Vec<mpsc::Sender<metric::Event>>)
+                   -> Vec<(&'a mut mpsc::Sender<metric::Event>, Vec<metric::Event>)> {
+        let event = event.clone();
+        vec![(&mut chans[0], vec![event])]
+    }
+}

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,0 +1,37 @@
+use metric;
+use mpsc;
+use time;
+
+mod id;
+mod collectd_scrub;
+
+pub use self::id::Id;
+pub use self::collectd_scrub::CollectdScrub;
+
+pub trait Filter {
+    // TODO There should be a way to send a modified event to some channels, not
+    // to others etc.
+    fn process<'a>(&mut self,
+                   event: &'a mut metric::Event,
+                   chans: &'a mut Vec<mpsc::Sender<metric::Event>>)
+                   -> Vec<(&'a mut mpsc::Sender<metric::Event>, Vec<metric::Event>)>;
+    fn run(&mut self,
+           mut recv: mpsc::Receiver<metric::Event>,
+           mut chans: Vec<mpsc::Sender<metric::Event>>) {
+        let mut attempts = 0;
+        loop {
+            time::delay(attempts);
+            match recv.next() {
+                None => attempts += 1,
+                Some(mut event) => {
+                    for &mut (ref mut chan, ref events) in
+                        &mut self.process(&mut event, &mut chans) {
+                        for ev in events {
+                            chan.send(ev)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate rusoto;
 extern crate lazy_static;
 extern crate flate2;
 extern crate rand;
+extern crate regex;
 extern crate quantiles;
 
 pub mod mpsc;
@@ -23,3 +24,4 @@ pub mod config;
 pub mod metric;
 pub mod time;
 pub mod source;
+pub mod filter;


### PR DESCRIPTION
This commit introduces the long-awaited Filter concept into cernan,
part of #115. It cannot be configured. A CollectdScrub is put into
place between Graphite and enabled sources, Id is put into place
between Statsd and enabled sources.

Without configuration this is not suitable to run in production.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>