### PR TITLE
Add self-telemetry to wavefront sink

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,7 @@ pub fn parse_args() -> Args {
                     host: args.value_of("wavefront-host").unwrap().to_string(),
                     bin_width: 1,
                     config_path: "sinks.wavefront".to_string(),
+                    tags: Default::default(),
                 })
             } else {
                 None
@@ -205,6 +206,7 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                 .map(|i| i as i64)
                 .unwrap(),
             config_path: "sinks.wavefront".to_string(),
+            tags: tags.clone(),
         })
     } else {
         None
@@ -452,8 +454,7 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                 if is_enabled {
                     let mut sconfig = StatsdConfig::default();
                     if let Some(p) = value.lookup("statsd.port") {
-                        sconfig.port =
-                            p.as_integer().expect("statsd-port must be integer") as u16;
+                        sconfig.port = p.as_integer().expect("statsd-port must be integer") as u16;
                     }
                     if let Some(fwds) = value.lookup("statsd.forwards") {
                         sconfig.forwards = fwds.as_slice()

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -300,6 +300,11 @@ impl Metric {
         self
     }
 
+    pub fn insert_value(mut self, value: f64) -> Metric {
+        self.value.insert(value);
+        self
+    }
+
     pub fn value(&self) -> Option<f64> {
         match self.kind {
             MetricKind::Gauge | MetricKind::Raw => self.value.last(),


### PR DESCRIPTION
This commit introduces telemetry to the wavefront sink on the
number of delivery attempts that have been made as well as on the
"time spread" of metrics. The "time spread" gives us a histogram
of the difference between time::now() and all the metrics which
are being shipped. This _should_ range from 0 to flush-interval.

As delivery attempts grows that gives us a sense of being backed-up
and time spread lets us know what the wall-clock delay is.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>