### PR TITLE
Drop too long lines from firehose report

### DIFF
--- a/src/sink/firehose.rs
+++ b/src/sink/firehose.rs
@@ -55,6 +55,7 @@ impl Sink for Firehose {
             let prbi = PutRecordBatchInput {
                 delivery_stream_name: self.delivery_stream_name.clone(),
                 records: chunk.iter()
+                    .filter(|m| m.value.len() < 1_024_000)
                     .map(|m| {
                         let mut pyld = Map::new();
                         pyld.insert(String::from("Path"), Value::String((*m.path).to_string()));


### PR DESCRIPTION
Based on lived experience it turns out that a payload can be
invalidated based on the length of individual lines. Here's an
example:

    [cernan::sink::firehose][106][2017-02-17T21:15:10.307939006+00:00][ERROR] Unable to write, validation failure: 1 validation error detected: Value 'java.nio.HeapByteBuffer[pos=0 lim=2757283 cap=2757283]' at 'records.97.member.data' failed to satisfy constraint: Member must have length less than or equal to 1024000

We drop these lines as, once they reach firehose, they cannot
reasonably be split into pieces.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>