### PR TITLE
Introduce payload clearing functions

### DIFF
--- a/resources/tests/scripts/clear_logs.lua
+++ b/resources/tests/scripts/clear_logs.lua
@@ -1,0 +1,9 @@
+function process_metric(pyld)
+end
+
+function process_log(pyld)
+   payload.clear_logs(pyld)
+end
+
+function tick(pyld)
+end

--- a/resources/tests/scripts/clear_metrics.lua
+++ b/resources/tests/scripts/clear_metrics.lua
@@ -1,0 +1,9 @@
+function process_metric(pyld)
+   payload.clear_metrics(pyld)
+end
+
+function process_log(pyld)
+end
+
+function tick(pyld)
+end

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -89,7 +89,7 @@ impl<'a> Payload<'a> {
     }
 
     #[allow(non_snake_case)]
-    unsafe extern "C" fn lua_clear_metric(L: *mut lua_State) -> c_int {
+    unsafe extern "C" fn lua_clear_metrics(L: *mut lua_State) -> c_int {
         let mut state = State::from_ptr(L);
         let pyld = state.to_userdata(1) as *mut Payload;
         (*pyld).metrics.clear();
@@ -114,7 +114,7 @@ impl<'a> Payload<'a> {
     }
 
     #[allow(non_snake_case)]
-    unsafe extern "C" fn lua_clear_log(L: *mut lua_State) -> c_int {
+    unsafe extern "C" fn lua_clear_logs(L: *mut lua_State) -> c_int {
         let mut state = State::from_ptr(L);
         let pyld = state.to_userdata(1) as *mut Payload;
         (*pyld).logs.clear();
@@ -317,8 +317,8 @@ impl<'a> Payload<'a> {
 
 const PAYLOAD_LIB: [(&'static str, Function); 14] =
     [("set_metric_name", Some(Payload::lua_set_metric_name)),
-     ("clear_logs", Some(Payload::lua_clear_log)),
-     ("clear_metrics", Some(Payload::lua_clear_metric)),
+     ("clear_logs", Some(Payload::lua_clear_logs)),
+     ("clear_metrics", Some(Payload::lua_clear_metrics)),
      ("log_remove_tag", Some(Payload::lua_log_remove_tag)),
      ("log_set_tag", Some(Payload::lua_log_set_tag)),
      ("log_tag_value", Some(Payload::lua_log_tag_value)),

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -9,8 +9,7 @@ use std::path::PathBuf;
 use std::sync;
 
 struct Payload<'a> {
-    metrics: Vec<Box<metric::Telemetry>>, // TODO if we switch from Box to Arc we
-    // might be better off
+    metrics: Vec<Box<metric::Telemetry>>,
     logs: Vec<Box<metric::LogLine>>,
     global_tags: &'a metric::TagMap,
     path: &'a str,
@@ -90,6 +89,14 @@ impl<'a> Payload<'a> {
     }
 
     #[allow(non_snake_case)]
+    unsafe extern "C" fn lua_clear_metric(L: *mut lua_State) -> c_int {
+        let mut state = State::from_ptr(L);
+        let pyld = state.to_userdata(1) as *mut Payload;
+        (*pyld).metrics.clear();
+        0
+    }
+
+    #[allow(non_snake_case)]
     unsafe extern "C" fn lua_push_log(L: *mut lua_State) -> c_int {
         let mut state = State::from_ptr(L);
         let pyld = state.to_userdata(1) as *mut Payload;
@@ -103,6 +110,14 @@ impl<'a> Payload<'a> {
                 error!("[push_log] no line argument given");
             }
         };
+        0
+    }
+
+    #[allow(non_snake_case)]
+    unsafe extern "C" fn lua_clear_log(L: *mut lua_State) -> c_int {
+        let mut state = State::from_ptr(L);
+        let pyld = state.to_userdata(1) as *mut Payload;
+        (*pyld).logs.clear();
         0
     }
 
@@ -300,19 +315,21 @@ impl<'a> Payload<'a> {
     }
 }
 
-const PAYLOAD_LIB: [(&'static str, Function); 12] =
-    [("metric_name", Some(Payload::lua_metric_name)),
-     ("metric_query", Some(Payload::lua_metric_query)),
+const PAYLOAD_LIB: [(&'static str, Function); 14] =
+    [("set_metric_name", Some(Payload::lua_set_metric_name)),
+     ("clear_logs", Some(Payload::lua_clear_log)),
+     ("clear_metrics", Some(Payload::lua_clear_metric)),
      ("log_remove_tag", Some(Payload::lua_log_remove_tag)),
      ("log_set_tag", Some(Payload::lua_log_set_tag)),
      ("log_tag_value", Some(Payload::lua_log_tag_value)),
+     ("metric_query", Some(Payload::lua_metric_query)),
      ("metric_remove_tag", Some(Payload::lua_metric_remove_tag)),
      ("metric_set_tag", Some(Payload::lua_metric_set_tag)),
      ("metric_tag_value", Some(Payload::lua_metric_tag_value)),
      ("metric_value", Some(Payload::lua_metric_value)),
      ("push_log", Some(Payload::lua_push_log)),
      ("push_metric", Some(Payload::lua_push_metric)),
-     ("set_metric_name", Some(Payload::lua_set_metric_name))];
+     ("metric_name", Some(Payload::lua_metric_name))];
 
 pub struct ProgrammableFilter {
     state: lua::State,

--- a/tests/programmable_filter.rs
+++ b/tests/programmable_filter.rs
@@ -35,6 +35,55 @@ mod integration {
         }
 
         #[test]
+        fn test_clear_metrics_filter() {
+            let mut script = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            script.push("resources/tests/scripts/clear_metrics.lua");
+
+            let config = ProgrammableFilterConfig {
+                script: script,
+                forwards: Vec::new(),
+                config_path: "filters.clear_metrics".to_string(),
+                tags: Default::default(),
+            };
+            let mut cs = ProgrammableFilter::new(config);
+
+            let metric = metric::Telemetry::new("clear_me", 12.0)
+                .overlay_tag("foo", "bar")
+                .overlay_tag("bizz", "bazz");
+            let event = metric::Event::new_telemetry(metric);
+
+            let mut events: Vec<metric::Event> = Vec::new();
+            let res = cs.process(event.clone(), &mut events);
+            assert!(res.is_ok());
+            assert!(events.is_empty());
+        }
+
+        #[test]
+        fn test_clear_logs_filter() {
+            let mut script = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            script.push("resources/tests/scripts/clear_logs.lua");
+
+            let config = ProgrammableFilterConfig {
+                script: script,
+                forwards: Vec::new(),
+                config_path: "filters.clear_logs".to_string(),
+                tags: Default::default(),
+            };
+            let mut cs = ProgrammableFilter::new(config);
+
+            let log = metric::LogLine::new("clear_me",
+                                           "i am the very model of the modern major general")
+                .overlay_tag("foo", "bar")
+                .overlay_tag("bizz", "bazz");
+            let event = metric::Event::new_log(log);
+
+            let mut events: Vec<metric::Event> = Vec::new();
+            let res = cs.process(event.clone(), &mut events);
+            assert!(res.is_ok());
+            assert!(events.is_empty());
+        }
+
+        #[test]
         fn test_remove_log_tag_kv() {
             let mut script = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             script.push("resources/tests/scripts/remove_keys.lua");


### PR DESCRIPTION
In conversation with @doubleyou I've learned that there's a use-case
for a filter that reads in a metric and then blanks the contents of
the payload. This is especially useful for filters that compute
analytics but want to dead-end streams of incoming metrics
excepting those that have been computed.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>