### PR TITLE
Flush intervals rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 src/metrics/statsd.rs
 src/metrics/graphite.rs
 *.bk
+/tags
+/.vscode

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -189,7 +189,7 @@ fn main() {
     // BACKGROUND
     //
 
-    let flush_interval = args.flush_interval;
+    let flush_interval = 1; // TODO: use constant
     joins.push(thread::spawn(move || {
         cernan::source::FlushTimer::new(flush_sends, flush_interval).run();
     }));

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -189,7 +189,7 @@ fn main() {
     // BACKGROUND
     //
 
-    let flush_interval = 1; // TODO: use constant
+    let flush_interval = 1;
     joins.push(thread::spawn(move || {
         cernan::source::FlushTimer::new(flush_sends, flush_interval).run();
     }));

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,6 @@ pub struct Args {
     pub files: Vec<FileServerConfig>,
     pub filters: HashMap<String, ProgrammableFilterConfig>,
     pub firehosen: Vec<FirehoseConfig>,
-    pub flush_interval: u64,
     pub graphites: HashMap<String, GraphiteConfig>,
     pub native_sink_config: Option<NativeConfig>,
     pub native_server_config: Option<NativeServerConfig>,
@@ -130,8 +129,6 @@ pub fn parse_args() -> Args {
                 graphites: graphites,
                 native_server_config: None,
                 native_sink_config: None,
-                flush_interval: u64::from_str(args.value_of("flush-interval").unwrap())
-                    .expect("flush-interval must be an integer"),
                 console: console,
                 null: null,
                 wavefront: wavefront,
@@ -628,10 +625,6 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
         graphites: graphites,
         native_sink_config: native_sink_config,
         native_server_config: native_server_config,
-        flush_interval: value.lookup("flush-interval")
-            .unwrap_or(&Value::Integer(60))
-            .as_integer()
-            .expect("flush-interval must be integer") as u64,
         console: console,
         null: null,
         wavefront: wavefront,
@@ -705,7 +698,6 @@ scripts-directory = "/foo/bar"
         assert_eq!(args.statsds.get("sources.statsd").unwrap().port, 8125);
         assert!(!args.graphites.is_empty());
         assert_eq!(args.graphites.get("sources.graphite").unwrap().port, 2003);
-        assert_eq!(args.flush_interval, 60);
         assert!(args.console.is_none());
         assert!(args.null.is_none());
         assert_eq!(true, args.firehosen.is_empty());
@@ -1387,7 +1379,6 @@ mission = "from_gad"
         let graphite_config = args.graphites.get("sources.graphite").unwrap();
         assert_eq!(graphite_config.port, 1034);
         assert_eq!(graphite_config.tags, tags);
-        assert_eq!(args.flush_interval, 128);
         assert!(args.console.is_some());
         assert!(args.null.is_some());
         assert!(args.firehosen.is_empty());

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -318,6 +318,7 @@ pub struct ProgrammableFilter {
     state: lua::State,
     path: String,
     global_tags: metric::TagMap,
+    last_flush_idx: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -365,6 +366,7 @@ impl ProgrammableFilter {
             state: state,
             path: config.config_path,
             global_tags: config.tags,
+            last_flush_idx: 0,
         }
     }
 }
@@ -406,7 +408,8 @@ impl filter::Filter for ProgrammableFilter {
                 }
                 Ok(())
             }
-            metric::Event::TimerFlush => {
+            metric::Event::TimerFlush(flush_idx) if self.last_flush_idx >= flush_idx => Ok(()),
+            metric::Event::TimerFlush(flush_idx) => {
                 self.state.get_global("tick");
                 if !self.state.is_fn(-1) {
                     let fail =
@@ -433,6 +436,8 @@ impl filter::Filter for ProgrammableFilter {
                 for mt in pyld.metrics {
                     res.push(metric::Event::new_telemetry(*mt));
                 }
+                res.push(event);
+                self.last_flush_idx = flush_idx;
                 Ok(())
             }
             metric::Event::Log(mut l) => {

--- a/src/metric/event.rs
+++ b/src/metric/event.rs
@@ -5,7 +5,7 @@ use std::sync;
 pub enum Event {
     Telemetry(sync::Arc<Option<Telemetry>>),
     Log(sync::Arc<Option<LogLine>>),
-    TimerFlush,
+    TimerFlush(u32),
 }
 
 impl Event {

--- a/src/metric/telemetry.rs
+++ b/src/metric/telemetry.rs
@@ -527,7 +527,7 @@ mod tests {
         fn rand<R: Rng>(rng: &mut R) -> Event {
             let i: usize = rng.gen();
             match i % 3 {
-                0 => Event::TimerFlush,
+                0 => Event::TimerFlush(rng.gen()),
                 _ => Event::Telemetry(Arc::new(Some(rng.gen()))),
             }
         }

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -53,7 +53,7 @@ pub trait Sink {
                                     self.flush();
                                     last_flush_idx = idx;
                                 }
-                                Event::TimerFlush(_) => {} 
+                                Event::TimerFlush(_) => {}
                                 Event::Telemetry(metric) => {
                                     self.deliver(metric);
                                 }

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -39,6 +39,7 @@ pub trait Sink {
     fn run(&mut self, recv: hopper::Receiver<Event>) {
         let mut attempts = 0;
         let mut recv = recv.into_iter();
+        let mut last_flush_idx = 0;
         loop {
             time::delay(attempts);
             match recv.next() {
@@ -48,7 +49,11 @@ pub trait Sink {
                     match self.valve_state() {
                         Valve::Open => {
                             match event {
-                                Event::TimerFlush => self.flush(),
+                                Event::TimerFlush(idx) if idx > last_flush_idx => {
+                                    self.flush();
+                                    last_flush_idx = idx;
+                                }
+                                Event::TimerFlush(_) => {} 
                                 Event::Telemetry(metric) => {
                                     self.deliver(metric);
                                 }

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -62,6 +62,7 @@ impl Sink for Native {
     fn run(&mut self, recv: hopper::Receiver<metric::Event>) {
         let mut attempts = 0;
         let mut recv = recv.into_iter();
+        let mut last_flush_idx = 0;
         loop {
             time::delay(attempts);
             if self.buffer.len() > 10_000 {
@@ -73,7 +74,11 @@ impl Sink for Native {
                 Some(event) => {
                     attempts = 0;
                     match event {
-                        metric::Event::TimerFlush => self.flush(),
+                        metric::Event::TimerFlush(idx) if idx > last_flush_idx => {
+                            self.flush();
+                            last_flush_idx = idx;
+                        }
+                        metric::Event::TimerFlush(_) => {} 
                         _ => self.buffer.push(event),
                     }
                 }

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -78,7 +78,7 @@ impl Sink for Native {
                             self.flush();
                             last_flush_idx = idx;
                         }
-                        metric::Event::TimerFlush(_) => {} 
+                        metric::Event::TimerFlush(_) => {}
                         _ => self.buffer.push(event),
                     }
                 }

--- a/src/source/flush.rs
+++ b/src/source/flush.rs
@@ -23,9 +23,12 @@ impl Source for FlushTimer {
     fn run(&mut self) {
         let duration = Duration::new(self.interval, 0);
         debug!("flush-interval: {:?}", duration);
+        let mut idx = 0;
         loop {
+            idx += 1; // we should start with TimerFlush(1) so all the receivers could compare it
+            // with default (0) value
             sleep(duration);
-            send("flush", &mut self.chans, metric::Event::TimerFlush);
+            send("flush", &mut self.chans, metric::Event::TimerFlush(idx));
         }
     }
 }

--- a/src/source/flush.rs
+++ b/src/source/flush.rs
@@ -25,8 +25,8 @@ impl Source for FlushTimer {
         debug!("flush-interval: {:?}", duration);
         let mut idx = 0;
         loop {
-            idx += 1; // we should start with TimerFlush(1) so all the receivers could compare it
-            // with default (0) value
+            idx += 1; // we should start with TimerFlush(1) so all the receivers that start with
+            // TimerFlush(0) will update their last_flush_idx seen
             sleep(duration);
             send("flush", &mut self.chans, metric::Event::TimerFlush(idx));
         }

--- a/tests/programmable_filter.rs
+++ b/tests/programmable_filter.rs
@@ -229,19 +229,21 @@ mod integration {
             let log2 = metric::Event::new_log(metric::LogLine::new("identity", "more"));
             let log3 = metric::Event::new_log(metric::LogLine::new("identity", "less"));
 
-            let flush = metric::Event::TimerFlush;
+            let flush1 = metric::Event::TimerFlush(1);
+            let flush2 = metric::Event::TimerFlush(2);
 
             let mut events = Vec::new();
             for ev in &[metric0, metric1, metric2, log0, log1] {
                 let _ = cs.process(ev.clone(), &mut events);
             }
             events.clear();
-            let res = cs.process(flush.clone(), &mut events);
+            let res = cs.process(flush1, &mut events);
             assert!(res.is_ok());
 
             assert!(!events.is_empty());
-            assert_eq!(events.len(), 2);
+            assert_eq!(events.len(), 3);
             println!("EVENTS: {:?}", events);
+            assert_eq!(events[2], metric::Event::TimerFlush(1));
             assert_eq!(events[1],
                        metric::Event::new_telemetry(metric::Telemetry::new("count_per_tick", 5.0)));
             assert_eq!(events[0],
@@ -249,16 +251,20 @@ mod integration {
                                                                    "count_per_tick: 5")));
 
             events.clear();
+            println!("EVENTS1: {:?}", events);
             for ev in &[log2, log3] {
                 let _ = cs.process(ev.clone(), &mut events);
             }
             events.clear();
-            let res = cs.process(flush, &mut events);
+            println!("EVENTS2: {:?}", events);
+            let res = cs.process(flush2, &mut events);
             assert!(res.is_ok());
+            println!("EVENTS3: {:?}", events);
 
             assert!(!events.is_empty());
-            assert_eq!(events.len(), 2);
+            assert_eq!(events.len(), 3);
             println!("EVENTS: {:?}", events);
+            assert_eq!(events[2], metric::Event::TimerFlush(2));
             assert_eq!(events[1],
                        metric::Event::new_telemetry(metric::Telemetry::new("count_per_tick", 2.0)));
             assert_eq!(events[0],

--- a/tests/programmable_filter.rs
+++ b/tests/programmable_filter.rs
@@ -251,15 +251,12 @@ mod integration {
                                                                    "count_per_tick: 5")));
 
             events.clear();
-            println!("EVENTS1: {:?}", events);
             for ev in &[log2, log3] {
                 let _ = cs.process(ev.clone(), &mut events);
             }
             events.clear();
-            println!("EVENTS2: {:?}", events);
             let res = cs.process(flush2, &mut events);
             assert!(res.is_ok());
-            println!("EVENTS3: {:?}", events);
 
             assert!(!events.is_empty());
             assert_eq!(events.len(), 3);


### PR DESCRIPTION
Flush intervals rework:
- Now flushes go every second and contain `flush index` value (u32)
- They pass through filters as well
- If a flush comes to the sink by different ways (from source + from filter[s]), only the first flush with the same `flush index` will be handled, all the next will be skipped