### PR TITLE
Remake the hard distinction between gauges / delta-gauges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lua 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quantiles 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck 0.4.0 (git+https://github.com/burntsushi/quickcheck.git?rev=570f6a84de55706257ca302ab76c16879f6b2af5)",
+ "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -402,8 +402,8 @@ dependencies = [
 
 [[package]]
 name = "quickcheck"
-version = "0.4.0"
-source = "git+https://github.com/burntsushi/quickcheck.git?rev=570f6a84de55706257ca302ab76c16879f6b2af5#570f6a84de55706257ca302ab76c16879f6b2af5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -879,7 +879,7 @@ dependencies = [
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
 "checksum pnacl-build-helper 1.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "61c9231d31aea845007443d62fcbb58bb6949ab9c18081ee1e09920e0cf1118b"
 "checksum quantiles 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58546e197383b53a50fa00289227758f29fa6831f97645281f4e8e914c6aa642"
-"checksum quickcheck 0.4.0 (git+https://github.com/burntsushi/quickcheck.git?rev=570f6a84de55706257ca302ab76c16879f6b2af5)" = "<none>"
+"checksum quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "02c2411d418cea2364325b18a205664f9ef8252e06b2e911db97c0b0d98b1406"
 "checksum quote 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "6732e32663c9c271bfc7c1823486b471f18c47a2dbf87c066897b7b51afc83be"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ uuid = {version = "0.2", features = ["v4"]}
 
 [dev-dependencies]
 tempdir = "0.3"
-quickcheck = { git = "https://github.com/burntsushi/quickcheck.git", rev = "570f6a84de55706257ca302ab76c16879f6b2af5" }
+quickcheck = "0.4"
 
 [build-dependencies]
 serde_codegen = "0.8"

--- a/examples/configs/basic.toml
+++ b/examples/configs/basic.toml
@@ -10,12 +10,13 @@ source = "cernan"
   [sources.statsd.primary]
   enabled = true
   port = 8125
-  forwards = ["sinks.console", "sinks.wavefront"]
+  forwards = ["sinks.console"] #, "sinks.wavefront"]
 
   [sources.graphite.primary]
   enabled = true
   port = 2004
-  forwards = ["filters.collectd_scrub"]
+  forwards = ["sinks.console"]
+#  forwards = ["filters.collectd_scrub"]
 
   # [sources.files]
   # [sources.files.example_log]
@@ -30,21 +31,21 @@ source = "cernan"
   # port = 1972
   # ip = "0.0.0.0"
 
-[filters]
-  [filters.collectd_scrub]
-  script = "collectd_scrub.lua"
-  forwards = ["sinks.console", "sinks.null", "sinks.wavefront"]
+# [filters]
+#   [filters.collectd_scrub]
+#   script = "collectd_scrub.lua"
+#   forwards = ["sinks.console", "sinks.null", "sinks.wavefront"]
 
 [sinks]
   [sinks.console]
   bin_width = 1
 
-  [sinks.null]
+  # [sinks.null]
 
-  [sinks.wavefront]
-  port = 2878
-  host = "127.0.0.1"
-  bin_width = 1
+  # [sinks.wavefront]
+  # port = 2878
+  # host = "127.0.0.1"
+  # bin_width = 1
 
   # [sinks.firehose.stream_two]
   # delivery_stream = "stream_two"

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -52,67 +52,6 @@ fn cmp(left: &TagMap, right: &TagMap) -> Option<Ordering> {
     }
 }
 
