### PR TITLE
Optimize the Metric

### DIFF
--- a/src/metric/metric_types.in.rs
+++ b/src/metric/metric_types.in.rs
@@ -13,7 +13,7 @@ pub struct Metric {
     pub created_time: i64,
     pub name: String,
     pub tags: TagMap,
-    value: CKMS<f64>,
+    value: MetricValue,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -21,6 +21,19 @@ pub enum Event {
     Telemetry(Metric),
     Log(LogLine),
     TimerFlush,
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+pub enum MetricValueKind {
+    Single,
+    Many,
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+pub struct MetricValue {
+    kind: MetricValueKind,
+    single: Option<f64>,
+    many: Option<CKMS<f64>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, PartialOrd, Eq, Hash)]


### PR DESCRIPTION
Very commonly a Metric only holds one value, until such a time as
metrics are aggregated. This commit recognizes that fact and makes
the metric value a switch between a single value and a CKMS. The
benchmarking numbers here are very promising:

 ```
 name                                                     control ns/iter  variable ns/iter  diff ns/iter   diff %
 bench_all_snd_all_rcv                                    109,096          102,835                 -6,261   -5.74%
 bench_graphite                                           251              207                        -44  -17.53%
 bench_multi_gauges                                       36,600           31,089                  -5,511  -15.06%
 bench_serialize_deserialize_metric                       557              404                       -153  -27.47%
 bench_serialize_deserialize_timerflush                   51               47                          -4   -7.84%
 bench_single_gauge                                       286              264                        -22   -7.69%
 bench_single_timer                                       277              254                        -23   -8.30%
 bench_statsd_counter_no_sample                           268              223                        -45  -16.79%
 bench_statsd_counter_with_sample                         389              289                       -100  -25.71%
 bench_statsd_gauge_mit_sample                            291              238                        -53  -18.21%
 bench_statsd_gauge_no_sample                             277              214                        -63  -22.74%
 bench_statsd_histogram                                   268              220                        -48  -17.91%
 bench_statsd_incr_gauge_no_sample                        269              226                        -43  -15.99%
 bench_statsd_incr_gauge_with_sample                      304              247                        -57  -18.75%
 bench_statsd_timer                                       275              225                        -50  -18.18%
```

Signed-off-by: Brian L. Troutwine <blt@postmates.com>