### PR TITLE
Update travis.yml to use v33 kcov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ addons:
       - binutils-dev
 
 after_success: |
-  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
-  tar xzf master.tar.gz &&
-  cd kcov-master &&
+  wget https://github.com/SimonKagstrom/kcov/archive/v33.tar.gz && 
+  tar xzf v33.tar.gz &&
+  cd kcov-33 &&
   mkdir build &&
   cd build &&
   cmake .. &&


### PR DESCRIPTION
We've seen some peculiar behaviour in the way our code coverage is
tracked when following kcov master. This commit will pin us against
v33.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>