### PR TITLE
Build a special-purpose aggregator for Prometheus

### DIFF
--- a/src/metric/mod.rs
+++ b/src/metric/mod.rs
@@ -1,4 +1,4 @@
-mod tagmap;
+pub mod tagmap;
 mod logline;
 mod event;
 mod telemetry;

--- a/src/metric/telemetry.rs
+++ b/src/metric/telemetry.rs
@@ -560,7 +560,7 @@ mod tests {
 
     impl Rand for Telemetry {
         fn rand<R: Rng>(rng: &mut R) -> Telemetry {
-            let name: String = rng.gen_iter::<char>().filter(|&x| x != ':').take(30).collect();
+            let name: String = rng.gen_iter::<char>().take(128).collect();
             let val: f64 = rng.gen();
             let kind: AggregationMethod = rng.gen();
             let persist: bool = rng.gen();

--- a/src/protocols/statsd.rs
+++ b/src/protocols/statsd.rs
@@ -214,7 +214,7 @@ mod tests {
         let max = pyld.lines.len();
         assert!(max != 0);
         for line in &pyld.lines[0..max - 1] {
-            pyld_buf.push_str(&line.name);
+            pyld_buf.push_str(&line.name.replace(":", "."));
             pyld_buf.push_str(":");
             pyld_buf.push_str(&line.value.to_string());
             pyld_buf.push_str("|");
@@ -235,7 +235,7 @@ mod tests {
             pyld_buf.push_str("\n");
         }
         let line = &pyld.lines[max - 1];
-        pyld_buf.push_str(&line.name);
+        pyld_buf.push_str(&line.name.replace(":", "."));
         pyld_buf.push_str(":");
         pyld_buf.push_str(&line.value.to_string());
         pyld_buf.push_str("|");

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -73,8 +73,8 @@ impl PrometheusAggr {
     fn find_match(&self, telem: &metric::Telemetry) -> Option<metric::Telemetry> {
         match self.inner
             .binary_search_by(|probe| prometheus_cmp(probe, &telem).expect("could not compare")) {
-            Ok(idx) => Some(self.inner[idx].clone()), 
-            Err(_) => None, 
+            Ok(idx) => Some(self.inner[idx].clone()),
+            Err(_) => None,
         }
     }
 
@@ -348,12 +348,11 @@ mod test {
 
     impl Rand for PrometheusAggr {
         fn rand<R: Rng>(rng: &mut R) -> PrometheusAggr {
-            let total_inner_sz: usize = rng.gen_range(0, 1024);
-            let mut inner: Vec<metric::Telemetry> = rng.gen_iter::<metric::Telemetry>().take(total_inner_sz).collect();
+            let total_inner_sz: usize = rng.gen_range(0, 512);
+            let mut inner: Vec<metric::Telemetry> =
+                rng.gen_iter::<metric::Telemetry>().take(total_inner_sz).collect();
             inner.sort_by(|a, b| prometheus_cmp(a, b).unwrap());
-            PrometheusAggr {
-                inner: inner
-            }
+            PrometheusAggr { inner: inner }
         }
     }
 
@@ -375,7 +374,7 @@ mod test {
 
             aggr.recombine(recomb);
 
-            let lower = cur_cnt; 
+            let lower = cur_cnt;
             let upper = cur_cnt + recomb_len;
 
             assert!(lower <= aggr.count() || aggr.count() <= upper);

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -5,6 +5,8 @@ use protobuf::repeated::RepeatedField;
 use protocols::prometheus::*;
 use sink::{Sink, Valve};
 use source::report_telemetry;
+use std::collections::BTreeMap;
+use std::io;
 use std::io::Write;
 use std::mem;
 use std::str;
@@ -12,11 +14,9 @@ use std::sync;
 use std::sync::Mutex;
 use time;
 
-pub type AggrMap = Vec<metric::Telemetry>;
-
 #[allow(dead_code)]
 pub struct Prometheus {
-    aggrs: sync::Arc<Mutex<AggrMap>>,
+    aggrs: sync::Arc<Mutex<PrometheusAggr>>,
     // `http_srv` is never used but we must keep it in this struct to avoid the
     // listening server being dropped
     http_srv: Listening,
@@ -31,11 +31,194 @@ pub struct PrometheusConfig {
 }
 
 struct SenderHandler {
-    aggrs: sync::Arc<Mutex<AggrMap>>,
+    aggr: sync::Arc<Mutex<PrometheusAggr>>,
 }
 
-#[inline]
-fn write_binary(aggrs: AggrMap, mut res: Response) {
+/// The specialized aggr for Prometheus
+///
+/// Prometheus is a weirdo. We have to make sure the following properties are
+/// held:
+///
+///   * If prometheus hangs up on us we _do not_ lose data.
+///   * We _never_ resubmit points for a time-series.
+///   * We _never_ submit new points for an already reported bin.
+///
+/// To help demonstrate this we have a special aggregation for Prometheus:
+/// PrometheusAggr. It's job is to encode these operations and allow us to
+/// establish the above invariants.
+#[derive(Clone, Debug)]
+struct PrometheusAggr {
+    /// last_time_report allows PrometheusAggr to keep track of when the last
+    /// report from this structure was done, giving us the ability to reject
+    /// points (per point three above) and compute what points to
+    /// retain. Because these gates are _per time series_ we must keep a map of
+    /// metric-name to report time.
+    last_time_report: BTreeMap<String, i64>, // WARNING: UNBOUNDED
+    inner: Vec<metric::Telemetry>,
+}
+
+impl PrometheusAggr {
+    /// Return the last time 'name' was reported
+    ///
+    /// It's possible that this function will return None if the 'name' was
+    /// never part of any report.
+    #[cfg(test)]
+    fn get_last_time_report(&self, name: &str) -> Option<i64> {
+        self.last_time_report.get(name).map(|x| *x)
+    }
+
+    /// Return an iterator over the aggregation's stored Telemetry
+    #[cfg(test)]
+    fn iter(&self) -> ::std::slice::Iter<metric::Telemetry> {
+        self.inner.iter()
+    }
+
+    /// Return an iterator over the aggregation's report times
+    #[cfg(test)]
+    fn iter_times(&self) -> ::std::collections::btree_map::Iter<String, i64> {
+        self.last_time_report.iter()
+    }
+
+    /// Return all 'reportable' Telemetry
+    ///
+    /// This function returns all the stored Telemetry points that are available
+    /// for shipping to Prometheus. Shipping a point to Prometheus drops that
+    /// point from memory, once it's gone over the wire.
+    ///
+    /// A Telemetry will _not_ be reportable if it is within the current second
+    /// bin. This function resets the last report time for each time series.
+    fn reportable(&mut self, current_time: i64) -> Vec<metric::Telemetry> {
+        // Prometheus does not allow metrics to appear from the same time
+        // interval across reports. Consider what happens in the following
+        // situation:
+        //
+        //     T0 - - - x - - - REPORT - - - x - - - T1 - - - - - - REPORT
+        //
+        // Where T0 and T1 are times, REPORT is a prometheus scrape and x is
+        // some metric to the same time series. In both cases x will have the
+        // same time, T0, but across two reports, giving prometheus
+        // heartburn. What we do is partition the guarded set where values in
+        // the current second are kept behind.
+        let inner = mem::replace(&mut self.inner, Default::default());
+        let (reportable, not_ripe): (Vec<metric::Telemetry>, Vec<metric::Telemetry>) =
+            inner.into_iter().partition(|ref x| x.timestamp < current_time);
+        for x in not_ripe.into_iter() {
+            self.inner.push(x);
+        }
+        reportable
+    }
+
+    /// Insert a Telemetry into the aggregation
+    ///
+    /// This function inserts the given Telemetry into the inner aggregation of
+    /// PrometheusAggr, being sure to respect any last report time gates. This
+    /// function _does not_ change those time gates.
+    ///
+    /// If the Telemetry is inserted true is returned, else false.
+    fn insert(&mut self, telem: metric::Telemetry) -> bool {
+        if let Some(t) = self.last_time_report.get(&telem.name) {
+            if telem.timestamp < *t {
+                return false;
+            }
+        };
+        // Why not use Metric::within to do the comparison? The documentation
+        // here https://prometheus.io/docs/instrumenting/exposition_formats/
+        // demands that "Each Metric within the same MetricFamily must have a
+        // unique set of LabelPair fields.". It's very likely in cernan-world
+        // that every metric which shares a name also shares its tags. It's not
+        // for-sure but very, very likely.
+        match self.inner.binary_search_by(|probe| probe.partial_cmp(&telem).unwrap()) {
+            Ok(idx) => self.inner[idx] += telem,
+            Err(idx) => self.inner.insert(idx, telem),
+        }
+        true
+    }
+
+    /// Recombine Telemetry into the aggregation
+    ///
+    /// In the event that Prometheus hangs up on us we have to recombine
+    /// 'reportable' Telemetry back into the aggregation, else we lose it. This
+    /// function _will_ reset the last_report for each time series.
+    ///
+    /// If a Telemetry is passed that did not previously exist or has not been
+    /// reported the effect will be the same as if `insert` had been called.
+    fn recombine(&mut self, telems: Vec<metric::Telemetry>) {
+        for telem in telems.into_iter() {
+            self.insert(telem);
+        }
+    }
+
+    /// Return the total points stored by this aggregation
+    fn count(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+impl Default for PrometheusAggr {
+    fn default() -> PrometheusAggr {
+        PrometheusAggr {
+            last_time_report: Default::default(),
+            inner: Default::default(),
+        }
+    }
+}
+
+impl Handler for SenderHandler {
+    fn handle(&self, req: Request, res: Response) {
+        let current_second = time::now(); // NOTE when #166 lands this will be broken
+        let mut aggr = self.aggr.lock().unwrap();
+        let reportable: Vec<metric::Telemetry> = aggr.reportable(current_second);
+        // Typed hyper::mime is challenging to use. In particular, matching does
+        // not seem to work like I expect and handling all other MIME cases in
+        // the existing enum strikes me as a fool's errand, on account of there
+        // may be an infinite number of MIMEs that'll come right on in. We'll
+        // just be monsters and assume if you aren't asking for protobuf you're
+        // asking for plaintext.
+        let accept: Vec<&str> = req.headers
+            .get_raw("accept")
+            .unwrap_or(&[])
+            .iter()
+            .map(|x| str::from_utf8(x))
+            .filter(|x| x.is_ok())
+            .map(|x| x.unwrap())
+            .collect();
+        let mut accept_proto = false;
+        for hdr in &accept {
+            if hdr.contains("application/vnd.google.protobuf;") {
+                accept_proto = true;
+                break;
+            }
+        }
+        let res = if accept_proto {
+            report_telemetry("cernan.sinks.prometheus.write.binary", 1.0);
+            write_binary(&reportable, res)
+        } else {
+            report_telemetry("cernan.sinks.prometheus.write.text", 1.0);
+            write_text(&reportable, res)
+        };
+        if res.is_err() {
+            aggr.recombine(reportable);
+        }
+    }
+}
+
+impl Prometheus {
+    pub fn new(config: PrometheusConfig) -> Prometheus {
+        let aggrs = sync::Arc::new(sync::Mutex::new(Default::default()));
+        let srv_aggrs = aggrs.clone();
+        let listener = Server::http((config.host.as_str(), config.port))
+            .unwrap()
+            .handle_threads(SenderHandler { aggr: srv_aggrs }, 1)
+            .unwrap();
+
+        Prometheus {
+            aggrs: aggrs,
+            http_srv: listener,
+        }
+    }
+}
+
+fn write_binary(aggrs: &[metric::Telemetry], mut res: Response) -> io::Result<()> {
     res.headers_mut()
         .set_raw("content-type",
                  vec!["application/vnd.google.protobuf; \
@@ -43,9 +226,9 @@ fn write_binary(aggrs: AggrMap, mut res: Response) {
                           .as_bytes()
                           .to_vec()]);
     let mut res = res.start().unwrap();
-    for mut m in aggrs.into_iter() {
+    for m in aggrs.into_iter() {
         let mut metric_family = MetricFamily::new();
-        metric_family.set_name(mem::replace(&mut m.name, Default::default()));
+        metric_family.set_name(m.name.clone());
         let mut metric = Metric::new();
         let mut label_pairs = Vec::with_capacity(8);
         for (k, v) in m.tags.into_iter() {
@@ -73,11 +256,10 @@ fn write_binary(aggrs: AggrMap, mut res: Response) {
         metric_family.write_length_delimited_to_writer(res.by_ref())
             .expect("FAILED TO WRITE TO HTTP RESPONSE");
     }
-    res.end().expect("FAILED TO CLOSE HTTP STREAMING RESPONSE");
+    res.end()
 }
 
-#[inline]
-fn write_text(aggrs: AggrMap, mut res: Response) {
+fn write_text(aggrs: &[metric::Telemetry], mut res: Response) -> io::Result<()> {
     res.headers_mut().set_raw("content-type",
                               vec!["text/plain; version=0.0.4".as_bytes().to_vec()]);
     let mut buf = String::with_capacity(1024);
@@ -133,76 +315,7 @@ fn write_text(aggrs: AggrMap, mut res: Response) {
     STREAMING RESPONSE");
         buf.clear();
     }
-    res.end().expect("FAILED TO CLOSE HTTP STREAMING RESPONSE");
-}
-
-impl Handler for SenderHandler {
-    fn handle(&self, req: Request, res: Response) {
-        let mut guard = self.aggrs.lock().unwrap();
-        // Prometheus does not allow metrics to appear from the same time
-        // interval across reports. Consider what happens in the following
-        // situation:
-        //
-        //     T0 - - - x - - - REPORT - - - x - - - T1 - - - - - - REPORT
-        //
-        // Where T0 and T1 are times, REPORT is a prometheus scrape and x is
-        // some metric to the same time series. In both cases x will have the
-        // same time, T0, but across two reports, giving prometheus
-        // heartburn. What we do is partition the guarded set where values in
-        // the current second are kept behind.
-        let current_second = time::now(); // NOTE when #166 lands this will
-        // _not_ be accurate and must be correctly adjusted.
-        let aggrs: AggrMap = mem::replace(&mut guard, Default::default());
-        let (reportable, not_fresh): (Vec<metric::Telemetry>, Vec<metric::Telemetry>) =
-            aggrs.into_iter().partition(|ref x| x.timestamp < current_second);
-        for x in not_fresh.into_iter() {
-            guard.push(x);
-        }
-        // Typed hyper::mime is challenging to use. In particular, matching does
-        // not seem to work like I expect and handling all other MIME cases in
-        // the existing enum strikes me as a fool's errand, on account of there
-        // may be an infinite number of MIMEs that'll come right on in. We'll
-        // just be monsters and assume if you aren't asking for protobuf you're
-        // asking for plaintext.
-        let accept: Vec<&str> = req.headers
-            .get_raw("accept")
-            .unwrap_or(&[])
-            .iter()
-            .map(|x| str::from_utf8(x))
-            .filter(|x| x.is_ok())
-            .map(|x| x.unwrap())
-            .collect();
-        let mut accept_proto = false;
-        for hdr in &accept {
-            if hdr.contains("application/vnd.google.protobuf;") {
-                accept_proto = true;
-                break;
-            }
-        }
-        if accept_proto {
-            report_telemetry("cernan.sinks.prometheus.write.binary", 1.0);
-            write_binary(reportable, res);
-        } else {
-            report_telemetry("cernan.sinks.prometheus.write.text", 1.0);
-            write_text(reportable, res);
-        }
-    }
-}
-
-impl Prometheus {
-    pub fn new(config: PrometheusConfig) -> Prometheus {
-        let aggrs = sync::Arc::new(sync::Mutex::new(Default::default()));
-        let srv_aggrs = aggrs.clone();
-        let listener = Server::http((config.host.as_str(), config.port))
-            .unwrap()
-            .handle_threads(SenderHandler { aggrs: srv_aggrs }, 1)
-            .unwrap();
-
-        Prometheus {
-            aggrs: aggrs,
-            http_srv: listener,
-        }
-    }
+    res.end()
 }
 
 /// Sanitize cernan Telemetry into prometheus' notion
@@ -245,16 +358,7 @@ impl Sink for Prometheus {
     fn deliver(&mut self, mut point: sync::Arc<Option<metric::Telemetry>>) -> () {
         let mut aggrs = self.aggrs.lock().unwrap();
         let metric = sanitize(sync::Arc::make_mut(&mut point).take().unwrap());
-        // Why not use Metric::within to do the comparison? The documentation
-        // here https://prometheus.io/docs/instrumenting/exposition_formats/
-        // demands that "Each Metric within the same MetricFamily must have a
-        // unique set of LabelPair fields.". It's very likely in cernan-world
-        // that every metric which shares a name also shares its tags. It's not
-        // for-sure but very, very likely.
-        match aggrs.binary_search_by(|probe| probe.partial_cmp(&metric).unwrap()) {
-            Ok(idx) => aggrs[idx] += metric,
-            Err(idx) => aggrs.insert(idx, metric),
-        };
+        aggrs.insert(metric);
     }
 
     fn deliver_line(&mut self, _: sync::Arc<Option<metric::LogLine>>) -> () {
@@ -263,7 +367,7 @@ impl Sink for Prometheus {
 
     fn valve_state(&self) -> Valve {
         let aggrs = self.aggrs.lock().unwrap();
-        if aggrs.len() > 10_000 {
+        if aggrs.count() > 10_000 {
             Valve::Closed
         } else {
             Valve::Open
@@ -274,10 +378,155 @@ impl Sink for Prometheus {
 #[cfg(test)]
 mod test {
     extern crate quickcheck;
+    extern crate rand;
 
-    use self::quickcheck::{QuickCheck, TestResult};
+    use self::quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
+    use self::rand::{Rand, Rng};
     use super::*;
     use metric;
+
+    impl Rand for PrometheusAggr {
+        fn rand<R: Rng>(rng: &mut R) -> PrometheusAggr {
+            let mut lt_reports: BTreeMap<String, i64> = Default::default();
+            let total_lt_reports: u16 = rng.gen_range(0, 512);
+            for _ in 0..total_lt_reports {
+                let name: String = rng.gen_iter::<char>().take(30).collect();
+                let report: i64 = rng.gen();
+                lt_reports.insert(name, report);
+            }
+            let total_inner_sz: usize = rng.gen_range(0, 1024);
+            PrometheusAggr {
+                last_time_report: lt_reports,
+                inner: rng.gen_iter::<metric::Telemetry>().take(total_inner_sz).collect(),
+            }
+        }
+    }
+
+    impl Arbitrary for PrometheusAggr {
+        fn arbitrary<G: Gen>(g: &mut G) -> PrometheusAggr {
+            g.gen()
+        }
+    }
+
+    // * recombining points should increase the size of aggr by the size of the
+    //   report vec
+    // * recombining points should adjust the last_report to the least of the
+    //   combined points
+    #[test]
+    fn test_recombine() {
+        fn inner(mut aggr: PrometheusAggr, recomb: Vec<metric::Telemetry>) -> TestResult {
+            let cur_cnt = aggr.count();
+            let expected_cnt = recomb.len() + cur_cnt;
+            let mut expected_last_reports: BTreeMap<String, i64> = Default::default();
+            for telem in recomb.iter() {
+                let elr_t = expected_last_reports.entry(telem.name.clone())
+                    .or_insert(telem.timestamp);
+                if *elr_t > telem.timestamp {
+                    *elr_t = telem.timestamp;
+                }
+            }
+
+            aggr.recombine(recomb);
+
+            assert_eq!(aggr.count(), expected_cnt);
+            for (nm, time) in aggr.iter_times() {
+                if let Some(t) = expected_last_reports.get(nm) {
+                    assert_eq!(time, t);
+                }
+            }
+            TestResult::passed()
+        }
+        QuickCheck::new()
+            .tests(1000)
+            .max_tests(10000)
+            .quickcheck(inner as fn(PrometheusAggr, Vec<metric::Telemetry>) -> TestResult);
+    }
+
+    #[test]
+    fn test_reportable() {
+        // points will be dropped on 'reportable' run iff
+        //   * telem.timestamp < reportable current_time
+        // additionally
+        //   * count will be equal to the number of points where time >= reportable
+        //     current_time
+        //   * last_report_time will be set to the max timestamp such that timestamp
+        //     < reportable current_time
+        fn inner(mut aggr: PrometheusAggr, current_time: i64) -> TestResult {
+            if current_time < 0 {
+                return TestResult::discard();
+            }
+            let mut expected_remain = 0;
+            let mut expected_reportable = 0;
+            let mut expected_last_reports: BTreeMap<String, i64> = Default::default();
+            for telem in aggr.iter() {
+                if telem.timestamp >= current_time {
+                    expected_remain += 1;
+                } else {
+                    expected_reportable += 1;
+                    let mut lr = expected_last_reports.entry(telem.name.clone()).or_insert(0);
+                    if *lr < telem.timestamp {
+                        *lr = telem.timestamp;
+                    }
+                }
+            }
+
+            let reportable = aggr.reportable(current_time);
+
+            assert_eq!(expected_reportable, reportable.len());
+            assert_eq!(expected_remain, aggr.count());
+
+            for (nm, time) in aggr.iter_times() {
+                if let Some(t) = expected_last_reports.get(nm) {
+                    assert_eq!(time, t);
+                }
+            }
+            TestResult::passed()
+        }
+        QuickCheck::new()
+            .tests(1000)
+            .max_tests(10000)
+            .quickcheck(inner as fn(PrometheusAggr, i64) -> TestResult);
+    }
+
+    #[test]
+    fn test_insertion_property() {
+        fn inner(mut aggr: PrometheusAggr, telem: metric::Telemetry) -> TestResult {
+            let cur_cnt = aggr.count();
+            match aggr.get_last_time_report(&telem.name) {
+                Some(t) => {
+                    if telem.timestamp < t {
+                        // inserting point where time < last_report does not insert
+                        assert!(!aggr.insert(telem.clone()));
+                        //   * count remains the same
+                        assert_eq!(cur_cnt, aggr.count());
+                        //   * point timestamp is NOT changed
+                        assert_eq!(t, aggr.get_last_time_report(&telem.name).unwrap());
+                    } else {
+                        // inserting point where time >= last_report does insert
+                        assert!(aggr.insert(telem.clone()));
+                        //   * count increases by one
+                        assert_eq!(cur_cnt + 1, aggr.count());
+                        //   * point timestamp is NOT changed
+                        assert_eq!(t, aggr.get_last_time_report(&telem.name).unwrap());
+                    }
+                }
+                None => {
+                    // inserting new point:
+                    //   * insertion returns true
+                    assert!(aggr.insert(telem.clone()));
+                    //   * count increases by one
+                    assert_eq!(cur_cnt + 1, aggr.count());
+                    //   * point timestamp is NOT changed
+                    assert_eq!(None, aggr.get_last_time_report(&telem.name));
+                }
+            }
+            TestResult::passed()
+        }
+        QuickCheck::new()
+            .tests(1000)
+            .max_tests(10000)
+            .quickcheck(inner as fn(PrometheusAggr, metric::Telemetry) -> TestResult);
+    }
 
     #[test]
     fn test_sanitization() {
@@ -293,8 +542,8 @@ mod test {
             TestResult::passed()
         }
         QuickCheck::new()
-            .tests(1000)
-            .max_tests(10000)
+            .tests(10000)
+            .max_tests(100000)
             .quickcheck(inner as fn(metric::Telemetry) -> TestResult);
     }
 }


### PR DESCRIPTION
The constraints placed by Prometheus on a reporter are non-trivial,
especially with regard to reports through time. This commit introduces
a new aggregator for Prometheus and a battery of quickcheck tests to
demonstrate singleton reports of time-series / timestamp, re-introduction
of telemetry after report failure and documentation of such.

We have to discover Prometheus' constraints, in part, and the model
presented in this commit may diverge from Prometheus' actual demands.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>