### PR TITLE
Get travis to check the format of branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-before_script: (cargo install rustfmt || true)
+cache: cargo
 rust:
   - stable
   - beta
@@ -10,22 +10,16 @@ script:
   - cargo test
   - cargo fmt -- --write-mode=diff
 
-cache:
-  apt: true
-  directories:
-    - $HOME/.cargo
-    - target/debug/build
-
-before_cache:
-    # Travis can't cache files that are not readable by "others"
-    - chmod -R a+r $HOME/.cargo
-
 matrix:
   allow_failures:
   - rust: nightly
 
 before_install:
   - sudo apt-get update
+
+install:
+  - (cargo install rustfmt || true)
+  - PATH=$PATH:/home/travis/.cargo/bin
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,24 @@
 language: rust
+before_script: (cargo install rustfmt || true)
 rust:
   - stable
   - beta
   - nightly
+
+script:
+  - cargo build
+  - cargo test
+  - cargo fmt -- --write-mode=diff
+
+cache:
+  apt: true
+  directories:
+    - $HOME/.cargo
+    - target/debug/build
+
+before_cache:
+    # Travis can't cache files that are not readable by "others"
+    - chmod -R a+r $HOME/.cargo
 
 matrix:
   allow_failures:

--- a/benches/buckets.rs
+++ b/benches/buckets.rs
@@ -5,12 +5,12 @@ extern crate cernan;
 extern crate chrono;
 extern crate rand;
 
+use self::test::Bencher;
 use cernan::buckets;
 use cernan::metric::Telemetry;
 
 use chrono::{TimeZone, UTC};
 use rand::Rng;
-use self::test::Bencher;
 
 #[bench]
 fn bench_single_timer(b: &mut Bencher) {

--- a/benches/metrics.rs
+++ b/benches/metrics.rs
@@ -3,10 +3,10 @@
 extern crate test;
 extern crate cernan;
 
+use self::test::Bencher;
 use cernan::metric::{TagMap, Telemetry};
 use cernan::protocols::graphite::parse_graphite;
 use cernan::protocols::statsd::parse_statsd;
-use self::test::Bencher;
 use std::sync;
 
 #[bench]

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -88,45 +88,35 @@ fn main() {
             .unwrap();
         flush_sends.push(null_send.clone());
         sends.insert(config.config_path.clone(), null_send);
-        joins.push(thread::spawn(move || {
-            cernan::sink::Null::new(config).run(null_recv);
-        }));
+        joins.push(thread::spawn(move || { cernan::sink::Null::new(config).run(null_recv); }));
     }
     if let Some(config) = args.wavefront {
         let (wf_send, wf_recv) = hopper::channel(&config.config_path, &args.data_directory)
             .unwrap();
         flush_sends.push(wf_send.clone());
         sends.insert(config.config_path.clone(), wf_send);
-        joins.push(thread::spawn(move || {
-            cernan::sink::Wavefront::new(config).run(wf_recv);
-        }));
+        joins.push(thread::spawn(move || { cernan::sink::Wavefront::new(config).run(wf_recv); }));
     }
     if let Some(config) = args.prometheus {
         let (wf_send, wf_recv) = hopper::channel(&config.config_path, &args.data_directory)
             .unwrap();
         flush_sends.push(wf_send.clone());
         sends.insert(config.config_path.clone(), wf_send);
-        joins.push(thread::spawn(move || {
-            cernan::sink::Prometheus::new(config).run(wf_recv);
-        }));
+        joins.push(thread::spawn(move || { cernan::sink::Prometheus::new(config).run(wf_recv); }));
     }
     if let Some(config) = args.influxdb {
         let (flx_send, flx_recv) = hopper::channel(&config.config_path, &args.data_directory)
             .unwrap();
         flush_sends.push(flx_send.clone());
         sends.insert(config.config_path.clone(), flx_send);
-        joins.push(thread::spawn(move || {
-            cernan::sink::InfluxDB::new(config).run(flx_recv);
-        }));
+        joins.push(thread::spawn(move || { cernan::sink::InfluxDB::new(config).run(flx_recv); }));
     }
     if let Some(config) = args.native_sink_config {
         let (cernan_send, cernan_recv) = hopper::channel(&config.config_path, &args.data_directory)
             .unwrap();
         flush_sends.push(cernan_send.clone());
         sends.insert(config.config_path.clone(), cernan_send);
-        joins.push(thread::spawn(move || {
-            cernan::sink::Native::new(config).run(cernan_recv);
-        }));
+        joins.push(thread::spawn(move || { cernan::sink::Native::new(config).run(cernan_recv); }));
     }
     for config in &args.firehosen {
         let f: FirehoseConfig = config.clone();
@@ -134,9 +124,7 @@ fn main() {
             hopper::channel(&config.config_path, &args.data_directory).unwrap();
         flush_sends.push(firehose_send.clone());
         sends.insert(config.config_path.clone(), firehose_send);
-        joins.push(thread::spawn(move || {
-            cernan::sink::Firehose::new(f).run(firehose_recv);
-        }));
+        joins.push(thread::spawn(move || { cernan::sink::Firehose::new(f).run(firehose_recv); }));
     }
 
     // FILTERS
@@ -175,9 +163,7 @@ fn main() {
                           &config.forwards,
                           &config.config_path,
                           &sends);
-        joins.push(thread::spawn(move || {
-            cernan::source::Statsd::new(statsd_sends, c).run();
-        }));
+        joins.push(thread::spawn(move || { cernan::source::Statsd::new(statsd_sends, c).run(); }));
     }
 
     for config in args.graphites.values() {
@@ -208,9 +194,7 @@ fn main() {
         cernan::source::FlushTimer::new(flush_sends, flush_interval).run();
     }));
 
