### PR TITLE
Adapt firehose telemetry

### DIFF
--- a/src/sink/firehose.rs
+++ b/src/sink/firehose.rs
@@ -88,11 +88,19 @@ impl Sink for Firehose {
                         debug!("Wrote {} records to delivery stream {}",
                                prbi.records.len(),
                                prbi.delivery_stream_name);
-                        report_telemetry("cernan.sinks.firehose.records.delivery", 1.0);
-                        report_telemetry("cernan.sinks.firehose.records.total_delivered", 1.0);
+                        report_telemetry(format!("cernan.sinks.firehose.{}.records.delivery",
+                                                 prbi.delivery_stream_name),
+                                         1.0);
+                        report_telemetry(format!("cernan.sinks.firehose.{}.records.\
+                                                  total_delivered",
+                                                 prbi.delivery_stream_name),
+                                         prbi.records.len() as f64);
                         let failed_put_count = prbo.failed_put_count;
-                        report_telemetry("cernan.sinks.firehose.records.total_failed", 1.0);
                         if failed_put_count > 0 {
+                            report_telemetry(format!("cernan.sinks.firehose.{}.records.\
+                                                      total_failed",
+                                                     prbi.delivery_stream_name),
+                                             failed_put_count as f64);
                             error!("Failed to write {} put records", failed_put_count);
                         }
                         break;
@@ -106,39 +114,56 @@ impl Sink for Firehose {
                             // the payload being wonky. This is an optimization for
                             // the future.
                             ResourceNotFound(rnf_err) => {
-                                report_telemetry("cernan.sinks.firehose.error.resource_not_found",
+                                report_telemetry(format!("cernan.sinks.firehose.{}.error.\
+                                                          resource_not_found",
+                                                         prbi.delivery_stream_name),
                                                  1.0);
                                 error!("Unable to write to resource, not found: {}", rnf_err);
                                 break;
                             }
                             InvalidArgument(ia_err) => {
-                                report_telemetry("cernan.sinks.firehose.error.invalid_argument",
+                                report_telemetry(format!("cernan.sinks.firehose.{}.error.\
+                                                          invalid_argument",
+                                                         prbi.delivery_stream_name),
                                                  1.0);
                                 error!("Unable to write, invalid argument: {}", ia_err);
                                 break;
                             }
                             HttpDispatch(hd_err) => {
-                                report_telemetry("cernan.sinks.firehose.error.http_dispatch", 1.0);
+                                report_telemetry(format!("cernan.sinks.firehose.{}.error.\
+                                                          http_dispatch",
+                                                         prbi.delivery_stream_name),
+                                                 1.0);
                                 error!("Unable to write, http dispatch: {}", hd_err);
                                 break;
                             }
                             Validation(v_err) => {
-                                report_telemetry("cernan.sinks.firehose.error.validation", 1.0);
+                                report_telemetry(format!("cernan.sinks.firehose.{}.error.\
+                                                          validation",
+                                                         prbi.delivery_stream_name),
+                                                 1.0);
                                 error!("Unable to write, validation failure: {}", v_err);
                                 break;
                             }
                             Unknown(u_err) => {
-                                report_telemetry("cernan.sinks.firehose.error.unknown", 1.0);
+                                report_telemetry(format!("cernan.sinks.firehose.{}.error.unknown",
+                                                         prbi.delivery_stream_name),
+                                                 1.0);
                                 error!("Unable to write, unknown failure: {}", u_err);
                                 break;
                             }
                             // The following errors are recoverable, potentially.
                             Credentials(c_err) => {
-                                report_telemetry("cernan.sinks.firehose.error.credentials", 1.0);
+                                report_telemetry(format!("cernan.sinks.firehose.{}.error.\
+                                                          credentials",
+                                                         prbi.delivery_stream_name),
+                                                 1.0);
                                 error!("Unable to write, credential failure: {}", c_err);
                             }
                             ServiceUnavailable(su_err) => {
-                                report_telemetry("cernan.sinks.firehose.error.service_unavailable",
+                                report_telemetry(format!("cernan.sinks.firehose.{}.error.\
+                                                          service_unavailable",
+                                                         prbi.delivery_stream_name),
                                                  1.0);
                                 error!("Service unavailable, will retry: {}", su_err);
                             }


### PR DESCRIPTION
After the last cut we quickly realized that the telemetry available
was not useful. To that end in this commit we correct the lack of
useful data and add further information to help us distinguish
what's what.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>