### PR TITLE
Introduce the 'internal' source

### DIFF
--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -2,6 +2,7 @@ use glob::glob;
 use metric;
 use seahash::SeaHasher;
 use source::Source;
+use source::internal::report_telemetry;
 use std::collections::HashMap;
 use std::fs;
 use std::hash::BuildHasherDefault;
@@ -225,6 +226,9 @@ impl Source for FileServer {
                                     buffer.pop();
                                     let path_name =
                                         file.path.to_str().expect("could not make path_name");
+                                    report_telemetry(format!("cernan.sources.file.{}.lines_read",
+                                                             path_name),
+                                                     1.0);
                                     trace!("{} | {}", path_name, buffer);
                                     lines.push(metric::LogLine::new(path_name, &buffer)
                                         .overlay_tags_from_map(&self.tags));

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -1,0 +1,90 @@
+use metric;
+use source::Source;
+use std::collections::VecDeque;
+use std::sync;
+use time;
+use util;
+
+lazy_static! {
+    static ref Q: sync::Mutex<VecDeque<metric::Telemetry>> = sync::Mutex::new(VecDeque::new());
+}
+
+/// 'Internal' is a Source which is meant to allow cernan to
+/// self-telemeter. This is an improvement over past methods as an explicit
+/// Source gives operators the ability to define a filter topology for such
+/// telemetry and makes it easier to modules to report on themeselves. 
+pub struct Internal {
+    chans: util::Channel,
+    tags: sync::Arc<metric::TagMap>,
+}
+
+/// The configuration struct for 'Internal'
+#[derive(Debug,Clone)]
+pub struct InternalConfig {
+    /// The configured name of Internal.
+    pub config_path: String,
+    /// The forwards which Internal will obey.
+    pub forwards: Vec<String>,
+    /// The default tags to apply to each Telemetry that comes through the queue.
+    pub tags: metric::TagMap,
+}
+
+impl Default for InternalConfig {
+    fn default() -> InternalConfig {
+        InternalConfig {
+            tags: metric::TagMap::default(),
+            forwards: Vec::new(),
+            config_path: "sources.internal".to_string(),
+        }
+    }
+}
+
+impl Internal {
+    pub fn new(chans: util::Channel, config: InternalConfig) -> Internal {
+        Internal {
+            chans: chans,
+            tags: sync::Arc::new(config.tags),
+        }
+    }
+}
+
+/// Push telemetry into the Internal queue
+///
+/// Given a name and value, construct a Telemetry with Sum aggregation and push
+/// into Internal's queue. This queue will then be drained into operator
+/// configured forwards.
+pub fn report_telemetry<S>(name: S, value: f64) -> ()
+    where S: Into<String>
+{
+    Q.lock().unwrap().push_back(metric::Telemetry::new(name, value).aggr_sum());
+}
+
+/// Internal as Source
+///
+/// The 'run' of Internal will pull Telemetry off the internal queue, apply
+/// Internal's configured tags and push said telemetry into operator configured
+/// channels. If no channels are configured we toss the Telemetry onto the
+/// floor.
+impl Source for Internal {
+    fn run(&mut self) {
+        let mut attempts = 0;
+        loop {
+            if let Some(telem) = Q.lock().unwrap().pop_front() {
+                attempts -= 1;
+                if !self.chans.is_empty() {
+                    util::send("internal",
+                               &mut self.chans,
+                               metric::Event::new_telemetry(telem.overlay_tags_from_map(&self.tags)));
+                } else {
+                    // do nothing, intentionally 
+                }
+            } else {
+                // We mod by an arbitrary constant. We don't want to wait _too_
+                // long between polls of the queue but neither do we want to
+                // burn up our CPU.
+                attempts = (attempts + 1) % 10;
+            }
+            time::delay(attempts);
+        }
+    }
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -1,12 +1,14 @@
-mod graphite;
-mod statsd;
 mod file;
 mod flush;
+mod graphite;
+mod internal;
 mod native;
+mod statsd;
 
 pub use self::file::{FileServer, FileServerConfig};
 pub use self::flush::FlushTimer;
 pub use self::graphite::{Graphite, GraphiteConfig};
+pub use self::internal::{Internal, InternalConfig};
 pub use self::native::{NativeServer, NativeServerConfig};
 pub use self::statsd::{Statsd, StatsdConfig};
 

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -1,6 +1,7 @@
 use metric;
 use protocols::statsd::parse_statsd;
 use source::Source;
+use source::internal::report_telemetry;
 use std::net::{ToSocketAddrs, UdpSocket};
 use std::str;
 use std::sync;
@@ -65,14 +66,10 @@ fn handle_udp(mut chans: util::Channel, tags: sync::Arc<metric::TagMap>, socket:
                     for m in metrics.drain(..) {
                         send("statsd", &mut chans, metric::Event::new_telemetry(m));
                     }
-                    let mut metric = metric::Telemetry::new("cernan.statsd.packet", 1.0).aggr_sum();
-                    metric = metric.overlay_tags_from_map(&tags);
-                    send("statsd", &mut chans, metric::Event::new_telemetry(metric));
+
+                    report_telemetry("cernan.statsd.packet", 1.0);
                 } else {
-                    let mut metric = metric::Telemetry::new("cernan.statsd.bad_packet", 1.0)
-                        .aggr_sum();
-                    metric = metric.overlay_tags_from_map(&tags);
-                    send("statsd", &mut chans, metric::Event::new_telemetry(metric));
+                    report_telemetry("cernan.statsd.bad_packet", 1.0);
                     error!("BAD PACKET: {:?}", val);
                 }
             }

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -66,7 +66,6 @@ fn handle_udp(mut chans: util::Channel, tags: sync::Arc<metric::TagMap>, socket:
                     for m in metrics.drain(..) {
                         send("statsd", &mut chans, metric::Event::new_telemetry(m));
                     }
-
                     report_telemetry("cernan.statsd.packet", 1.0);
                 } else {
                     report_telemetry("cernan.statsd.bad_packet", 1.0);


### PR DESCRIPTION
This new source allows cernan to self-telemeter. It is not possible
for modules to report telemetry 'up' to be distributed through
the filter topology as operators see fit. This interface is
intentionally minimal and can be extended as need arises.

Closes #212

Signed-off-by: Brian L. Troutwine <blt@postmates.com>