-    joins.push(thread::spawn(move || {
-        cernan::time::update_time();
-    }));
+    joins.push(thread::spawn(move || { cernan::time::update_time(); }));
 
     for jh in joins {
         // TODO Having sub-threads panic will not cause a bubble-up if that

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -177,13 +177,13 @@ impl Buckets {
 mod test {
     extern crate quickcheck;
 
+    use self::quickcheck::{QuickCheck, TestResult};
+    use super::*;
     use chrono::{TimeZone, UTC};
     use metric::Telemetry;
     use quantiles::ckms::CKMS;
-    use self::quickcheck::{QuickCheck, TestResult};
     use std::cmp::Ordering;
     use std::collections::{HashMap, HashSet};
-    use super::*;
 
     fn within(width: i64, lhs: i64, rhs: i64) -> bool {
         (lhs / width) == (rhs / width)

--- a/src/config.rs
+++ b/src/config.rs
@@ -481,15 +481,13 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                     if is_enabled {
                         let mut sconfig = StatsdConfig::default();
                         if let Some(p) = tbl.lookup("port") {
-                            sconfig.port =
-                                p.as_integer().expect("statsd-port must be integer") as u16;
+                            sconfig.port = p.as_integer().expect("statsd-port must be integer") as
+                                           u16;
                         }
                         if let Some(p) = tbl.lookup("delete-gauges") {
-                            sconfig.delete_gauges =
-                                p.as_bool()
-                                    .expect("statsd delete-gauges \
-                                             must be \
-                                             boolean") as bool;
+                            sconfig.delete_gauges = p.as_bool()
+                                .expect("statsd delete-gauges must be boolean") as
+                                                    bool;
                         }
                         if let Some(fwds) = tbl.lookup("forwards") {
                             sconfig.forwards = fwds.as_slice()
@@ -546,8 +544,8 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                     if is_enabled {
                         let mut gconfig = GraphiteConfig::default();
                         if let Some(p) = tbl.lookup("port") {
-                            gconfig.port =
-                                p.as_integer().expect("graphite-port must be integer") as u16;
+                            gconfig.port = p.as_integer().expect("graphite-port must be integer") as
+                                           u16;
                         }
                         if let Some(fwds) = tbl.lookup("forwards") {
                             gconfig.forwards = fwds.as_slice()
@@ -569,8 +567,8 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                 if is_enabled {
                     let mut gconfig = GraphiteConfig::default();
                     if let Some(p) = value.lookup("graphite.port") {
-                        gconfig.port =
-                            p.as_integer().expect("graphite-port must be integer") as u16;
+                        gconfig.port = p.as_integer().expect("graphite-port must be integer") as
+                                       u16;
                     }
                     if let Some(fwds) = value.lookup("graphite.forwards") {
                         gconfig.forwards = fwds.as_slice()
@@ -649,11 +647,11 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use filter::ProgrammableFilterConfig;
     use metric::TagMap;
     use rusoto::Region;
     use std::path::{Path, PathBuf};
-    use super::*;
 
     #[test]
     fn config_file_data_directory() {

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -161,7 +161,7 @@ impl<'a> Payload<'a> {
                         state.push_nil();
                     }
                 }
-            } 
+            }
             None => {
                 error!("[log_tag_value] no key provided");
                 state.push_nil();
@@ -378,13 +378,12 @@ impl filter::Filter for ProgrammableFilter {
             metric::Event::Telemetry(mut m) => {
                 self.state.get_global("process_metric");
                 if !self.state.is_fn(-1) {
-                    let fail =
-                        metric::Event::Telemetry(sync::Arc::new(Some(metric::Telemetry::new(format!("cernan.filture.\
-                                                                              {}.process_metric.\
-                                                                              failure",
-                                                                             self.path),
-                                                                     1.0)
-                            .aggr_sum())));
+                    let filter_telem = metric::Telemetry::new(format!("cernan.filter.{}.\
+                                                                       process_metric.failure",
+                                                                      self.path),
+                                                              1.0)
+                        .aggr_sum();
+                    let fail = metric::Event::Telemetry(sync::Arc::new(Some(filter_telem)));
                     return Err(filter::FilterError::NoSuchFunction("process_metric", fail));
                 }
 
@@ -413,8 +412,8 @@ impl filter::Filter for ProgrammableFilter {
                     let fail =
                         metric::Event::new_telemetry(metric::Telemetry::new(format!("cernan.filter.\
                                                                                   {}.tick.failure",
-                                                                                 self.path),
-                                                                         1.0)
+                                                                                    self.path),
+                                                                            1.0)
                             .aggr_sum());
                     return Err(filter::FilterError::NoSuchFunction("tick", fail));
                 }
@@ -443,8 +442,8 @@ impl filter::Filter for ProgrammableFilter {
                         metric::Event::new_telemetry(metric::Telemetry::new(format!("cernan.filter.\
                                                                                   {}.process_log.\
                                                                                   failure",
-                                                                                 self.path),
-                                                                         1.0)
+                                                                                    self.path),
+                                                                            1.0)
                             .aggr_sum());
                     return Err(filter::FilterError::NoSuchFunction("process_log", fail));
                 }

--- a/src/metric/telemetry.rs
+++ b/src/metric/telemetry.rs
@@ -436,9 +436,9 @@ mod tests {
     extern crate rand;
     extern crate quickcheck;
 
-    use metric::{AggregationMethod, Event, Telemetry};
     use self::quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
     use self::rand::{Rand, Rng};
+    use metric::{AggregationMethod, Event, Telemetry};
     use std::cmp;
     use std::sync::Arc;
 
@@ -473,7 +473,7 @@ mod tests {
             match i {
                 0 => AggregationMethod::Sum,
                 1 => AggregationMethod::Set,
-                _ => AggregationMethod::Summarize, 
+                _ => AggregationMethod::Summarize,
             }
         }
     }

--- a/src/protocols/graphite.rs
+++ b/src/protocols/graphite.rs
@@ -37,10 +37,10 @@ pub fn parse_graphite(source: &str,
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use chrono::{TimeZone, UTC};
     use metric::{AggregationMethod, Telemetry};
     use std::sync;
-    use super::*;
 
     #[test]
     fn test_parse_graphite() {

--- a/src/protocols/statsd.rs
+++ b/src/protocols/statsd.rs
@@ -42,7 +42,7 @@ pub fn parse_statsd(source: &str,
                         metric = metric.timestamp(time::now());
                         let signed = match &src[offset..(offset + 1)] {
                             "+" | "-" => true,
-                            _ => false, 
+                            _ => false,
                         };
                         offset += pipe_idx + 1;
                         if offset >= len {
@@ -61,7 +61,7 @@ pub fn parse_statsd(source: &str,
                                     }
                                     "c|" | "c" => {
                                         let sample = match f64::from_str(&src[(offset + sample_idx +
-                                                                               1)..]) {
+                                                                           1)..]) {
                                             Ok(f) => f,
                                             Err(_) => return false,
                                         };
@@ -100,9 +100,9 @@ pub fn parse_statsd(source: &str,
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use metric::{AggregationMethod, Telemetry};
     use std::sync;
-    use super::*;
 
     #[test]
     fn test_counter() {

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -1,5 +1,5 @@
 //! TODO
- 
+
 use buckets::Buckets;
 use chrono;
 use metric::{AggregationMethod, LogLine, Telemetry};
@@ -94,7 +94,7 @@ impl Sink for Console {
                             tgt.push_str(&f.to_string());
                             tgt.push_str("\n");
                         }
-                    } 
+                    }
                     AggregationMethod::Set => {
                         let mut tgt = &mut sets;
                         if let Some(f) = value.value() {

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -224,11 +224,11 @@ impl Sink for InfluxDB {
 mod test {
     extern crate quickcheck;
 
+    use super::*;
     use chrono::{TimeZone, UTC};
     use metric::{TagMap, Telemetry};
     use sink::Sink;
     use std::sync::Arc;
-    use super::*;
 
     #[test]
     fn test_format_influxdb() {

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -56,7 +56,7 @@ pub trait Sink {
                                     self.deliver_line(line);
                                 }
                             }
-                        }                            
+                        }
                         Valve::Closed => {
                             attempts += 1;
                             continue;

--- a/src/sink/null.rs
+++ b/src/sink/null.rs
@@ -2,8 +2,7 @@ use metric::{LogLine, Telemetry};
 use sink::{Sink, Valve};
 use std::sync;
 
-pub struct Null {
-}
+pub struct Null {}
 
 impl Null {
     pub fn new(_config: NullConfig) -> Null {

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -125,7 +125,7 @@ impl Handler for SenderHandler {
         // aren't asking for plaintext you're asking for protobuf.
         match req.headers.get() {
             Some(&ContentType(Mime(TopLevel::Text, SubLevel::Plain, _))) => write_text(aggrs, res),
-            _ => write_binary(aggrs, res), 
+            _ => write_binary(aggrs, res),
         }
     }
 }
@@ -179,7 +179,7 @@ impl Sink for Prometheus {
         // for-sure but very, very likely.
         match aggrs.binary_search_by(|probe| probe.partial_cmp(&metric).unwrap()) {
             Ok(idx) => aggrs[idx] += metric,
-            Err(idx) => aggrs.insert(idx, metric), 
+            Err(idx) => aggrs.insert(idx, metric),
         };
     }
 

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -92,7 +92,7 @@ impl Wavefront {
 
                             tag_buf.clear();
                         }
-                    } 
+                    }
                     AggregationMethod::Summarize => {
                         fmt_tags(&value.tags, &mut tag_buf);
                         for tup in &[("min", 0.0),
@@ -206,11 +206,11 @@ impl Sink for Wavefront {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use chrono::{TimeZone, UTC};
     use metric::{TagMap, Telemetry};
     use sink::Sink;
     use std::sync::Arc;
-    use super::*;
 
     #[test]
     fn test_format_wavefront() {

--- a/src/source/graphite.rs
+++ b/src/source/graphite.rs
@@ -1,3 +1,4 @@
+use super::Source;
 use metric;
 use protocols::graphite::parse_graphite;
 use std::io::BufReader;
@@ -7,7 +8,6 @@ use std::net::{TcpListener, TcpStream};
 use std::str;
 use std::sync::Arc;
 use std::thread;
-use super::Source;
 use util;
 use util::send;
 
@@ -52,18 +52,14 @@ fn handle_tcp(chans: util::Channel,
               tags: Arc<metric::TagMap>,
               listner: TcpListener)
               -> thread::JoinHandle<()> {
-    thread::spawn(move || {
-        for stream in listner.incoming() {
-            if let Ok(stream) = stream {
-                debug!("new peer at {:?} | local addr for peer {:?}",
-                       stream.peer_addr(),
-                       stream.local_addr());
-                let tags = tags.clone();
-                let chans = chans.clone();
-                thread::spawn(move || {
-                    handle_stream(chans, tags, stream);
-                });
-            }
+    thread::spawn(move || for stream in listner.incoming() {
+        if let Ok(stream) = stream {
+            debug!("new peer at {:?} | local addr for peer {:?}",
+                   stream.peer_addr(),
+                   stream.local_addr());
+            let tags = tags.clone();
+            let chans = chans.clone();
+            thread::spawn(move || { handle_stream(chans, tags, stream); });
         }
     })
 }


### PR DESCRIPTION
This PR introduces running `cargo fmt -- --write-mode=diff` against every branch to ensure that style is maintained. This _may_ be annoying as differing versions of rustfmt seem to do different text manipulations but we'll see. If it is annoying we can always back it out. 