-impl PartialEq for MetricKind {
-    fn eq(&self, other: &MetricKind) -> bool {
-        match (self, other) {
-            (&MetricKind::Gauge, &MetricKind::Gauge) |
-            (&MetricKind::Gauge, &MetricKind::DeltaGauge) |
-            (&MetricKind::DeltaGauge, &MetricKind::DeltaGauge) |
-            (&MetricKind::DeltaGauge, &MetricKind::Gauge) |
-            (&MetricKind::Counter, &MetricKind::Counter) |
-            (&MetricKind::Timer, &MetricKind::Timer) |
-            (&MetricKind::Histogram, &MetricKind::Histogram) |
-            (&MetricKind::Raw, &MetricKind::Raw) => true,
-            _ => false,
-        }
-    }
-}
-
-impl PartialOrd for MetricKind {
-    fn partial_cmp(&self, other: &MetricKind) -> Option<Ordering> {
-        match (self, other) {
-            (&MetricKind::Counter, &MetricKind::DeltaGauge) |
-            (&MetricKind::Counter, &MetricKind::Gauge) |
-            (&MetricKind::Counter, &MetricKind::Histogram) |
-            (&MetricKind::Counter, &MetricKind::Raw) |
-            (&MetricKind::Counter, &MetricKind::Timer) |
-            (&MetricKind::Histogram, &MetricKind::Raw) |
-            (&MetricKind::DeltaGauge, &MetricKind::Histogram) |
-            (&MetricKind::DeltaGauge, &MetricKind::Raw) |
-            (&MetricKind::DeltaGauge, &MetricKind::Timer) |
-            (&MetricKind::Gauge, &MetricKind::Histogram) |
-            (&MetricKind::Gauge, &MetricKind::Raw) |
-            (&MetricKind::Gauge, &MetricKind::Timer) |
-            (&MetricKind::Timer, &MetricKind::Histogram) |
-            (&MetricKind::Timer, &MetricKind::Raw) => Some(Ordering::Less),
-
-            (&MetricKind::Counter, &MetricKind::Counter) |
-            (&MetricKind::DeltaGauge, &MetricKind::DeltaGauge) |
-            (&MetricKind::DeltaGauge, &MetricKind::Gauge) |
-            (&MetricKind::Gauge, &MetricKind::DeltaGauge) |
-            (&MetricKind::Gauge, &MetricKind::Gauge) |
-            (&MetricKind::Histogram, &MetricKind::Histogram) |
-            (&MetricKind::Raw, &MetricKind::Raw) |
-            (&MetricKind::Timer, &MetricKind::Timer) => Some(Ordering::Equal),
-
-            (&MetricKind::DeltaGauge, &MetricKind::Counter) |
-            (&MetricKind::Gauge, &MetricKind::Counter) |
-            (&MetricKind::Histogram, &MetricKind::Counter) |
-            (&MetricKind::Histogram, &MetricKind::DeltaGauge) |
-            (&MetricKind::Histogram, &MetricKind::Gauge) |
-            (&MetricKind::Histogram, &MetricKind::Timer) |
-            (&MetricKind::Raw, &MetricKind::Counter) |
-            (&MetricKind::Raw, &MetricKind::DeltaGauge) |
-            (&MetricKind::Raw, &MetricKind::Gauge) |
-            (&MetricKind::Raw, &MetricKind::Histogram) |
-            (&MetricKind::Raw, &MetricKind::Timer) |
-            (&MetricKind::Timer, &MetricKind::Counter) |
-            (&MetricKind::Timer, &MetricKind::DeltaGauge) |
-            (&MetricKind::Timer, &MetricKind::Gauge) => Some(Ordering::Greater),
-        }
-    }
-}
-
 impl AddAssign for Metric {
     fn add_assign(&mut self, rhs: Metric) {
         match rhs.kind {
@@ -609,8 +548,8 @@ mod tests {
         let mdg = Metric::new("l6", 0.7913855).delta_gauge().time(47);
         let mg = Metric::new("l6", 0.9683).gauge().time(47);
 
-        assert_eq!(Some(Ordering::Equal), mg.partial_cmp(&mdg));
-        assert_eq!(Some(Ordering::Equal), mdg.partial_cmp(&mg));
+        assert_eq!(Some(Ordering::Less), mg.partial_cmp(&mdg));
+        assert_eq!(Some(Ordering::Greater), mdg.partial_cmp(&mg));
     }
 
     impl Rand for MetricKind {
@@ -649,7 +588,7 @@ mod tests {
     impl Rand for Event {
         fn rand<R: Rng>(rng: &mut R) -> Event {
             let i: usize = rng.gen();
-            match i % 4 {
+            match i % 3 {
                 0 => Event::TimerFlush,
                 _ => Event::Telemetry(rng.gen()),
             }

--- a/src/metric_types.in.rs
+++ b/src/metric_types.in.rs
@@ -23,7 +23,7 @@ pub enum Event {
     TimerFlush,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, Hash)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, PartialOrd, Eq, Hash)]
 pub enum MetricKind {
     Counter,
     Gauge,

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -29,8 +29,8 @@ impl ConsoleConfig {
 }
 
 /// Print a single stats line.
-fn fmt_line(key: &str, value: f64) {
-    println!("    {}: {}", key, value)
+fn fmt_line(key: &str, time: i64, value: f64) {
+    println!("    {}({}): {}", key, time, value)
 }
 
 impl Sink for Console {
@@ -45,14 +45,13 @@ impl Sink for Console {
     }
 
     fn flush(&mut self) {
-        let now = chrono::UTC::now();
-        println!("Flushing metrics: {}", now.to_rfc3339());
+        println!("Flushing metrics: {}", chrono::UTC::now().to_rfc3339());
 
         println!("  counters:");
         for (key, value) in self.aggrs.counters() {
             for m in value {
                 if let Some(f) = m.value() {
-                    fmt_line(key, f)
+                    fmt_line(key, m.time, f)
                 }
             }
         }
@@ -61,7 +60,14 @@ impl Sink for Console {
         for (key, value) in self.aggrs.gauges() {
             for m in value {
                 if let Some(f) = m.value() {
-                    fmt_line(key, f)
+                    fmt_line(key, m.time, f)
+                }
+            }
+        }
+        for (key, value) in self.aggrs.delta_gauges() {
+            for m in value {
+                if let Some(f) = m.value() {
+                    fmt_line(key, m.time, f)
                 }
             }
         }
@@ -70,7 +76,7 @@ impl Sink for Console {
         for (key, value) in self.aggrs.raws() {
             for m in value {
                 if let Some(f) = m.value() {
-                    fmt_line(key, f)
+                    fmt_line(key, m.time, f)
                 }
             }
         }

--- a/src/time.rs
+++ b/src/time.rs
@@ -30,13 +30,13 @@ pub fn update_time() {
 
 #[inline]
 pub fn delay(attempts: u32) {
-    if attempts > 0 && attempts < 16 {
-        let max_delay: u32 = 60_000;
-        let delay = cmp::min(max_delay, 2u32.pow(attempts));
+    println!("ATTEMPTS: {}", attempts);
+    if attempts > 0 && attempts < 9 {
+        let delay = cmp::min(500, 2u32.pow(attempts));
         let sleep_time = time::Duration::from_millis(delay as u64);
         thread::sleep(sleep_time);
-    } else if attempts >= 16 {
-        let sleep_time = time::Duration::from_millis(60_000);
+    } else if attempts >= 9 {
+        let sleep_time = time::Duration::from_millis(500);
         thread::sleep(sleep_time);
-    }
+    };
 }


### PR DESCRIPTION
We previously blurred the line between gauges and delta-gagues--or
increment only counters--and that turned out not to be great in a
subtle way. Say you have a gauge-only series that reports every
so often. What does cernan do? Well! It turns out it will persist
the last value. Worse, a delta-gague series will reset every bin
interval to sum up when it should persist across intervals.

Womp womp

Signed-off-by: Brian L. Troutwine <blt@postmates.com>