### PR TITLE
Adjust how gauge times are maintained across resets

### DIFF
--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -7,6 +7,7 @@ use metric::{Metric, MetricKind};
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use fnv::FnvHasher;
+use time;
 
 pub type HashMapFnv<K, V> = HashMap<K, V, BuildHasherDefault<FnvHasher>>;
 
@@ -81,6 +82,7 @@ impl Buckets {
             if len > 0 {
                 v.swap(0, len - 1);
                 v.truncate(1);
+                v[0].time = time::now();
             }
         }
     }


### PR DESCRIPTION
Here's a fun one! By retaining gauges across resets we've effectively
said that the time value of that gauge is as useful as its value. This
is not true. The time value _ought_ to be reset even while the value
persists.

Not doing so throws off the wavefront sink self-telemetry.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>