### PR TITLE
Increase the responsiveness of the file source

### DIFF
--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -1,5 +1,3 @@
-//! TODO
-
 use buckets::Buckets;
 use chrono;
 use metric::{AggregationMethod, LogLine, Telemetry};

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -18,37 +18,71 @@ use util::send;
 
 type HashMapFnv<K, V> = HashMap<K, V, BuildHasherDefault<SeaHasher>>;
 
+/// 'FileServer' is a Source which cooperatively schedules reads over files,
+/// converting the lines of said files into LogLine structures. As FileServer is
+/// intended to be useful across multiple operating systems with POSIX
+/// filesystem semantics FileServer must poll for changes. That is, no event
+/// notification is used by FileServer.
+///
+/// FileServer is configured on a path to watch. The files do _not_ need to
+/// exist at cernan startup. FileServer will discover new files which match its
+/// path in at most 60 seconds.
 pub struct FileServer {
     chans: util::Channel,
     path: PathBuf,
+    max_read_lines: usize,
     tags: metric::TagMap,
 }
 
+/// The configuration struct for 'FileServer'.
 #[derive(Debug)]
 pub struct FileServerConfig {
+    /// The path that FileServer will watch. Globs are allowed and FileServer
+    /// will watch multiple files.
     pub path: PathBuf,
+    /// The maximum number of lines to read from a file before switching to a
+    /// new file.
+    pub max_read_lines: usize,
+    /// The default tags to apply to each discovered LogLine.
     pub tags: metric::TagMap,
+    /// The forwards which FileServer will obey.
     pub forwards: Vec<String>,
+    /// The configured name of FileServer.
     pub config_path: String,
 }
 
 impl FileServer {
+    /// Make a FileServer
+    ///
     pub fn new(chans: util::Channel, config: FileServerConfig) -> FileServer {
         FileServer {
             chans: chans,
             path: config.path,
             tags: config.tags,
+            max_read_lines: config.max_read_lines,
         }
     }
 }
 
-pub struct FileWatcher {
+/// The 'FileWatcher' struct defines the polling based state machine which reads
+/// from a file path, transparently updating the underlying file descriptor when
+/// the file has been rolled over, as is common for logs.
+///
+/// The 'FileWatcher' is expected to live for the lifetime of the file
+/// path. FileServer is responsible for clearing away FileWatchers which no
+/// longer exist.
+struct FileWatcher {
     pub path: PathBuf,
     pub reader: io::BufReader<fs::File>,
     pub file_id: (u64, u64), // (dev, ino)
 }
 
 impl FileWatcher {
+    /// Create a new FileWatcher
+    ///
+    /// The input path will be used by FileWatcher to prime its state machine. A
+    /// FileWatcher tracks _only one_ file. This function returns None if the
+    /// path does not exist or is not readable by cernan.
     pub fn new(path: PathBuf) -> Option<FileWatcher> {
         match fs::File::open(&path) {
             Ok(f) => {
@@ -69,11 +103,16 @@ impl FileWatcher {
         }
     }
 
+    /// Read a single line from the underlying file
+    ///
+    /// This function will attempt to read a new line from its file, blocking,
+    /// up to some maximum but unspecified amount of time. `read_line` will open
+    /// a new file handler at need, transparently to the caller.
     pub fn read_line(&mut self, mut buffer: &mut String) -> io::Result<usize> {
         let max_attempts = 6;
         loop {
             let mut attempts = 0;
-            // read lines
+            // Read lines, delaying up to max_attempts times.
             loop {
                 match self.reader.read_line(&mut buffer) {
                     Ok(sz) => {
@@ -94,7 +133,8 @@ impl FileWatcher {
                     }
                 }
             }
-
+            // Check to see if the file_id has changed and, if so, open up a new
+            // file handler.
             if let Ok(metadata) = fs::metadata(&self.path) {
                 let dev = metadata.dev();
                 let ino = metadata.ino();
@@ -113,6 +153,19 @@ impl FileWatcher {
     }
 }
 
+/// FileServer as Source
+///
+/// The 'run' of FileServer performs the cooperative scheduling of reads over
+/// FileServer's configured files. Much care has been taking to make this
+/// scheduling 'fair', meaning busy files do not drown out quiet files or vice
+/// versa but there's no one perfect approach. Very fast files _will_ be lost if
+/// your system aggressively rolls log files. FileServer will keep a file
+/// handler open but should your system move so quickly that a file disappears
+/// before cernan is able to open it the contents will be lost. This should be a
+/// rare occurence.
+///
+/// Specific operating systems support evented interfaces that correct this
+/// problem but your intrepid authors know of no generic solution.
 impl Source for FileServer {
     fn run(&mut self) {
         let mut fp_map: HashMapFnv<PathBuf, FileWatcher> = HashMapFnv::default();
@@ -121,7 +174,22 @@ impl Source for FileServer {
 
         let mut lines = Vec::new();
 
+        // Alright friends, how does this work?
+        //
+        // There's two loops, the outer one we'll call the 'glob poll' loop. The
+        // inner one we'll call the 'file poll' loop. The glob poll resets at
+        // least every 60 seconds, finding new files to create FileWatchers out
+        // of and then enters the file poll. The file poll loops through all
+        // existing FileWatchers and reads at most max_read_lines lines out of a
+        // file.
+        //
+        // The glob poll enforces a delay between files. This is done to
+        // minimize the CPU impact of this polling approach. If a file has no
+        // lines to read an attempt counter will go up and we'll wait
+        // time::delay(attempts). If a line is read out of the file we'll reset
+        // attempts to 0.
         loop {
+            // glob poll
             for entry in glob(self.path.to_str().expect("no ability to glob"))
                 .expect("Failed to read glob pattern") {
                 match entry {
@@ -139,6 +207,7 @@ impl Source for FileServer {
             let start = Instant::now();
             let mut attempts = 0;
             loop {
+                // file poll
                 if fp_map.is_empty() {
                     time::delay(9);
                     break;
@@ -150,6 +219,7 @@ impl Source for FileServer {
                         let mut lines_read = 0;
                         match file.read_line(&mut buffer) {
                             Ok(sz) => {
+                                attempts = 0;
                                 if sz > 0 {
                                     lines_read += 1;
                                     buffer.pop();
@@ -159,7 +229,7 @@ impl Source for FileServer {
                                     lines.push(metric::LogLine::new(path_name, &buffer)
                                         .overlay_tags_from_map(&self.tags));
                                     buffer.clear();
-                                    if lines_read > 10_000 {
+                                    if lines_read > self.max_read_lines {
                                         break;
                                     }
                                 }


### PR DESCRIPTION
Consider a situation where there are a few very fast log files but
mostly slow ones. What happens? Well, previously we waited 512ms
between files _without_ reducing that wait. Now we zip the wait down
to 0ms if we've hit a file that has changes, which _should_ improve
responsiveness in mixed-speed situations.

Additionally the file source has grown a max_read_lines configuration
option, allowing operators to decide how many lines to read from an
individual file before moving on to the next. By default this value
is 10k.

This resolves #233

Signed-off-by: Brian L. Troutwine <blt@postmates.com>