### PR TITLE
Introduce codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  precision: 2
+  round: down
+  range: 70...100
+
+  status:
+    project: true
+    changes: false
+
+    patch:
+      default:
+        target: 95%
+        threshold: 1%
+
+comment:
+  layout: "header, diff"
+  behavior: default  # update if exists else create new


### PR DESCRIPTION
We want to be sure that we keep code coverage of this project to
a certain level, 95%. Coverage is not correctness but it does
show whether we've probed sufficiently in test. We allow coverage
to drop by 1% per PR.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>