### PR TITLE
Correct firehose sink 

### DIFF
--- a/examples/configs/quickstart-files.toml
+++ b/examples/configs/quickstart-files.toml
@@ -1,0 +1,21 @@
+data-directory = "data/"
+scripts-directory = "examples/scripts/"
+
+flush-interval = 5
+
+[tags]
+source = "cernan"
+
+[sources]
+  [sources.files]
+  [sources.files.tmp_upstart_logs]
+  path = "/tmp/log/upstart/*.log"
+  forwards = ["sinks.null"]
+
+  [sources.files.tmp_logs]
+  path = "/tmp/log/*.log"
+  forwards = ["sinks.null"]
+
+[sinks]
+  [sinks.null]
+

--- a/examples/configs/quickstart-files.toml
+++ b/examples/configs/quickstart-files.toml
@@ -8,14 +8,12 @@ source = "cernan"
 
 [sources]
   [sources.files]
-  [sources.files.tmp_upstart_logs]
-  path = "/tmp/log/upstart/*.log"
-  forwards = ["sinks.null"]
-
   [sources.files.tmp_logs]
   path = "/tmp/log/*.log"
-  forwards = ["sinks.null"]
+  forwards = ["sinks.firehose.stream_two"]
 
 [sinks]
-  [sinks.null]
-
+  [sinks.firehose.stream_two]
+  delivery_stream = "stream_two"
+  batch_size = 800
+  region = "us-east-1"

--- a/src/sink/firehose.rs
+++ b/src/sink/firehose.rs
@@ -76,6 +76,9 @@ impl Sink for Firehose {
                 time::delay(attempts);
                 match client.put_record_batch(&prbi) {
                     Ok(prbo) => {
+                        debug!("Wrote {} records to delivery stream {}",
+                               prbi.records.len(),
+                               prbi.delivery_stream_name);
                         let failed_put_count = prbo.failed_put_count;
                         if failed_put_count > 0 {
                             error!("Failed to write {} put records", failed_put_count);

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -167,10 +167,9 @@ impl Source for FileServer {
                         }
                     }
                     if !lines.is_empty() {
-                        for l in lines {
+                        for l in lines.drain(..) {
                             send("file", &mut self.chans, metric::Event::new_log(l));
                         }
-                        lines = Vec::new();
                     }
                 }
                 if start.elapsed() >= glob_delay {

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -137,7 +137,9 @@ impl Source for FileServer {
                 }
             }
             let start = Instant::now();
+            let mut attempts = 0;
             loop {
+                time::delay(attempts);
                 for file in fp_map.values_mut() {
                     loop {
                         let mut lines_read = 0;
@@ -170,6 +172,9 @@ impl Source for FileServer {
                         for l in lines.drain(..) {
                             send("file", &mut self.chans, metric::Event::new_log(l));
                         }
+                        attempts = 0;
+                    } else {
+                        attempts += 1;
                     }
                 }
                 if start.elapsed() >= glob_delay {


### PR DESCRIPTION
In the move to 0.5.0 we introduced a regression whereby the firehose sink would no longer pull events from its queue properly. This nerfed the effectiveness of the firehose sink. This PR correct and introduces a few small changes in the process of looking for what was up. 