### PR TITLE
Steps toward InfluxDB in prod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,13 +4,13 @@ version = "0.5.9"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.23.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "hopper 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopper 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lua 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -18,11 +18,11 @@ dependencies = [
  "quantiles 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -33,7 +33,7 @@ name = "Inflector"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -84,12 +84,12 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.0.0-alpha5"
+version = "1.0.0-alpha7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -104,7 +104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -132,14 +132,14 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.21.1"
+version = "2.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term_size 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -181,11 +181,6 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "dtoa"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -208,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -241,11 +236,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hopper"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bincode 1.0.0-alpha5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.0.0-alpha7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -255,7 +250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.10.5"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "httparse 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -278,24 +273,19 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "native-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "idna"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "itoa"
@@ -318,7 +308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "0.2.4"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -386,13 +376,13 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "openssl 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "schannel 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "security-framework 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "security-framework-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schannel 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -401,14 +391,14 @@ name = "num"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -419,7 +409,7 @@ name = "num-iter"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -438,19 +428,19 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -475,8 +465,8 @@ name = "quantiles"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -514,8 +504,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rayon-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "redox_syscall"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -535,7 +545,7 @@ name = "regex"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -554,49 +564,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "reqwest"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hyper 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "native-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_urlencoded 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "ring"
-version = "0.6.3"
+name = "retry"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ring"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rusoto"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_codegen 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_credential 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_codegen 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_credential 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -604,27 +624,28 @@ dependencies = [
 
 [[package]]
 name = "rusoto_codegen"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "Inflector 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rusoto_credential"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -642,13 +663,13 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "secur32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -670,18 +691,18 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "security-framework-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -695,60 +716,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "serde"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_codegen_internals"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "syn 0.11.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_codegen_internals 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_json"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -759,7 +766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -785,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "term_size"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -835,7 +842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -911,7 +918,7 @@ name = "url"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -974,41 +981,39 @@ dependencies = [
 "checksum Inflector 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7c19d25307383974da633a677359cea2f6b143debcc30f2ea21e74fd0ab2e92"
 "checksum advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
-"checksum aho-corasick 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0638fd549427caa90c499814196d1b9e3725eb4d15d7339d6de073a680ed0ca2"
+"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
-"checksum bincode 1.0.0-alpha5 (registry+https://github.com/rust-lang/crates.io-index)" = "f11a7874ce42d1e5b119f3d3299a8d67ef9dc2fbe2d9759f5c26e8a480d30558"
+"checksum bincode 1.0.0-alpha7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b59e448d990f22ba554bc162da49bb5f8636eaffe3fabd085398f356865f127"
 "checksum bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a6577517ecd0ee0934f48a7295a89aaef3e6dfafeac404f94c0b3448518ddfe"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
-"checksum bitflags 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e1ab483fc81a8143faa7203c4a3c02888ebd1a782e37e41fa34753ba9a162"
+"checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "158b0bd7d75cbb6bf9c25967a48a2e9f77da95876b858eadfabaa99cd069de6e"
-"checksum clap 2.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "74a80f603221c9cd9aa27a28f52af452850051598537bb6b359c38a7d61e5cda"
+"checksum clap 2.23.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf1114886d7cde2d6448517161d7db8d681a9a1c09f7d210f0b0864e48195f6"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
 "checksum deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1614659040e711785ed8ea24219140654da1729f3ec8a47a9719d041112fe7bf"
-"checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum fern 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4d2f58d053ad7791bfaad58a3f3541fe2d2aecc564dd82aee7f92fa402c054b2"
-"checksum flate2 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "d4e4d0c15ef829cbc1b7cda651746be19cceeb238be7b1049227b14891df9e25"
+"checksum flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "36df0166e856739905cd3d7e0b210fe818592211a008862599845e012d8d304c"
 "checksum foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e4056b9bd47f8ac5ba12be771f77a0dae796d1bbaaf5fd0b9c2d38b69b8a29d"
 "checksum gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "40899336fb50db0c78710f53e87afc54d8c7266fb76262fecc78ca1a7f09deae"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum hopper 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bee1adeb9d5c623836ca2afa3a4775d84b0946ff76eb1d42b0697d31f3f0e94e"
+"checksum hopper 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ca6025db18ecc7544da0b0962789c829b4bed3ec5c93d1453921c8397c0b13e9"
 "checksum httparse 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e7a63e511f9edffbab707141fbb8707d1a3098615fb2adbd5769cdfcc9b17d"
-"checksum hyper 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)" = "43a15e3273b2133aaac0150478ab443fb89f15c3de41d8d93d8f3bb14bf560f6"
+"checksum hyper 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)" = "38368702037feddcb6470b4dc641adcc585373ab037c757bbc2818a21968d051"
 "checksum hyper-native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "afe68f772f0497a7205e751626bb8e1718568b58534b6108c73a74ef80483409"
-"checksum idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1053236e00ce4f668aeca4a769a09b3bf5a682d802abd6f3cb39374f6b162c11"
-"checksum itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3088ea4baeceb0284ee9eea42f591226e6beaecf65373e41b38d95a1b8e7a1"
+"checksum idna 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6ac85ec3f80c8e4e99d9325521337e14ec7555c458a14e377d189659a427f375"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-"checksum lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7291b1dd97d331f752620b02dfdbc231df7fc01bf282a00769e1cdb963c460dc"
+"checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
 "checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
 "checksum lua 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "652f45fa7edd0b02ae5e8629930046eaf105edf4fe10b609071b2938470232f2"
@@ -1018,14 +1023,14 @@ dependencies = [
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum mime 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5514f038123342d01ee5f95129e4ef1e0470c93bc29edf058a46f9ee3ba6737e"
 "checksum miniz-sys 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "28eaee17666671fa872e567547e8428e83308ebe5808cdf6a0e28397dbe2c726"
-"checksum native-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b805ee0e8fa268f67a4e5c7f4f80adb8af1fc4428ea0ce5b0ecab1430ef17ec0"
+"checksum native-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1e94a2fc65a44729fe969cc973da87c1052ae3f000b2cb33029f14aeb85550d5"
 "checksum num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "98b15ba84e910ea7a1973bccd3df7b31ae282bf9d8bd2897779950c9b8303d40"
-"checksum num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "21e4df1098d1d797d27ef0c69c178c3fab64941559b290fcae198e0825c9c8b5"
+"checksum num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1a4bf6f9174aa5783a9b4cc892cacd11aebad6c69ad027a0b65c6ca5f8aa37"
 "checksum num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d1891bd7b936f12349b7d1403761c8a0b85a18b148e9da4429d5d102c1a41e"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
 "checksum num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a18c392466409c50b87369414a2680c93e739aedeb498eb2bff7d7eb569744e2"
-"checksum openssl 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d59714233ccf23bc962f5eddc5d5c551c5848400e5ab01c64dded1743f3e3784"
-"checksum openssl-sys 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "376c5c6084e5ea95eea9c3280801e46d0dcf51251d4f01b747e044fb64d1fb31"
+"checksum openssl 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8aa0eb7aad44f0da6f7dda13ddb4559d91a0f40cfab150b1f76ad5b39ec523f"
+"checksum openssl-sys 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "14f5bfd12054d764510b887152d564ba11d99ae24ea7d740781778f646620576"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3e2ed6fe8ff3b20b44bb4b4f54de12ac89dc38cb451dce8ae5e9dcd1507f738"
 "checksum quantiles 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3ef2080d9bd8158eddd47a8944349ce185064ee990d94d10ac6701db151f2c2"
@@ -1033,36 +1038,37 @@ dependencies = [
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum rayon 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50c575b58c2b109e2fbc181820cbe177474f35610ff9e357dc75f6bac854ffbf"
-"checksum redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd35cc9a8bdec562c757e3d43c1526b5c6d2653e23e2315065bc25556550753"
+"checksum rayon 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8c83adcb08e5b922e804fe1918142b422602ef11f2fd670b0b52218cb5984a20"
+"checksum rayon-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "767d91bacddf07d442fe39257bf04fd95897d1c47c545d009f6beb03efd038f8"
+"checksum redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "29dbdfd4b9df8ab31dec47c6087b7b13cbf4a776f335e4de8efba8288dda075b"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
-"checksum reqwest 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfc011675ace22e9dd00d0734b1d00854859e6309c9545b6eb3e98cc088cf1eb"
-"checksum ring 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f171b03b4d8db3b2b2de34661ad25b8f21749a7b94fbb0090463be285122cd83"
-"checksum rusoto 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70ef50eae6a2604f0e332a4e6e8e48434b10e516a40934c357cfa501e51a0e70"
-"checksum rusoto_codegen 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2531be952faafadd9665791718555e35f04a404e961e103a8d755266d22ed61"
-"checksum rusoto_credential 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7e95a6fa69ee072cadf266510bf92462702daaf3842ad4d9672dd8b2de53f4ef"
+"checksum reqwest 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bef9ed8fdfcc30947d6b774938dc0c3f369a474efe440df2c7f278180b2d2e6"
+"checksum retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29460f6011a25fc70b22010e796bd98330baccaa0005cba6f90b858a510dec0d"
+"checksum ring 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "66f03581d6c7ff60d4068ccee9bcb53982e055bda76ec7bb49d6cc44fd63c63c"
+"checksum rusoto 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de544c629614ed2d5ea19769d15ff0628c77c52f6bbfb8deab1ffe89bfdd6f2e"
+"checksum rusoto_codegen 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6abc5c06c51d596124af8bcc0af8f1e7f0073632181d979ca4f1ed46ccf14feb"
+"checksum rusoto_credential 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d0d7f808ae960d8bc1cc3d95ae4692c56d50a993b4475b19666a3159248fdc2"
 "checksum rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "684ce48436d6465300c9ea783b6b14c4361d6b8dcbb1375b486a69cc19e2dfb0"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
-"checksum schannel 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0168331892e26bcd763535c1edd4b850708d0288b0e73942c116bbbf8e903c7f"
+"checksum schannel 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c8b291854e37196c2b67249e09d6bdeff410b19e1acf05558168e9c4413b4e95"
 "checksum seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e048636bed25842fcdc36e5ad1ec6295b72d4b5b8a4b759b64915a4ce2b9d09d"
 "checksum secur32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f412dfa83308d893101dd59c10d6fda8283465976c28c287c5c855bf8d216bc"
-"checksum security-framework 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbc5b9d01e63664f602cf854effab7c185156211cff63ab84e0f6a1cb0c8022"
-"checksum security-framework-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cb581c7dde4b6b03ff6d404cf912869b3360cacac8d821cb632f16de139efec0"
+"checksum security-framework 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "42ddf098d78d0b64564b23ee6345d07573e7d10e52ad86875d89ddf5f8378a02"
+"checksum security-framework-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "5bacdada57ea62022500c457c8571c17dfb5e6240b7c8eac5916ffa8c7138a55"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
-"checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-"checksum serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)" = "a702319c807c016e51f672e5c77d6f0b46afddd744b5e437d6b8436b888b458f"
-"checksum serde_codegen_internals 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d52006899f910528a10631e5b727973fe668f3228109d1707ccf5bad5490b6e"
-"checksum serde_derive 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f15ea24bd037b2d64646b4d934fa99c649be66e3f7b29fb595a5543b212b1452"
-"checksum serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "67f7d2e9edc3523a9c8ec8cd6ec481b3a27810aafee3e625d311febd3e656b4c"
-"checksum serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "dbc45439552eb8fb86907a2c41c1fd0ef97458efb87ff7f878db466eb581824e"
-"checksum serde_urlencoded 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53d4ebaa8d1d4f90d1b63dfca81ccd98ac20e1e479dbae393cbaf60f6fecd8d8"
+"checksum serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "231dfd55909400769e437326cfb4af8bec97c3dd56ab3d02df8ef5c7e00f179b"
+"checksum serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc888bd283bd2420b16ad0d860e35ad8acb21941180a83a189bb2046f9d00400"
+"checksum serde_derive 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "d75c72ef4dd193d89eb652b73890fe2489996c9ead8b37980f57a1078f96ed50"
+"checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"
+"checksum serde_urlencoded 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4cde9c1d41c4852426d097c53b9151c53e314e9c6ec8a7765e083137d45c76"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
-"checksum syn 0.11.9 (registry+https://github.com/rust-lang/crates.io-index)" = "480c834701caba3548aa991e54677281be3a5414a9d09ddbdf4ed74a569a9d19"
+"checksum syn 0.11.10 (registry+https://github.com/rust-lang/crates.io-index)" = "171b739972d9a1bfb169e8077238b51f9ebeaae4ff6e08072f7ba386a8802da2"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
-"checksum term_size 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "07b6c1ac5b3fffd75073276bca1ceed01f67a28537097a2a9539e116e50fb21a"
+"checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lua = "0.0.10"
 protobuf = "1.2"
 quantiles = "0.4"
 rand = "0.3"
-rusoto = {version = "0.23.1", features = ["firehose"]}
+rusoto = {version = "0.24.0", features = ["firehose"]}
 seahash = "3.0"
 serde = "0.9"
 serde_derive = "0.9"

--- a/benches/buckets.rs
+++ b/benches/buckets.rs
@@ -14,31 +14,37 @@ use rand::Rng;
 
 #[bench]
 fn bench_single_timer(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
+               let mut bucket = buckets::Buckets::default();
 
-        bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
-    });
+               bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
+           });
 }
 
 #[bench]
 fn bench_single_timer_100(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
+               let mut bucket = buckets::Buckets::default();
 
-        for _ in 0..100 {
-            bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
-        }
-    });
+               for _ in 0..100 {
+                   bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
+               }
+           });
 }
 
 #[bench]
 fn bench_single_timer_rand_100(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
         let mut bucket = buckets::Buckets::default();
@@ -46,27 +52,33 @@ fn bench_single_timer_rand_100(b: &mut Bencher) {
 
         for _ in 0..100 {
             let i: usize = rng.gen_range(0, 100);
-            bucket.add(Telemetry::new("a", i as f64).timestamp(dt_0).aggr_summarize());
+            bucket.add(Telemetry::new("a", i as f64)
+                           .timestamp(dt_0)
+                           .aggr_summarize());
         }
     });
 }
 
 #[bench]
 fn bench_single_timer_1000(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
+               let mut bucket = buckets::Buckets::default();
 
-        for _ in 0..1000 {
-            bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
-        }
-    });
+               for _ in 0..1000 {
+                   bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
+               }
+           });
 }
 
 #[bench]
 fn bench_single_timer_rand_1000(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
         let mut bucket = buckets::Buckets::default();
@@ -74,27 +86,33 @@ fn bench_single_timer_rand_1000(b: &mut Bencher) {
 
         for _ in 0..1000 {
             let i: usize = rng.gen_range(0, 1000);
-            bucket.add(Telemetry::new("a", i as f64).timestamp(dt_0).aggr_summarize());
+            bucket.add(Telemetry::new("a", i as f64)
+                           .timestamp(dt_0)
+                           .aggr_summarize());
         }
     });
 }
 
 #[bench]
 fn bench_single_timer_10000(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
+               let mut bucket = buckets::Buckets::default();
 
-        for _ in 0..10000 {
-            bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
-        }
-    });
+               for _ in 0..10000 {
+                   bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
+               }
+           });
 }
 
 #[bench]
 fn bench_single_timer_rand_10000(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
         let mut bucket = buckets::Buckets::default();
@@ -102,38 +120,46 @@ fn bench_single_timer_rand_10000(b: &mut Bencher) {
 
         for _ in 0..10000 {
             let i: usize = rng.gen_range(0, 10000);
-            bucket.add(Telemetry::new("a", i as f64).timestamp(dt_0).aggr_summarize());
+            bucket.add(Telemetry::new("a", i as f64)
+                           .timestamp(dt_0)
+                           .aggr_summarize());
         }
     });
 }
 
 #[bench]
 fn bench_single_histogram(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
+               let mut bucket = buckets::Buckets::default();
 
-        bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
-    });
+               bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
+           });
 }
 
 #[bench]
 fn bench_single_histogram_100(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
+               let mut bucket = buckets::Buckets::default();
 
-        for _ in 0..100 {
-            bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
-        }
-    });
+               for _ in 0..100 {
+                   bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
+               }
+           });
 }
 
 #[bench]
 fn bench_single_histogram_rand_100(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
         let mut bucket = buckets::Buckets::default();
@@ -141,27 +167,33 @@ fn bench_single_histogram_rand_100(b: &mut Bencher) {
 
         for _ in 0..100 {
             let i: usize = rng.gen_range(0, 100);
-            bucket.add(Telemetry::new("a", i as f64).timestamp(dt_0).aggr_summarize());
+            bucket.add(Telemetry::new("a", i as f64)
+                           .timestamp(dt_0)
+                           .aggr_summarize());
         }
     });
 }
 
 #[bench]
 fn bench_single_histogram_1000(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
+               let mut bucket = buckets::Buckets::default();
 
-        for _ in 0..1_000 {
-            bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
-        }
-    });
+               for _ in 0..1_000 {
+                   bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
+               }
+           });
 }
 
 #[bench]
 fn bench_single_histogram_rand_1000(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
         let mut bucket = buckets::Buckets::default();
@@ -169,27 +201,33 @@ fn bench_single_histogram_rand_1000(b: &mut Bencher) {
 
         for _ in 0..1_000 {
             let i: usize = rng.gen_range(0, 1_000);
-            bucket.add(Telemetry::new("a", i as f64).timestamp(dt_0).aggr_summarize());
+            bucket.add(Telemetry::new("a", i as f64)
+                           .timestamp(dt_0)
+                           .aggr_summarize());
         }
     });
 }
 
 #[bench]
 fn bench_single_histogram_10000(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
+               let mut bucket = buckets::Buckets::default();
 
-        for _ in 0..10_000 {
-            bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
-        }
-    });
+               for _ in 0..10_000 {
+                   bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
+               }
+           });
 }
 
 #[bench]
 fn bench_single_histogram_rand_10000(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
         let mut bucket = buckets::Buckets::default();
@@ -197,15 +235,21 @@ fn bench_single_histogram_rand_10000(b: &mut Bencher) {
 
         for _ in 0..10_000 {
             let i: usize = rng.gen_range(0, 10_000);
-            bucket.add(Telemetry::new("a", i as f64).timestamp(dt_0).aggr_summarize());
+            bucket.add(Telemetry::new("a", i as f64)
+                           .timestamp(dt_0)
+                           .aggr_summarize());
         }
     });
 }
 
 #[bench]
 fn bench_multi_counters(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
-    let dt_1 = UTC.ymd(1972, 12, 14).and_hms_milli(5, 40, 56, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
+    let dt_1 = UTC.ymd(1972, 12, 14)
+        .and_hms_milli(5, 40, 56, 0)
+        .timestamp();
 
 
     b.iter(|| {
@@ -225,19 +269,25 @@ fn bench_multi_counters(b: &mut Bencher) {
 
 #[bench]
 fn bench_single_counter(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
+               let mut bucket = buckets::Buckets::default();
 
-        bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_sum());
-    });
+               bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_sum());
+           });
 }
 
 #[bench]
 fn bench_multi_gauges(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
-    let dt_1 = UTC.ymd(1972, 12, 14).and_hms_milli(5, 40, 56, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
+    let dt_1 = UTC.ymd(1972, 12, 14)
+        .and_hms_milli(5, 40, 56, 0)
+        .timestamp();
 
     b.iter(|| {
         let mut bucket = buckets::Buckets::default();
@@ -256,11 +306,13 @@ fn bench_multi_gauges(b: &mut Bencher) {
 
 #[bench]
 fn bench_single_gauge(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
+    let dt_0 = UTC.ymd(1972, 12, 11)
+        .and_hms_milli(11, 59, 49, 0)
+        .timestamp();
 
     b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
+               let mut bucket = buckets::Buckets::default();
 
-        bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_set());
-    });
+               bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_set());
+           });
 }

--- a/benches/filters.rs
+++ b/benches/filters.rs
@@ -28,11 +28,11 @@ mod benches {
                         protocol_counter-TCPFastOpenActive";
 
             b.iter(|| {
-                let metric = metric::Telemetry::new(orig, 12.0);
-                let event = metric::Event::new_telemetry(metric);
-                let res = cs.process(event);
-                assert!(res.is_ok());
-            });
+                       let metric = metric::Telemetry::new(orig, 12.0);
+                       let event = metric::Event::new_telemetry(metric);
+                       let res = cs.process(event);
+                       assert!(res.is_ok());
+                   });
         }
 
     }

--- a/benches/metrics.rs
+++ b/benches/metrics.rs
@@ -26,80 +26,80 @@ fn bench_merge_tags_from_map(b: &mut Bencher) {
 #[bench]
 fn bench_statsd_incr_gauge_no_sample(b: &mut Bencher) {
     b.iter(|| {
-        let metric = sync::Arc::new(Some(Telemetry::default()));
-        let mut res = Vec::new();
-        parse_statsd("a.b:+12.1|g\n", &mut res, metric);
-    });
+               let metric = sync::Arc::new(Some(Telemetry::default()));
+               let mut res = Vec::new();
+               parse_statsd("a.b:+12.1|g\n", &mut res, metric);
+           });
 }
 
 #[bench]
 fn bench_statsd_incr_gauge_with_sample(b: &mut Bencher) {
     b.iter(|| {
-        let metric = sync::Arc::new(Some(Telemetry::default()));
-        let mut res = Vec::new();
-        parse_statsd("a.b:+12.1|g@2.2\n", &mut res, metric);
-    });
+               let metric = sync::Arc::new(Some(Telemetry::default()));
+               let mut res = Vec::new();
+               parse_statsd("a.b:+12.1|g@2.2\n", &mut res, metric);
+           });
 }
 
 #[bench]
 fn bench_statsd_gauge_no_sample(b: &mut Bencher) {
     b.iter(|| {
-        let metric = sync::Arc::new(Some(Telemetry::default()));
-        let mut res = Vec::new();
-        parse_statsd("a.b:12.1|g\n", &mut res, metric);
-    });
+               let metric = sync::Arc::new(Some(Telemetry::default()));
+               let mut res = Vec::new();
+               parse_statsd("a.b:12.1|g\n", &mut res, metric);
+           });
 }
 
 #[bench]
 fn bench_statsd_gauge_mit_sample(b: &mut Bencher) {
     b.iter(|| {
-        let metric = sync::Arc::new(Some(Telemetry::default()));
-        let mut res = Vec::new();
-        parse_statsd("a.b:12.1|g@0.22\n", &mut res, metric);
-    });
+               let metric = sync::Arc::new(Some(Telemetry::default()));
+               let mut res = Vec::new();
+               parse_statsd("a.b:12.1|g@0.22\n", &mut res, metric);
+           });
 }
 
 #[bench]
 fn bench_statsd_counter_no_sample(b: &mut Bencher) {
     b.iter(|| {
-        let metric = sync::Arc::new(Some(Telemetry::default()));
-        let mut res = Vec::new();
-        parse_statsd("a.b:12.1|c\n", &mut res, metric);
-    });
+               let metric = sync::Arc::new(Some(Telemetry::default()));
+               let mut res = Vec::new();
+               parse_statsd("a.b:12.1|c\n", &mut res, metric);
+           });
 }
 
 #[bench]
 fn bench_statsd_counter_with_sample(b: &mut Bencher) {
     b.iter(|| {
-        let metric = sync::Arc::new(Some(Telemetry::default()));
-        let mut res = Vec::new();
-        parse_statsd("a.b:12.1|c@1.0\n", &mut res, metric);
-    });
+               let metric = sync::Arc::new(Some(Telemetry::default()));
+               let mut res = Vec::new();
+               parse_statsd("a.b:12.1|c@1.0\n", &mut res, metric);
+           });
 }
 
 #[bench]
 fn bench_statsd_timer(b: &mut Bencher) {
     b.iter(|| {
-        let metric = sync::Arc::new(Some(Telemetry::default()));
-        let mut res = Vec::new();
-        parse_statsd("a.b:12.1|ms\n", &mut res, metric);
-    });
+               let metric = sync::Arc::new(Some(Telemetry::default()));
+               let mut res = Vec::new();
+               parse_statsd("a.b:12.1|ms\n", &mut res, metric);
+           });
 }
 
 #[bench]
 fn bench_statsd_histogram(b: &mut Bencher) {
     b.iter(|| {
-        let metric = sync::Arc::new(Some(Telemetry::default()));
-        let mut res = Vec::new();
-        parse_statsd("a.b:12.1|h\n", &mut res, metric);
-    });
+               let metric = sync::Arc::new(Some(Telemetry::default()));
+               let mut res = Vec::new();
+               parse_statsd("a.b:12.1|h\n", &mut res, metric);
+           });
 }
 
 #[bench]
 fn bench_graphite(b: &mut Bencher) {
     b.iter(|| {
-        let metric = sync::Arc::new(Some(Telemetry::default()));
-        let mut res = Vec::new();
-        parse_graphite("fst 1 101\n", &mut res, metric);
-    });
+               let metric = sync::Arc::new(Some(Telemetry::default()));
+               let mut res = Vec::new();
+               parse_graphite("fst 1 101\n", &mut res, metric);
+           });
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,7 @@ coverage:
 
     patch:
       default:
-        target: 100%
+        target: 90%
 
     project:
       default:

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -55,13 +55,13 @@ fn main() {
 
     let logger_config = fern::DispatchConfig {
         format: Box::new(|msg: &str, level: &log::LogLevel, location: &log::LogLocation| {
-            format!("[{}][{}][{}][{}] {}",
-                    location.module_path(),
-                    location.line(),
-                    UTC::now().to_rfc3339(),
-                    level,
-                    msg)
-        }),
+                             format!("[{}][{}][{}][{}] {}",
+                                     location.module_path(),
+                                     location.line(),
+                                     UTC::now().to_rfc3339(),
+                                     level,
+                                     msg)
+                         }),
         output: vec![fern::OutputConfig::stdout()],
         level: level,
     };
@@ -86,8 +86,8 @@ fn main() {
             hopper::channel(&config.config_path, &args.data_directory).unwrap();
         sends.insert(config.config_path.clone(), console_send);
         joins.push(thread::spawn(move || {
-                cernan::sink::Console::new(config).run(console_recv);
-            }));
+                                     cernan::sink::Console::new(config).run(console_recv);
+                                 }));
     }
     if let Some(config) = args.null {
         let (null_send, null_recv) = hopper::channel(&config.config_path, &args.data_directory)
@@ -106,8 +106,8 @@ fn main() {
             hopper::channel(&config.config_path, &args.data_directory).unwrap();
         sends.insert(config.config_path.clone(), prometheus_send);
         joins.push(thread::spawn(move || {
-            cernan::sink::Prometheus::new(config).run(prometheus_recv);
-        }));
+                                     cernan::sink::Prometheus::new(config).run(prometheus_recv);
+                                 }));
     }
     if let Some(config) = args.influxdb {
         let (flx_send, flx_recv) = hopper::channel(&config.config_path, &args.data_directory)
@@ -144,8 +144,9 @@ fn main() {
                           &config.config_path,
                           &sends);
         joins.push(thread::spawn(move || {
-            cernan::filter::ProgrammableFilter::new(c).run(flt_recv, downstream_sends);
-        }));
+                                     cernan::filter::ProgrammableFilter::new(c)
+                                         .run(flt_recv, downstream_sends);
+                                 }));
     }
 
     // SOURCES
@@ -158,8 +159,9 @@ fn main() {
                           &config.config_path,
                           &sends);
         joins.push(thread::spawn(move || {
-            cernan::source::NativeServer::new(native_server_send, config).run();
-        }))
+                                     cernan::source::NativeServer::new(native_server_send, config)
+                                         .run();
+                                 }))
     }
 
     let internal_config = args.internal;
@@ -170,8 +172,9 @@ fn main() {
                       &internal_config.config_path,
                       &sends);
     joins.push(thread::spawn(move || {
-        cernan::source::Internal::new(internal_send, internal_config).run();
-    }));
+                                 cernan::source::Internal::new(internal_send, internal_config)
+                                     .run();
+                             }));
 
     for config in args.statsds.values() {
         let c = (*config).clone();
@@ -193,8 +196,8 @@ fn main() {
                           &config.config_path,
                           &sends);
         joins.push(thread::spawn(move || {
-            cernan::source::Graphite::new(graphite_sends, c).run();
-        }));
+                                     cernan::source::Graphite::new(graphite_sends, c).run();
+                                 }));
     }
 
     for config in args.files {
@@ -205,8 +208,8 @@ fn main() {
                           &config.config_path,
                           &sends);
         joins.push(thread::spawn(move || {
-            cernan::source::FileServer::new(fp_sends, config).run();
-        }));
+                                     cernan::source::FileServer::new(fp_sends, config).run();
+                                 }));
     }
 
     // BACKGROUND

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -126,15 +126,16 @@ impl Buckets {
     /// bucket.add(metric);
     /// ```
     pub fn add(&mut self, value: Telemetry) {
-        let mut hsh = match self.keys
-            .binary_search_by(|probe| probe.partial_cmp(&value.name).unwrap()) {
-            Ok(hsh_idx) => self.values.index_mut(hsh_idx),
-            Err(hsh_idx) => {
-                self.keys.insert(hsh_idx, value.name.to_owned());
-                self.values.insert(hsh_idx, Vec::with_capacity(128));
-                self.values.index_mut(hsh_idx)
-            }
-        };
+        let mut hsh =
+            match self.keys
+                      .binary_search_by(|probe| probe.partial_cmp(&value.name).unwrap()) {
+                Ok(hsh_idx) => self.values.index_mut(hsh_idx),
+                Err(hsh_idx) => {
+                    self.keys.insert(hsh_idx, value.name.to_owned());
+                    self.values.insert(hsh_idx, Vec::with_capacity(128));
+                    self.values.index_mut(hsh_idx)
+                }
+            };
         let bin_width = self.bin_width;
 
         match hsh.binary_search_by(|probe| probe.within(bin_width, &value)) {
@@ -200,9 +201,18 @@ mod test {
         //  * an ephemeral SET|SUM will have its value inherited by a persist SET|SUM
         //  * an ephemeral SET|SUM will not inherit the value of a persist SET|SUM
         let bin_width = 1;
-        let m0 = Telemetry::new("lO", 1.0).timestamp(0).aggr_set().ephemeral();
-        let m1 = Telemetry::new("lO", 2.0).timestamp(1).aggr_sum().persist();
-        let m2 = Telemetry::new("lO", 0.0).timestamp(1).aggr_set().ephemeral();
+        let m0 = Telemetry::new("lO", 1.0)
+            .timestamp(0)
+            .aggr_set()
+            .ephemeral();
+        let m1 = Telemetry::new("lO", 2.0)
+            .timestamp(1)
+            .aggr_sum()
+            .persist();
+        let m2 = Telemetry::new("lO", 0.0)
+            .timestamp(1)
+            .aggr_set()
+            .ephemeral();
 
         let mut bkt = Buckets::new(bin_width);
         bkt.add(m0);
@@ -256,9 +266,15 @@ mod test {
     #[test]
     fn test_gauge_small_bin_width() {
         let bin_width = 1;
-        let m0 = Telemetry::new("lO", 3.211).timestamp(645181811).aggr_set();
-        let m1 = Telemetry::new("lO", 4.322).timestamp(645181812).aggr_set();
-        let m2 = Telemetry::new("lO", 5.433).timestamp(645181813).aggr_set();
+        let m0 = Telemetry::new("lO", 3.211)
+            .timestamp(645181811)
+            .aggr_set();
+        let m1 = Telemetry::new("lO", 4.322)
+            .timestamp(645181812)
+            .aggr_set();
+        let m2 = Telemetry::new("lO", 5.433)
+            .timestamp(645181813)
+            .aggr_set();
 
         let mut bkt = Buckets::new(bin_width);
         bkt.add(m0);
@@ -335,10 +351,14 @@ mod test {
     #[test]
     fn test_add_gauge_metric_distinct_tags() {
         let mut buckets = Buckets::default();
-        let m0 =
-            Telemetry::new("some.metric", 1.0).aggr_set().timestamp(10).overlay_tag("foo", "bar");
-        let m1 =
-            Telemetry::new("some.metric", 1.0).aggr_set().timestamp(10).overlay_tag("foo", "bingo");
+        let m0 = Telemetry::new("some.metric", 1.0)
+            .aggr_set()
+            .timestamp(10)
+            .overlay_tag("foo", "bar");
+        let m1 = Telemetry::new("some.metric", 1.0)
+            .aggr_set()
+            .timestamp(10)
+            .overlay_tag("foo", "bingo");
 
         buckets.add(m0.clone());
         buckets.add(m1.clone());
@@ -368,7 +388,9 @@ mod test {
     #[test]
     fn test_reset_add_counter_metric() {
         let mut buckets = Buckets::default();
-        let m0 = Telemetry::new("some.metric", 1.0).aggr_sum().timestamp(101);
+        let m0 = Telemetry::new("some.metric", 1.0)
+            .aggr_sum()
+            .timestamp(101);
         let m1 = m0.clone();
 
         buckets.add(m0);
@@ -389,14 +411,26 @@ mod test {
     fn test_true_histogram() {
         let mut buckets = Buckets::default();
 
-        let dt_0 = UTC.ymd(1996, 10, 7).and_hms_milli(10, 11, 11, 0).timestamp();
-        let dt_1 = UTC.ymd(1996, 10, 7).and_hms_milli(10, 11, 12, 0).timestamp();
-        let dt_2 = UTC.ymd(1996, 10, 7).and_hms_milli(10, 11, 13, 0).timestamp();
+        let dt_0 = UTC.ymd(1996, 10, 7)
+            .and_hms_milli(10, 11, 11, 0)
+            .timestamp();
+        let dt_1 = UTC.ymd(1996, 10, 7)
+            .and_hms_milli(10, 11, 12, 0)
+            .timestamp();
+        let dt_2 = UTC.ymd(1996, 10, 7)
+            .and_hms_milli(10, 11, 13, 0)
+            .timestamp();
 
         let name = String::from("some.metric");
-        let m0 = Telemetry::new("some.metric", 1.0).timestamp(dt_0).aggr_summarize();
-        let m1 = Telemetry::new("some.metric", 2.0).timestamp(dt_1).aggr_summarize();
-        let m2 = Telemetry::new("some.metric", 3.0).timestamp(dt_2).aggr_summarize();
+        let m0 = Telemetry::new("some.metric", 1.0)
+            .timestamp(dt_0)
+            .aggr_summarize();
+        let m1 = Telemetry::new("some.metric", 2.0)
+            .timestamp(dt_1)
+            .aggr_summarize();
+        let m2 = Telemetry::new("some.metric", 3.0)
+            .timestamp(dt_2)
+            .aggr_summarize();
 
         buckets.add(m0.clone());
         buckets.add(m1.clone());
@@ -462,9 +496,14 @@ mod test {
         // require this explicit reset, only the +/- on the metric value.
         let mut buckets = Buckets::default();
         let rmname = String::from("some.metric");
-        let metric = Telemetry::new("some.metric", 100.0).timestamp(0).aggr_set();
+        let metric = Telemetry::new("some.metric", 100.0)
+            .timestamp(0)
+            .aggr_set();
         buckets.add(metric);
-        let delta_metric = Telemetry::new("some.metric", -11.5).timestamp(0).aggr_sum().persist();
+        let delta_metric = Telemetry::new("some.metric", -11.5)
+            .timestamp(0)
+            .aggr_sum()
+            .persist();
         buckets.add(delta_metric);
         assert_eq!(Some(88.5), buckets.get(&rmname).unwrap()[0].value());
         assert_eq!(1, buckets.count());
@@ -508,13 +547,25 @@ mod test {
     #[test]
     fn test_raws_store_one_point_per_second() {
         let mut buckets = Buckets::default();
-        let dt_0 = UTC.ymd(2016, 9, 13).and_hms_milli(11, 30, 0, 0).timestamp();
-        let dt_1 = UTC.ymd(2016, 9, 13).and_hms_milli(11, 30, 1, 0).timestamp();
+        let dt_0 = UTC.ymd(2016, 9, 13)
+            .and_hms_milli(11, 30, 0, 0)
+            .timestamp();
+        let dt_1 = UTC.ymd(2016, 9, 13)
+            .and_hms_milli(11, 30, 1, 0)
+            .timestamp();
 
-        buckets.add(Telemetry::new("some.metric", 1.0).timestamp(dt_0).aggr_set());
-        buckets.add(Telemetry::new("some.metric", 2.0).timestamp(dt_0).aggr_set());
-        buckets.add(Telemetry::new("some.metric", 3.0).timestamp(dt_0).aggr_set());
-        buckets.add(Telemetry::new("some.metric", 4.0).timestamp(dt_1).aggr_set());
+        buckets.add(Telemetry::new("some.metric", 1.0)
+                        .timestamp(dt_0)
+                        .aggr_set());
+        buckets.add(Telemetry::new("some.metric", 2.0)
+                        .timestamp(dt_0)
+                        .aggr_set());
+        buckets.add(Telemetry::new("some.metric", 3.0)
+                        .timestamp(dt_0)
+                        .aggr_set());
+        buckets.add(Telemetry::new("some.metric", 4.0)
+                        .timestamp(dt_1)
+                        .aggr_set());
 
         let mname = String::from("some.metric");
         let metrics = buckets.get(&mname).unwrap();
@@ -536,11 +587,13 @@ mod test {
                 bucket.add(m);
             }
 
-            let cnts: HashSet<String> = ms.iter().fold(HashSet::default(), |mut acc, ref m| {
-                acc.insert(m.name.clone());
-                acc
-            });
-            let b_cnts: HashSet<String> = bucket.into_iter()
+            let cnts: HashSet<String> = ms.iter()
+                .fold(HashSet::default(), |mut acc, ref m| {
+                    acc.insert(m.name.clone());
+                    acc
+                });
+            let b_cnts: HashSet<String> = bucket
+                .into_iter()
                 .fold(HashSet::default(), |mut acc, v| {
                     acc.insert(v[0].name.clone());
                     acc

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -729,12 +729,29 @@ mod test {
                 assert_eq!(cnts_v.len(), v.len());
 
                 for (i, c_v) in cnts_v.iter().enumerate() {
-                    assert_eq!((c_v.0, c_v.1.clone()), (v[i].timestamp, v[i].ckms()));
+                    assert_eq!(c_v.0, v[i].timestamp);
+                    let l_ckms = c_v.1.clone();
+                    let r_ckms = v[i].ckms();
+
+                    assert!((l_ckms.sum().unwrap() - r_ckms.sum().unwrap()).abs() < 0.0001);
+                    assert!((l_ckms.cma().unwrap() - r_ckms.cma().unwrap()).abs() < 0.0001);
+                    assert_eq!(l_ckms.count(), r_ckms.count());
+                    assert!((l_ckms.query(0.5).unwrap().1 - r_ckms.query(0.5).unwrap().1).abs() <
+                            0.0001);
+                    assert!((l_ckms.query(0.75).unwrap().1 - r_ckms.query(0.75).unwrap().1)
+                                .abs() < 0.0001);
+                    assert!((l_ckms.query(0.99).unwrap().1 - r_ckms.query(0.99).unwrap().1)
+                                .abs() < 0.0001);
+                    assert!((l_ckms.query(0.999).unwrap().1 - r_ckms.query(0.999).unwrap().1)
+                                .abs() < 0.0001);
                 }
             }
 
             TestResult::passed()
         }
-        QuickCheck::new().quickcheck(qos_ret as fn(Vec<Telemetry>) -> TestResult);
+        QuickCheck::new()
+            .tests(1000)
+            .max_tests(10000)
+            .quickcheck(qos_ret as fn(Vec<Telemetry>) -> TestResult);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,15 +50,15 @@ pub fn parse_args() -> Args {
         .author("Brian L. Troutwine <blt@postmates.com>")
         .about("telemetry aggregation and shipping, last up the ladder")
         .arg(Arg::with_name("config-file")
-            .long("config")
-            .short("C")
-            .value_name("config")
-            .help("The config file to feed in.")
-            .takes_value(true))
+                 .long("config")
+                 .short("C")
+                 .value_name("config")
+                 .help("The config file to feed in.")
+                 .takes_value(true))
         .arg(Arg::with_name("verbose")
-            .short("v")
-            .multiple(true)
-            .help("Turn on verbose output."))
+                 .short("v")
+                 .multiple(true)
+                 .help("Turn on verbose output."))
         .get_matches();
 
     let verb = if args.is_present("verbose") {
@@ -97,14 +97,14 @@ pub fn parse_args() -> Args {
                                        ("99".to_string(), 0.99),
                                        ("999".to_string(), 0.999)];
                 Some(WavefrontConfig {
-                    port: u16::from_str(args.value_of("wavefront-port").unwrap()).unwrap(),
-                    host: args.value_of("wavefront-host").unwrap().to_string(),
-                    bin_width: 1,
-                    config_path: "sinks.wavefront".to_string(),
-                    percentiles: percentiles,
-                    tags: Default::default(),
-                    flush_interval: flush_interval,
-                })
+                         port: u16::from_str(args.value_of("wavefront-port").unwrap()).unwrap(),
+                         host: args.value_of("wavefront-host").unwrap().to_string(),
+                         bin_width: 1,
+                         config_path: "sinks.wavefront".to_string(),
+                         percentiles: percentiles,
+                         tags: Default::default(),
+                         flush_interval: flush_interval,
+                     })
             } else {
                 None
             };
@@ -127,16 +127,16 @@ pub fn parse_args() -> Args {
 
             let mut graphite_config = GraphiteConfig::default();
             if let Some(gport_str) = args.value_of("graphite-port") {
-                graphite_config.port = u16::from_str(gport_str)
-                    .expect("graphite-port must be an integer");
+                graphite_config.port =
+                    u16::from_str(gport_str).expect("graphite-port must be an integer");
             }
             let mut graphites = HashMap::new();
             graphites.insert("sources.graphite".to_string(), graphite_config);
 
             let mut statsd_config = StatsdConfig::default();
             if let Some(sport_str) = args.value_of("statsd-port") {
-                statsd_config.port = u16::from_str(sport_str)
-                    .expect("statsd-port must be an integer");
+                statsd_config.port =
+                    u16::from_str(sport_str).expect("statsd-port must be an integer");
             }
             let mut statsds = HashMap::new();
             statsds.insert("sources.statsd".to_string(), statsd_config);
@@ -174,7 +174,8 @@ pub fn parse_args() -> Args {
 pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
     let value: toml::Value = buffer.parse().unwrap();
 
-    let scripts_dir: PathBuf = value.lookup("scripts-directory")
+    let scripts_dir: PathBuf = value
+        .lookup("scripts-directory")
         .unwrap_or(&Value::String("/tmp/cernan-scripts".to_string()))
         .as_str()
         .map(|s| Path::new(s).to_path_buf())
@@ -193,46 +194,61 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
         None => TagMap::default(),
     };
 
-    let global_flush_interval = value.lookup("flush-interval")
+    let global_flush_interval = value
+        .lookup("flush-interval")
         .unwrap_or(&Value::Integer(60))
         .as_integer()
         .unwrap();
 
-    let null = if value.lookup("null").or(value.lookup("sinks.null")).is_some() {
+    let null = if value
+           .lookup("null")
+           .or(value.lookup("sinks.null"))
+           .is_some() {
         Some(NullConfig { config_path: "sinks.null".to_string() })
     } else {
         None
     };
 
-    let console = if value.lookup("console").or(value.lookup("sinks.console")).is_some() {
+    let console = if value
+           .lookup("console")
+           .or(value.lookup("sinks.console"))
+           .is_some() {
         Some(ConsoleConfig {
-            bin_width: value.lookup("console.bin_width")
-                .or(value.lookup("sinks.console.bin_width"))
-                .unwrap_or(&Value::Integer(1))
-                .as_integer()
-                .expect("could not parse sinks.console.bin_width"),
-            config_path: "sinks.console".to_string(),
-            flush_interval: value.lookup("console.flush_interval")
-                .or(value.lookup("sinks.console.flush_interval"))
-                .unwrap_or(&Value::Integer(global_flush_interval))
-                .as_integer()
-                .map(|i| i as u64)
-                .unwrap(),
-        })
+                 bin_width: value
+                     .lookup("console.bin_width")
+                     .or(value.lookup("sinks.console.bin_width"))
+                     .unwrap_or(&Value::Integer(1))
+                     .as_integer()
+                     .expect("could not parse sinks.console.bin_width"),
+                 config_path: "sinks.console".to_string(),
+                 flush_interval: value
+                     .lookup("console.flush_interval")
+                     .or(value.lookup("sinks.console.flush_interval"))
+                     .unwrap_or(&Value::Integer(global_flush_interval))
+                     .as_integer()
+                     .map(|i| i as u64)
+                     .unwrap(),
+             })
     } else {
         None
     };
 
-    let wavefront = if value.lookup("wavefront").or(value.lookup("sinks.wavefront")).is_some() {
+    let wavefront = if value
+           .lookup("wavefront")
+           .or(value.lookup("sinks.wavefront"))
+           .is_some() {
         let mut prcnt = Vec::new();
-        if let Some(tbl) = value.lookup("wavefront.percentiles")
-            .or(value.lookup("sinks.wavefront.percentiles"))
-            .and_then(|t| t.as_slice()) {
+        if let Some(tbl) = value
+               .lookup("wavefront.percentiles")
+               .or(value.lookup("sinks.wavefront.percentiles"))
+               .and_then(|t| t.as_slice()) {
             for opt_val in tbl.iter().map(|x| x.as_slice()) {
                 match opt_val {
                     Some(val) => {
-                        let k: String =
-                            val[0].as_str().expect("percentile name must be a string").to_string();
+                        let k: String = val[0]
+                            .as_str()
+                            .expect("percentile name must be a string")
+                            .to_string();
                         let v: f64 = val[1]
                             .as_str()
                             .expect("percentile value must be a string of a float")
@@ -263,113 +279,133 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
         };
 
         Some(WavefrontConfig {
-            port: value.lookup("wavefront.port")
-                .or(value.lookup("sinks.wavefront.port"))
-                .unwrap_or(&Value::Integer(2878))
-                .as_integer()
-                .map(|i| i as u16)
-                .expect("could not parse sinks.wavefront.port"),
-            host: value.lookup("wavefront.host")
-                .or(value.lookup("sinks.wavefront.host"))
-                .unwrap_or(&Value::String("127.0.0.1".to_string()))
-                .as_str()
-                .map(|s| s.to_string())
-                .expect("could not parse sinks.wavefront.host"),
-            bin_width: value.lookup("wavefront.bin_width")
-                .or(value.lookup("sinks.wavefront.bin_width"))
-                .unwrap_or(&Value::Integer(1))
-                .as_integer()
-                .expect("could not parse sinks.wavefront.bin_width"),
-            config_path: "sinks.wavefront".to_string(),
-            percentiles: percentiles,
-            tags: tags.clone(),
-            flush_interval: value.lookup("wavefront.flush_interval")
-                .or(value.lookup("sinks.wavefront.flush_interval"))
-                .unwrap_or(&Value::Integer(global_flush_interval))
-                .as_integer()
-                .map(|i| i as u64)
-                .unwrap(),
-        })
+                 port: value
+                     .lookup("wavefront.port")
+                     .or(value.lookup("sinks.wavefront.port"))
+                     .unwrap_or(&Value::Integer(2878))
+                     .as_integer()
+                     .map(|i| i as u16)
+                     .expect("could not parse sinks.wavefront.port"),
+                 host: value
+                     .lookup("wavefront.host")
+                     .or(value.lookup("sinks.wavefront.host"))
+                     .unwrap_or(&Value::String("127.0.0.1".to_string()))
+                     .as_str()
+                     .map(|s| s.to_string())
+                     .expect("could not parse sinks.wavefront.host"),
+                 bin_width: value
+                     .lookup("wavefront.bin_width")
+                     .or(value.lookup("sinks.wavefront.bin_width"))
+                     .unwrap_or(&Value::Integer(1))
+                     .as_integer()
+                     .expect("could not parse sinks.wavefront.bin_width"),
+                 config_path: "sinks.wavefront".to_string(),
+                 percentiles: percentiles,
+                 tags: tags.clone(),
+                 flush_interval: value
+                     .lookup("wavefront.flush_interval")
+                     .or(value.lookup("sinks.wavefront.flush_interval"))
+                     .unwrap_or(&Value::Integer(global_flush_interval))
+                     .as_integer()
+                     .map(|i| i as u64)
+                     .unwrap(),
+             })
     } else {
         None
     };
 
-    let influxdb = if value.lookup("influxdb").or(value.lookup("sinks.influxdb")).is_some() {
+    let influxdb = if value
+           .lookup("influxdb")
+           .or(value.lookup("sinks.influxdb"))
+           .is_some() {
         Some(InfluxDBConfig {
-            port: value.lookup("influxdb.port")
-                .or(value.lookup("sinks.influxdb.port"))
-                .unwrap_or(&Value::Integer(8089))
-                .as_integer()
-                .map(|i| i as u16)
-                .expect("could not parse sinks.influxdb.port"),
-            host: value.lookup("influxdb.host")
-                .or(value.lookup("sinks.influxdb.host"))
-                .unwrap_or(&Value::String("127.0.0.1".to_string()))
-                .as_str()
-                .map(|s| s.to_string())
-                .expect("could not parse sinks.influxdb.host"),
-            bin_width: value.lookup("influxdb.bin_width")
-                .or(value.lookup("sinks.influxdb.bin_width"))
-                .unwrap_or(&Value::Integer(1))
-                .as_integer()
-                .expect("could not parse sinks.influxdb.bin_width"),
-            config_path: "sinks.influxdb".to_string(),
-            tags: tags.clone(),
-            flush_interval: value.lookup("influxdb.flush_interval")
-                .or(value.lookup("sinks.influxdb.flush_interval"))
-                .unwrap_or(&Value::Integer(global_flush_interval))
-                .as_integer()
-                .map(|i| i as u64)
-                .unwrap(),
-        })
+                 port: value
+                     .lookup("influxdb.port")
+                     .or(value.lookup("sinks.influxdb.port"))
+                     .unwrap_or(&Value::Integer(8089))
+                     .as_integer()
+                     .map(|i| i as u16)
+                     .expect("could not parse sinks.influxdb.port"),
+                 host: value
+                     .lookup("influxdb.host")
+                     .or(value.lookup("sinks.influxdb.host"))
+                     .unwrap_or(&Value::String("127.0.0.1".to_string()))
+                     .as_str()
+                     .map(|s| s.to_string())
+                     .expect("could not parse sinks.influxdb.host"),
+                 bin_width: value
+                     .lookup("influxdb.bin_width")
+                     .or(value.lookup("sinks.influxdb.bin_width"))
+                     .unwrap_or(&Value::Integer(1))
+                     .as_integer()
+                     .expect("could not parse sinks.influxdb.bin_width"),
+                 config_path: "sinks.influxdb".to_string(),
+                 tags: tags.clone(),
+                 flush_interval: value
+                     .lookup("influxdb.flush_interval")
+                     .or(value.lookup("sinks.influxdb.flush_interval"))
+                     .unwrap_or(&Value::Integer(global_flush_interval))
+                     .as_integer()
+                     .map(|i| i as u64)
+                     .unwrap(),
+             })
     } else {
         None
     };
 
-    let prometheus = if value.lookup("prometheus").or(value.lookup("sinks.prometheus")).is_some() {
+    let prometheus = if value
+           .lookup("prometheus")
+           .or(value.lookup("sinks.prometheus"))
+           .is_some() {
         Some(PrometheusConfig {
-            port: value.lookup("prometheus.port")
-                .or(value.lookup("sinks.prometheus.port"))
-                .unwrap_or(&Value::Integer(8086))
-                .as_integer()
-                .map(|i| i as u16)
-                .expect("could not parse sinks.prometheus.port"),
-            host: value.lookup("prometheus.host")
-                .or(value.lookup("sinks.prometheus.host"))
-                .unwrap_or(&Value::String("127.0.0.1".to_string()))
-                .as_str()
-                .map(|s| s.to_string())
-                .expect("could not parse sinks.prometheus.host"),
-            bin_width: value.lookup("prometheus.bin_width")
-                .or(value.lookup("sinks.prometheus.bin_width"))
-                .unwrap_or(&Value::Integer(1))
-                .as_integer()
-                .expect("could not parse sinks.prometheus.bin_width"),
-            config_path: "sinks.prometheus".to_string(),
-        })
+                 port: value
+                     .lookup("prometheus.port")
+                     .or(value.lookup("sinks.prometheus.port"))
+                     .unwrap_or(&Value::Integer(8086))
+                     .as_integer()
+                     .map(|i| i as u16)
+                     .expect("could not parse sinks.prometheus.port"),
+                 host: value
+                     .lookup("prometheus.host")
+                     .or(value.lookup("sinks.prometheus.host"))
+                     .unwrap_or(&Value::String("127.0.0.1".to_string()))
+                     .as_str()
+                     .map(|s| s.to_string())
+                     .expect("could not parse sinks.prometheus.host"),
+                 bin_width: value
+                     .lookup("prometheus.bin_width")
+                     .or(value.lookup("sinks.prometheus.bin_width"))
+                     .unwrap_or(&Value::Integer(1))
+                     .as_integer()
+                     .expect("could not parse sinks.prometheus.bin_width"),
+                 config_path: "sinks.prometheus".to_string(),
+             })
     } else {
         None
     };
 
     let native_sink_config = if value.lookup("sinks.native").is_some() {
         Some(NativeConfig {
-            port: value.lookup("sinks.native.port")
-                .unwrap_or(&Value::Integer(1972))
-                .as_integer()
-                .map(|i| i as u16)
-                .expect("could not parse sinks.native.port"),
-            host: value.lookup("sinks.native.host")
-                .unwrap_or(&Value::String("127.0.0.1".to_string()))
-                .as_str()
-                .map(|s| s.to_string())
-                .expect("could not parse sinks.native.host"),
-            config_path: "sinks.native".to_string(),
-            flush_interval: value.lookup("sinks.native.flush_interval")
-                .unwrap_or(&Value::Integer(global_flush_interval))
-                .as_integer()
-                .map(|i| i as u64)
-                .unwrap(),
-        })
+                 port: value
+                     .lookup("sinks.native.port")
+                     .unwrap_or(&Value::Integer(1972))
+                     .as_integer()
+                     .map(|i| i as u16)
+                     .expect("could not parse sinks.native.port"),
+                 host: value
+                     .lookup("sinks.native.host")
+                     .unwrap_or(&Value::String("127.0.0.1".to_string()))
+                     .as_str()
+                     .map(|s| s.to_string())
+                     .expect("could not parse sinks.native.host"),
+                 config_path: "sinks.native".to_string(),
+                 flush_interval: value
+                     .lookup("sinks.native.flush_interval")
+                     .unwrap_or(&Value::Integer(global_flush_interval))
+                     .as_integer()
+                     .map(|i| i as u64)
+                     .unwrap(),
+             })
     } else {
         None
     };
@@ -446,11 +482,12 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                             //
                             // Someday a static analysis system will flag this as
                             // unsafe. Welcome.
-                            let max_read_lines = tbl.lookup("max_read_lines")
-                                .unwrap_or(&Value::Integer(10_000))
-                                .as_integer()
-                                .expect("could not parse file.max_read_lines") as
-                                                 usize;
+                            let max_read_lines =
+                                tbl.lookup("max_read_lines")
+                                    .unwrap_or(&Value::Integer(10_000))
+                                    .as_integer()
+                                    .expect("could not parse file.max_read_lines") as
+                                usize;
                             let path_buf = path.to_path_buf();
                             let config = FileServerConfig {
                                 path: path_buf.clone(),
@@ -518,19 +555,19 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                                 .unwrap_or(&Value::String("us-west-2".into()))
                                 .as_str()
                                 .map(|s| match s {
-                                    "ap-northeast-1" => Region::ApNortheast1,
-                                    "ap-northeast-2" => Region::ApNortheast2,
-                                    "ap-south-1" => Region::ApSouth1,
-                                    "ap-southeast-1" => Region::ApSoutheast1,
-                                    "ap-southeast-2" => Region::ApSoutheast2,
-                                    "cn-north-1" => Region::CnNorth1,
-                                    "eu-central-1" => Region::EuCentral1,
-                                    "eu-west-1" => Region::EuWest1,
-                                    "sa-east-1" => Region::SaEast1,
-                                    "us-east-1" => Region::UsEast1,
-                                    "us-west-1" => Region::UsWest1,
-                                    "us-west-2" | _ => Region::UsWest2,
-                                });
+                                         "ap-northeast-1" => Region::ApNortheast1,
+                                         "ap-northeast-2" => Region::ApNortheast2,
+                                         "ap-south-1" => Region::ApSouth1,
+                                         "ap-southeast-1" => Region::ApSoutheast1,
+                                         "ap-southeast-2" => Region::ApSoutheast2,
+                                         "cn-north-1" => Region::CnNorth1,
+                                         "eu-central-1" => Region::EuCentral1,
+                                         "eu-west-1" => Region::EuWest1,
+                                         "sa-east-1" => Region::SaEast1,
+                                         "us-east-1" => Region::UsEast1,
+                                         "us-west-1" => Region::UsWest1,
+                                         "us-west-2" | _ => Region::UsWest2,
+                                     });
                             let delivery_stream = ds.unwrap().to_string();
                             let flush_interval = val.lookup("flush_interval")
                                 .unwrap_or(&Value::Integer(global_flush_interval))
@@ -538,12 +575,13 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                                 .map(|i| i as u64)
                                 .unwrap();
                             firehosen.push(FirehoseConfig {
-                                delivery_stream: delivery_stream.clone(),
-                                batch_size: bs,
-                                region: r.unwrap(),
-                                config_path: format!("sinks.firehose.{}", delivery_stream),
-                                flush_interval: flush_interval,
-                            })
+                                               delivery_stream: delivery_stream.clone(),
+                                               batch_size: bs,
+                                               region: r.unwrap(),
+                                               config_path: format!("sinks.firehose.{}",
+                                                                    delivery_stream),
+                                               flush_interval: flush_interval,
+                                           })
                         }
                         None => continue,
                     }
@@ -564,31 +602,31 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                                 .unwrap_or(&Value::String("us-west-2".into()))
                                 .as_str()
                                 .map(|s| match s {
-                                    "ap-northeast-1" => Region::ApNortheast1,
-                                    "ap-northeast-2" => Region::ApNortheast2,
-                                    "ap-south-1" => Region::ApSouth1,
-                                    "ap-southeast-1" => Region::ApSoutheast1,
-                                    "ap-southeast-2" => Region::ApSoutheast2,
-                                    "cn-north-1" => Region::CnNorth1,
-                                    "eu-central-1" => Region::EuCentral1,
-                                    "eu-west-1" => Region::EuWest1,
-                                    "sa-east-1" => Region::SaEast1,
-                                    "us-east-1" => Region::UsEast1,
-                                    "us-west-1" => Region::UsWest1,
-                                    "us-west-2" | _ => Region::UsWest2,
-                                });
+                                         "ap-northeast-1" => Region::ApNortheast1,
+                                         "ap-northeast-2" => Region::ApNortheast2,
+                                         "ap-south-1" => Region::ApSouth1,
+                                         "ap-southeast-1" => Region::ApSoutheast1,
+                                         "ap-southeast-2" => Region::ApSoutheast2,
+                                         "cn-north-1" => Region::CnNorth1,
+                                         "eu-central-1" => Region::EuCentral1,
+                                         "eu-west-1" => Region::EuWest1,
+                                         "sa-east-1" => Region::SaEast1,
+                                         "us-east-1" => Region::UsEast1,
+                                         "us-west-1" => Region::UsWest1,
+                                         "us-west-2" | _ => Region::UsWest2,
+                                     });
                             let flush_interval = tbl.lookup("flush_interval")
                                 .unwrap_or(&Value::Integer(global_flush_interval))
                                 .as_integer()
                                 .map(|i| i as u64)
                                 .unwrap();
                             firehosen.push(FirehoseConfig {
-                                delivery_stream: ds.unwrap().to_string(),
-                                batch_size: bs,
-                                region: r.unwrap(),
-                                config_path: format!("sinks.firehose.{}", key),
-                                flush_interval: flush_interval,
-                            })
+                                               delivery_stream: ds.unwrap().to_string(),
+                                               batch_size: bs,
+                                               region: r.unwrap(),
+                                               config_path: format!("sinks.firehose.{}", key),
+                                               flush_interval: flush_interval,
+                                           })
                         }
                         None => continue,
                     }
@@ -622,9 +660,10 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                             sconfig.host = p.as_str().unwrap().to_string();
                         }
                         if let Some(p) = tbl.lookup("delete-gauges") {
-                            sconfig.delete_gauges = p.as_bool()
-                                .expect("statsd delete-gauges must be boolean") as
-                                                    bool;
+                            sconfig.delete_gauges =
+                                p.as_bool()
+                                    .expect("statsd delete-gauges must be boolean") as
+                                bool;
                         }
                         if let Some(fwds) = tbl.lookup("forwards") {
                             sconfig.forwards = fwds.as_slice()
@@ -639,7 +678,8 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                     }
                 }
             } else {
-                let is_enabled = value.lookup("statsd.enabled")
+                let is_enabled = value
+                    .lookup("statsd.enabled")
                     .unwrap_or(&Value::Boolean(true))
                     .as_bool()
                     .expect("must be a bool");
@@ -700,7 +740,8 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                     }
                 }
             } else {
-                let is_enabled = value.lookup("graphite.enabled")
+                let is_enabled = value
+                    .lookup("graphite.enabled")
                     .unwrap_or(&Value::Boolean(true))
                     .as_bool()
                     .expect("must be a bool");
@@ -725,8 +766,7 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
         }
     };
 
-    let native_server_config = if value.lookup("sources.native")
-        .is_some() {
+    let native_server_config = if value.lookup("sources.native").is_some() {
         let port = match value.lookup("sources.native.port") {
             Some(p) => p.as_integer().expect("fed_server.port must be integer") as u16,
             None => 1972,
@@ -747,12 +787,12 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
             None => Vec::new(),
         };
         Some(NativeServerConfig {
-            ip: ip.to_owned(),
-            port: port,
-            tags: tags.clone(),
-            forwards: fwds,
-            config_path: "sources.native".to_string(),
-        })
+                 ip: ip.to_owned(),
+                 port: port,
+                 tags: tags.clone(),
+                 forwards: fwds,
+                 config_path: "sources.native".to_string(),
+             })
     } else {
         None
     };
@@ -783,7 +823,8 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
     };
 
     Args {
-        data_directory: value.lookup("data-directory")
+        data_directory: value
+            .lookup("data-directory")
             .unwrap_or(&Value::String("/tmp/cernan-data".to_string()))
             .as_str()
             .map(|s| Path::new(s).to_path_buf())
@@ -794,7 +835,8 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
         graphites: graphites,
         native_sink_config: native_sink_config,
         native_server_config: native_server_config,
-        flush_interval: value.lookup("flush-interval")
+        flush_interval: value
+            .lookup("flush-interval")
             .unwrap_or(&Value::Integer(60))
             .as_integer()
             .expect("flush-interval must be integer") as u64,
@@ -824,7 +866,7 @@ mod test {
         let config = r#"
 data-directory = "/foo/bar"
 "#
-            .to_string();
+                .to_string();
         let args = parse_config_file(config, 4);
         let dir = Path::new("/foo/bar").to_path_buf();
 
@@ -845,7 +887,7 @@ data-directory = "/foo/bar"
         let config = r#"
 scripts-directory = "/foo/bar"
 "#
-            .to_string();
+                .to_string();
         let args = parse_config_file(config, 4);
         let dir = Path::new("/foo/bar").to_path_buf();
 
@@ -887,7 +929,7 @@ scripts-directory = "/foo/bar"
   ip = "127.0.0.1"
   port = 1972
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -904,7 +946,7 @@ scripts-directory = "/foo/bar"
   [sources.internal]
   forwards = ["sinks.console", "sinks.null"]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -921,7 +963,7 @@ scripts-directory = "/foo/bar"
   port = 1972
   flush_interval = 120
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -937,7 +979,7 @@ scripts-directory = "/foo/bar"
         let config = r#"
 statsd-port = 1024
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -953,7 +995,7 @@ statsd-port = 1024
 [statsd]
 port = 1024
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -968,7 +1010,7 @@ port = 1024
 enabled = false
 port = 1024
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -986,7 +1028,7 @@ port = 1024
   delete-gauges = true
   forwards = ["sinks.console", "sinks.null"]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1015,7 +1057,7 @@ port = 1024
   port = 4048
   forwards = ["sinks.wavefront"]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1038,7 +1080,7 @@ port = 1024
         let config = r#"
 graphite-port = 1024
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1054,7 +1096,7 @@ graphite-port = 1024
 [graphite]
 port = 1024
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1071,7 +1113,7 @@ port = 1024
 enabled = false
 port = 1024
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1088,7 +1130,7 @@ port = 1024
   port = 2003
   forwards = ["filters.collectd_scrub"]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1115,7 +1157,7 @@ port = 1024
   port = 2004
   forwards = ["sinks.wavefront"]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1139,7 +1181,7 @@ port = 1024
   script = "cernan_bridge.lua"
   forwards = ["sinks.console"]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1162,7 +1204,7 @@ scripts-directory = "data/"
   script = "cernan_bridge.lua"
   forwards = ["sinks.console"]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1183,7 +1225,7 @@ port = 3131
 host = "example.com"
 bin_width = 9
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1204,7 +1246,7 @@ bin_width = 9
   bin_width = 9
   flush_interval = 15
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1226,7 +1268,7 @@ bin_width = 9
   bin_width = 9
   percentiles = [ ["min", "0.0"], ["max", "1.0"], ["median", "0.5"] ]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1251,7 +1293,7 @@ port = 3131
 host = "example.com"
 bin_width = 9
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1272,7 +1314,7 @@ bin_width = 9
   bin_width = 9
   flush_interval = 70
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1292,7 +1334,7 @@ port = 3131
 host = "example.com"
 bin_width = 9
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1312,7 +1354,7 @@ bin_width = 9
   host = "example.com"
   bin_width = 9
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1328,7 +1370,7 @@ bin_width = 9
         let config = r#"
 [console]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1342,7 +1384,7 @@ bin_width = 9
 [console]
 bin_width = 9
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1357,7 +1399,7 @@ bin_width = 9
   [sinks.console]
   bin_width = 9
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1372,7 +1414,7 @@ bin_width = 9
         let config = r#"
 [null]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1385,7 +1427,7 @@ bin_width = 9
 [sinks]
   [sinks.null]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1401,7 +1443,7 @@ delivery_stream = "stream_one"
 [[firehose]]
 delivery_stream = "stream_two"
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1428,7 +1470,7 @@ delivery_stream = "stream_two"
 batch_size = 800
 region = "us-east-1"
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1457,7 +1499,7 @@ region = "us-east-1"
   batch_size = 800
   region = "us-east-1"
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1480,7 +1522,7 @@ region = "us-east-1"
 [[file]]
 path = "/foo/bar.txt"
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1497,7 +1539,7 @@ path = "/foo/bar.txt"
 [[file]]
 path = "/bar.txt"
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1515,7 +1557,7 @@ path = "/bar.txt"
   path = "/foo/bar.txt"
   forwards = ["sink.blech"]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1539,7 +1581,7 @@ path = "/bar.txt"
   path = "/bar.txt"
   forwards = ["sink.bar.blech"]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
 
@@ -1561,7 +1603,7 @@ mission = "from_gad"
 
 [wavefront]
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
         let mut tags = TagMap::default();
@@ -1596,7 +1638,7 @@ purpose = "serious_business"
 mission = "from_gad"
 
 "#
-            .to_string();
+                .to_string();
 
         let args = parse_config_file(config, 4);
         println!("ARGS : {:?}", args);

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -422,9 +422,10 @@ impl ProgrammableFilter {
 
         state.get_global("package");
         let mut path = String::new();
-        path.push_str(config.scripts_directory
-            .to_str()
-            .expect("must have valid unicode scripts_directory"));
+        path.push_str(config
+                          .scripts_directory
+                          .to_str()
+                          .expect("must have valid unicode scripts_directory"));
         path.push_str("/?.lua");
         state.push_string(&path);
         state.set_field(-2, "path");
@@ -486,7 +487,7 @@ impl filter::Filter for ProgrammableFilter {
                                                                        process_metric.failure",
                                                                       self.path),
                                                               1.0)
-                        .aggr_sum();
+                            .aggr_sum();
                     let fail = metric::Event::Telemetry(sync::Arc::new(Some(filter_telem)));
                     return Err(filter::FilterError::NoSuchFunction("process_metric", fail));
                 }
@@ -519,7 +520,7 @@ impl filter::Filter for ProgrammableFilter {
                                                                                   {}.tick.failure",
                                                                                     self.path),
                                                                             1.0)
-                            .aggr_sum());
+                                                             .aggr_sum());
                     return Err(filter::FilterError::NoSuchFunction("tick", fail));
                 }
 
@@ -551,7 +552,7 @@ impl filter::Filter for ProgrammableFilter {
                                                                                   failure",
                                                                                     self.path),
                                                                             1.0)
-                            .aggr_sum());
+                                                             .aggr_sum());
                     return Err(filter::FilterError::NoSuchFunction("process_log", fail));
                 }
 

--- a/src/protocols/graphite.rs
+++ b/src/protocols/graphite.rs
@@ -21,10 +21,11 @@ pub fn parse_graphite(source: &str,
                             Err(_) => return false,
                         };
                         let metric = sync::Arc::make_mut(&mut metric.clone()).take().unwrap();
-                        res.push(metric.set_name(name)
-                            .set_value(parsed_val)
-                            .aggr_set()
-                            .timestamp(parsed_time));
+                        res.push(metric
+                                     .set_name(name)
+                                     .set_value(parsed_val)
+                                     .aggr_set()
+                                     .timestamp(parsed_time));
                     }
                     None => return false,
                 }

--- a/src/protocols/statsd.rs
+++ b/src/protocols/statsd.rs
@@ -273,7 +273,7 @@ mod tests {
                     if sline.sampled {
                         assert!((sline.value * (1.0 / sline.sample_rate) -
                                  telem.value().unwrap())
-                            .abs() < 0.0001);
+                                        .abs() < 0.0001);
                     } else {
                         assert!((sline.value - telem.value().unwrap()).abs() < 0.0001);
                     }
@@ -475,7 +475,13 @@ mod tests {
 
     #[test]
     fn test_metric_invalid() {
-        let invalid = vec!["", "metric", "metric|11:", "metric|12", "metric:13|", ":|@", ":1.0|c"];
+        let invalid = vec!["",
+                           "metric",
+                           "metric|11:",
+                           "metric|12",
+                           "metric:13|",
+                           ":|@",
+                           ":1.0|c"];
         let metric = sync::Arc::new(Some(Telemetry::default()));
         for input in invalid.iter() {
             assert!(!parse_statsd(*input, &mut Vec::new(), metric.clone()));

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -70,7 +70,8 @@ impl Sink for Console {
     }
 
     fn deliver(&mut self, mut point: sync::Arc<Option<Telemetry>>) -> () {
-        self.aggrs.add(sync::Arc::make_mut(&mut point).take().unwrap());
+        self.aggrs
+            .add(sync::Arc::make_mut(&mut point).take().unwrap());
     }
 
     fn deliver_line(&mut self, _: sync::Arc<Option<LogLine>>) -> () {

--- a/src/sink/firehose.rs
+++ b/src/sink/firehose.rs
@@ -62,7 +62,8 @@ impl Sink for Firehose {
         for chunk in self.buffer.chunks(self.batch_size) {
             let prbi = PutRecordBatchInput {
                 delivery_stream_name: self.delivery_stream_name.clone(),
-                records: chunk.iter()
+                records: chunk
+                    .iter()
                     .filter(|m| m.value.len() < 1_024_000)
                     .map(|m| {
                         let mut pyld = Map::new();

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -1,5 +1,4 @@
-use buckets::Buckets;
-use metric::{AggregationMethod, LogLine, TagMap, Telemetry};
+use metric::{LogLine, TagMap, Telemetry};
 use sink::{Sink, Valve};
 use std::cmp;
 use std::net::{ToSocketAddrs, UdpSocket};
@@ -10,7 +9,7 @@ use time;
 pub struct InfluxDB {
     host: String,
     port: u16,
-    aggrs: Buckets,
+    aggrs: Vec<Telemetry>,
     delivery_attempts: u32,
     stats: String,
     flush_interval: u64,
@@ -56,17 +55,12 @@ fn get_from_cache<T>(cache: &mut Vec<(T, String)>, val: T) -> &str
     }
 }
 
-#[inline]
-fn ms_to_ns(ms_time: i64) -> i64 {
-    ms_time * 1000000
-}
-
 impl InfluxDB {
     pub fn new(config: InfluxDBConfig) -> InfluxDB {
         InfluxDB {
             host: config.host,
             port: config.port,
-            aggrs: Buckets::new(config.bin_width),
+            aggrs: Vec::with_capacity(4048),
             delivery_attempts: 0,
             stats: String::with_capacity(8_192),
             flush_interval: config.flush_interval,
@@ -76,86 +70,25 @@ impl InfluxDB {
     /// Convert the buckets into a String that
     /// can be sent to the the wavefront proxy
     pub fn format_stats(&mut self) -> () {
-        let mut time_cache: Vec<(i64, String)> = Vec::with_capacity(128);
-        let mut count_cache: Vec<(usize, String)> = Vec::with_capacity(128);
+        let mut time_cache: Vec<(u64, String)> = Vec::with_capacity(128);
         let mut value_cache: Vec<(f64, String)> = Vec::with_capacity(128);
 
         let mut tag_buf = String::with_capacity(1_024);
-        for values in self.aggrs.into_iter() {
-            for m in values {
-                match m.aggr_method {
-                    AggregationMethod::Sum | AggregationMethod::Set => {
-                        if let Some(val) = m.value() {
-                            self.stats.push_str(&m.name);
-                            self.stats.push_str(",");
-                            fmt_tags(&m.tags, &mut tag_buf);
-                            self.stats.push_str(&tag_buf);
-                            self.stats.push_str(" ");
-                            self.stats.push_str("value=");
-                            self.stats.push_str(get_from_cache(&mut value_cache, val));
-                            self.stats.push_str(",");
-                            self.stats.push_str("count=");
-                            self.stats.push_str(get_from_cache(&mut count_cache, m.count()));
-                            self.stats.push_str(" ");
-                            self.stats
-                                .push_str(get_from_cache(&mut time_cache, ms_to_ns(m.timestamp)));
-                            self.stats.push_str("\n");
-                            tag_buf.clear();
-                        }
-                    }
-                    AggregationMethod::Summarize => {
-                        let time = ms_to_ns(m.timestamp);
-                        let count = m.count();
-
-                        self.stats.push_str(&m.name);
-                        self.stats.push_str(",");
-                        fmt_tags(&m.tags, &mut tag_buf);
-                        self.stats.push_str(&tag_buf);
-                        self.stats.push_str(" ");
-                        self.stats.push_str("min=");
-                        self.stats
-                            .push_str(get_from_cache(&mut value_cache, m.query(0.0).unwrap()));
-                        self.stats.push_str(",");
-                        self.stats.push_str("max=");
-                        self.stats
-                            .push_str(get_from_cache(&mut value_cache, m.query(1.0).unwrap()));
-                        self.stats.push_str(",");
-                        self.stats.push_str("25=");
-                        self.stats
-                            .push_str(get_from_cache(&mut value_cache, m.query(0.25).unwrap()));
-                        self.stats.push_str(",");
-                        self.stats.push_str("50=");
-                        self.stats
-                            .push_str(get_from_cache(&mut value_cache, m.query(0.5).unwrap()));
-                        self.stats.push_str(",");
-                        self.stats.push_str("75=");
-                        self.stats
-                            .push_str(get_from_cache(&mut value_cache, m.query(0.75).unwrap()));
-                        self.stats.push_str(",");
-                        self.stats.push_str("90=");
-                        self.stats
-                            .push_str(get_from_cache(&mut value_cache, m.query(0.90).unwrap()));
-                        self.stats.push_str(",");
-                        self.stats.push_str("95=");
-                        self.stats
-                            .push_str(get_from_cache(&mut value_cache, m.query(0.95).unwrap()));
-                        self.stats.push_str(",");
-                        self.stats.push_str("99=");
-                        self.stats
-                            .push_str(get_from_cache(&mut value_cache, m.query(0.99).unwrap()));
-                        self.stats.push_str(",");
-                        self.stats.push_str("999=");
-                        self.stats
-                            .push_str(get_from_cache(&mut value_cache, m.query(0.999).unwrap()));
-                        self.stats.push_str(",");
-                        self.stats.push_str("count=");
-                        self.stats.push_str(get_from_cache(&mut count_cache, count));
-                        self.stats.push_str(" ");
-                        self.stats.push_str(get_from_cache(&mut time_cache, time));
-                        self.stats.push_str("\n");
-                        tag_buf.clear();
-                    }
-                }
+        for telem in self.aggrs.iter() {
+            if let Some(val) = telem.value() {
+                self.stats.push_str(&telem.name);
+                self.stats.push_str(",");
+                fmt_tags(&telem.tags, &mut tag_buf);
+                self.stats.push_str(&tag_buf);
+                self.stats.push_str(" ");
+                self.stats.push_str("value=");
+                self.stats
+                    .push_str(get_from_cache(&mut value_cache, val));
+                self.stats.push_str(" ");
+                self.stats
+                    .push_str(get_from_cache(&mut time_cache, telem.timestamp_ns));
+                self.stats.push_str("\n");
+                tag_buf.clear();
             }
         }
     }
@@ -182,7 +115,7 @@ impl Sink for InfluxDB {
                                 self.format_stats();
                                 let res = socket.send_to(self.stats.as_bytes(), ip);
                                 if res.is_ok() {
-                                    self.aggrs.reset();
+                                    self.aggrs.clear();
                                     self.stats.clear();
                                     self.delivery_attempts = 0;
                                     return;
@@ -211,7 +144,8 @@ impl Sink for InfluxDB {
     }
 
     fn deliver(&mut self, mut point: sync::Arc<Option<Telemetry>>) -> () {
-        self.aggrs.add(sync::Arc::make_mut(&mut point).take().unwrap());
+        self.aggrs
+            .push(sync::Arc::make_mut(&mut point).take().unwrap());
     }
 
     fn deliver_line(&mut self, _: sync::Arc<Option<LogLine>>) -> () {
@@ -219,7 +153,7 @@ impl Sink for InfluxDB {
     }
 
     fn valve_state(&self) -> Valve {
-        if self.aggrs.len() > 10_000 {
+        if self.aggrs.len() > 100_000 {
             Valve::Closed
         } else {
             Valve::Open
@@ -250,67 +184,79 @@ mod test {
             flush_interval: 60,
         };
         let mut influxdb = InfluxDB::new(config);
-        let dt_0 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 11, 00).timestamp();
-        let dt_1 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 12, 00).timestamp();
-        let dt_2 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 13, 00).timestamp();
+        let dt_0 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 11, 00);
+        let dt_1 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 12, 00);
+        let dt_2 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 13, 00);
         influxdb.deliver(Arc::new(Some(Telemetry::new("test.counter", -1.0)
-            .timestamp(dt_0)
-            .aggr_sum()
-            .overlay_tags_from_map(&tags))));
+                                           .timestamp_and_ns(dt_0.timestamp(),
+                                                             dt_0.timestamp_subsec_nanos())
+                                           .aggr_sum()
+                                           .overlay_tags_from_map(&tags))));
         influxdb.deliver(Arc::new(Some(Telemetry::new("test.counter", 2.0)
-            .timestamp(dt_0)
-            .aggr_sum()
-            .overlay_tags_from_map(&tags))));
+                                           .timestamp_and_ns(dt_0.timestamp(),
+                                                             dt_0.timestamp_subsec_nanos())
+                                           .aggr_sum()
+                                           .overlay_tags_from_map(&tags))));
         influxdb.deliver(Arc::new(Some(Telemetry::new("test.counter", 3.0)
-            .timestamp(dt_1)
-            .aggr_sum()
-            .overlay_tags_from_map(&tags))));
+                                           .timestamp_and_ns(dt_1.timestamp(),
+                                                             dt_1.timestamp_subsec_nanos())
+                                           .aggr_sum()
+                                           .overlay_tags_from_map(&tags))));
         influxdb.deliver(Arc::new(Some(Telemetry::new("test.gauge", 3.211)
-            .timestamp(dt_0)
-            .aggr_set()
-            .overlay_tags_from_map(&tags))));
+                                           .timestamp_and_ns(dt_0.timestamp(),
+                                                             dt_0.timestamp_subsec_nanos())
+                                           .aggr_set()
+                                           .overlay_tags_from_map(&tags))));
         influxdb.deliver(Arc::new(Some(Telemetry::new("test.gauge", 4.322)
-            .timestamp(dt_1)
-            .aggr_set()
-            .overlay_tags_from_map(&tags))));
+                                           .timestamp_and_ns(dt_1.timestamp(),
+                                                             dt_1.timestamp_subsec_nanos())
+                                           .aggr_set()
+                                           .overlay_tags_from_map(&tags))));
         influxdb.deliver(Arc::new(Some(Telemetry::new("test.gauge", 5.433)
-            .timestamp(dt_2)
-            .aggr_set()
-            .overlay_tags_from_map(&tags))));
+                                           .timestamp_and_ns(dt_2.timestamp(),
+                                                             dt_2.timestamp_subsec_nanos())
+                                           .aggr_set()
+                                           .overlay_tags_from_map(&tags))));
         influxdb.deliver(Arc::new(Some(Telemetry::new("test.timer", 12.101)
-            .timestamp(dt_0)
-            .aggr_summarize()
-            .overlay_tags_from_map(&tags))));
+                                           .timestamp_and_ns(dt_0.timestamp(),
+                                                             dt_0.timestamp_subsec_nanos())
+                                           .aggr_summarize()
+                                           .overlay_tags_from_map(&tags))));
         influxdb.deliver(Arc::new(Some(Telemetry::new("test.timer", 1.101)
-            .timestamp(dt_0)
-            .aggr_summarize()
-            .overlay_tags_from_map(&tags))));
+                                           .timestamp_and_ns(dt_0.timestamp(),
+                                                             dt_0.timestamp_subsec_nanos())
+                                           .aggr_summarize()
+                                           .overlay_tags_from_map(&tags))));
         influxdb.deliver(Arc::new(Some(Telemetry::new("test.timer", 3.101)
-            .timestamp(dt_0)
-            .aggr_summarize()
-            .overlay_tags_from_map(&tags))));
+                                           .timestamp_and_ns(dt_0.timestamp(),
+                                                             dt_0.timestamp_subsec_nanos())
+                                           .aggr_summarize()
+                                           .overlay_tags_from_map(&tags))));
         influxdb.deliver(Arc::new(Some(Telemetry::new("test.raw", 1.0)
-            .timestamp(dt_0)
-            .aggr_set()
-            .overlay_tags_from_map(&tags))));
+                                           .timestamp_and_ns(dt_0.timestamp(),
+                                                             dt_0.timestamp_subsec_nanos())
+                                           .aggr_set()
+                                           .overlay_tags_from_map(&tags))));
         influxdb.deliver(Arc::new(Some(Telemetry::new("test.raw", 2.0)
-            .timestamp(dt_1)
-            .aggr_set()
-            .overlay_tags_from_map(&tags))));
+                                           .timestamp_and_ns(dt_1.timestamp(),
+                                                             dt_1.timestamp_subsec_nanos())
+                                           .aggr_set()
+                                           .overlay_tags_from_map(&tags))));
         influxdb.format_stats();
         let lines: Vec<&str> = influxdb.stats.lines().collect();
 
         println!("{:?}", lines);
-        assert_eq!(8, lines.len());
-        assert!(lines.contains(&"test.counter,source=test-src value=1,count=2 645181811000000"));
-        assert!(lines.contains(&"test.counter,source=test-src value=3,count=1 645181812000000"));
-        assert!(lines.contains(&"test.gauge,source=test-src value=3.211,count=1 645181811000000"));
-        assert!(lines.contains(&"test.gauge,source=test-src value=4.322,count=1 645181812000000"));
-        assert!(lines.contains(&"test.gauge,source=test-src value=5.433,count=1 645181813000000"));
-        assert!(lines.contains(&"test.raw,source=test-src value=1,count=1 645181811000000"));
-        assert!(lines.contains(&"test.raw,source=test-src value=2,count=1 645181812000000"));
-        assert!(lines.contains(&"test.timer,source=test-src \
-                                 min=1.101,max=12.101,25=1.101,50=3.101,75=3.101,90=12.101,\
-                                 95=12.101,99=12.101,999=12.101,count=3 645181811000000"));
+        assert_eq!(11, lines.len());
+        assert!(lines.contains(&"test.counter,source=test-src value=-1 645181811000000000"));
+        assert!(lines.contains(&"test.counter,source=test-src value=2 645181811000000000"));
+        assert!(lines.contains(&"test.counter,source=test-src value=3 645181812000000000"));
+        assert!(lines.contains(&"test.gauge,source=test-src value=3.211 645181811000000000"));
+        assert!(lines.contains(&"test.gauge,source=test-src value=4.322 645181812000000000"));
+        assert!(lines.contains(&"test.gauge,source=test-src value=5.433 645181813000000000"));
+        assert!(lines.contains(&"test.timer,source=test-src value=12.101 645181811000000000"));
+        assert!(lines.contains(&"test.timer,source=test-src value=1.101 645181811000000000"));
+        assert!(lines.contains(&"test.timer,source=test-src value=3.101 645181811000000000"));
+        assert!(lines.contains(&"test.raw,source=test-src value=1 645181811000000000"));
+        assert!(lines.contains(&"test.raw,source=test-src value=2 645181812000000000"));
     }
 }

--- a/src/source/graphite.rs
+++ b/src/source/graphite.rs
@@ -56,16 +56,16 @@ fn handle_tcp(chans: util::Channel,
               listner: TcpListener)
               -> thread::JoinHandle<()> {
     thread::spawn(move || for stream in listner.incoming() {
-        if let Ok(stream) = stream {
-            report_telemetry("cernan.graphite.new_peer", 1.0);
-            debug!("new peer at {:?} | local addr for peer {:?}",
-                   stream.peer_addr(),
-                   stream.local_addr());
-            let tags = tags.clone();
-            let chans = chans.clone();
-            thread::spawn(move || { handle_stream(chans, tags, stream); });
-        }
-    })
+                      if let Ok(stream) = stream {
+                          report_telemetry("cernan.graphite.new_peer", 1.0);
+                          debug!("new peer at {:?} | local addr for peer {:?}",
+                                 stream.peer_addr(),
+                                 stream.local_addr());
+                          let tags = tags.clone();
+                          let chans = chans.clone();
+                          thread::spawn(move || { handle_stream(chans, tags, stream); });
+                      }
+                  })
 }
 
 
@@ -75,7 +75,7 @@ fn handle_stream(mut chans: util::Channel, tags: Arc<metric::TagMap>, stream: Tc
         let mut res = Vec::new();
         let mut line_reader = BufReader::new(stream);
         let basic_metric = Arc::new(Some(metric::Telemetry::default()
-            .overlay_tags_from_map(&tags)));
+                                             .overlay_tags_from_map(&tags)));
         while let Some(len) = line_reader.read_line(&mut line).ok() {
             if len > 0 {
                 if parse_graphite(&line, &mut res, basic_metric.clone()) {

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -57,7 +57,9 @@ impl Internal {
 pub fn report_telemetry<S>(name: S, value: f64) -> ()
     where S: Into<String>
 {
-    Q.lock().unwrap().push_back(metric::Telemetry::new(name, value).aggr_sum());
+    Q.lock()
+        .unwrap()
+        .push_back(metric::Telemetry::new(name, value).aggr_sum());
 }
 
 /// Internal as Source

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -45,15 +45,15 @@ fn handle_tcp(chans: util::Channel,
               listner: TcpListener)
               -> thread::JoinHandle<()> {
     thread::spawn(move || for stream in listner.incoming() {
-        if let Ok(stream) = stream {
-            debug!("new peer at {:?} | local addr for peer {:?}",
-                   stream.peer_addr(),
-                   stream.local_addr());
-            let tags = tags.clone();
-            let chans = chans.clone();
-            thread::spawn(move || { handle_stream(chans, tags, stream); });
-        }
-    })
+                      if let Ok(stream) = stream {
+                          debug!("new peer at {:?} | local addr for peer {:?}",
+                                 stream.peer_addr(),
+                                 stream.local_addr());
+                          let tags = tags.clone();
+                          let chans = chans.clone();
+                          thread::spawn(move || { handle_stream(chans, tags, stream); });
+                      }
+                  })
 }
 
 fn handle_stream(mut chans: util::Channel, tags: metric::TagMap, stream: TcpStream) {
@@ -136,8 +136,8 @@ impl Source for NativeServer {
             .to_socket_addrs()
             .expect("unable to make socket addr")
             .collect();
-        let listener = TcpListener::bind(srv.first().unwrap())
-            .expect("Unable to bind to TCP socket");
+        let listener =
+            TcpListener::bind(srv.first().unwrap()).expect("Unable to bind to TCP socket");
         let chans = self.chans.clone();
         let tags = self.tags.clone();
         info!("server started on {}:{}", self.ip, self.port);

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -54,7 +54,7 @@ fn handle_udp(mut chans: util::Channel, tags: sync::Arc<metric::TagMap>, socket:
     let mut buf = [0; 8192];
     let mut metrics = Vec::new();
     let basic_metric = sync::Arc::new(Some(metric::Telemetry::default()
-        .overlay_tags_from_map(&tags)));
+                                               .overlay_tags_from_map(&tags)));
     loop {
         let (len, _) = match socket.recv_from(&mut buf) {
             Ok(r) => r,

--- a/src/time.rs
+++ b/src/time.rs
@@ -17,6 +17,12 @@ pub fn now() -> i64 {
     NOW.load(Ordering::Relaxed) as i64
 }
 
+pub fn now_ns() -> u64 {
+    let now = UTC::now();
+    let seconds = (now.timestamp() as u64).saturating_mul(1_000_000_000);
+    seconds.saturating_add(now.timestamp_subsec_nanos() as u64)
+}
+
 pub fn update_time() {
     let dur = time::Duration::from_millis(500);
     loop {

--- a/tests/programmable_filter.rs
+++ b/tests/programmable_filter.rs
@@ -82,8 +82,8 @@ mod integration {
 
             let log = metric::LogLine::new("clear_me",
                                            "i am the very model of the modern major general")
-                .overlay_tag("foo", "bar")
-                .overlay_tag("bizz", "bazz");
+                    .overlay_tag("foo", "bar")
+                    .overlay_tag("bizz", "bazz");
             let event = metric::Event::new_log(log);
 
             let mut events: Vec<metric::Event> = Vec::new();
@@ -110,12 +110,12 @@ mod integration {
 
             let orig_log = metric::LogLine::new("identity",
                                                 "i am the very model of the modern major general")
-                .overlay_tag("foo", "bar")
-                .overlay_tag("bizz", "bazz");
+                    .overlay_tag("foo", "bar")
+                    .overlay_tag("bizz", "bazz");
             let expected_log = metric::LogLine::new("identity",
                                                     "i am the very model of the modern major \
                                                      general")
-                .overlay_tag("foo", "bar");
+                    .overlay_tag("foo", "bar");
             let orig_event = metric::Event::new_log(orig_log);
             let expected_event = metric::Event::new_log(expected_log);
 
@@ -143,11 +143,9 @@ mod integration {
             };
             let mut cs = ProgrammableFilter::new(config);
 
-            let orig_metric = metric::Telemetry::new("identity", 12.0)
-                .overlay_tag("foo", "bar")
-                .overlay_tag("bizz", "bazz");
-            let expected_metric = metric::Telemetry::new("identity", 12.0)
-                .overlay_tag("foo", "bar");
+            let expected_metric =
+                metric::Telemetry::new("identity", 12.0).overlay_tag("foo", "bar");
+            let orig_metric = expected_metric.clone().overlay_tag("bizz", "bazz");
             let orig_event = metric::Event::new_telemetry(orig_metric);
             let expected_event = metric::Event::new_telemetry(expected_metric);
 
@@ -236,11 +234,11 @@ mod integration {
             let expected_log = metric::LogLine::new("identity",
                                                     "i am the very model of the modern major \
                                                      general")
-                .overlay_tag("foo", "bar")
-                .overlay_tag("bizz", "bazz");
+                    .overlay_tag("foo", "bar")
+                    .overlay_tag("bizz", "bazz");
             let orig_log = metric::LogLine::new("identity",
                                                 "i am the very model of the modern major general")
-                .overlay_tag("foo", "bar");
+                    .overlay_tag("foo", "bar");
             let orig_event = metric::Event::new_log(orig_log);
             let expected_event = metric::Event::new_log(expected_log);
 
@@ -271,11 +269,11 @@ mod integration {
             let expected_log = metric::LogLine::new("identity",
                                                     "i am the very model of the modern major \
                                                      general")
-                .overlay_tag("foo", "bar")
-                .overlay_tag("bizz", "bazz");
+                    .overlay_tag("foo", "bar")
+                    .overlay_tag("bizz", "bazz");
             let orig_log = metric::LogLine::new("identity",
                                                 "i am the very model of the modern major general")
-                .overlay_tag("foo", "bar");
+                    .overlay_tag("foo", "bar");
             let orig_event = metric::Event::new_log(orig_log);
             let expected_event = metric::Event::new_log(expected_log);
 
@@ -303,10 +301,8 @@ mod integration {
             };
             let mut cs = ProgrammableFilter::new(config);
 
-            let expected_metric = metric::Telemetry::new("identity", 12.0)
-                .overlay_tag("foo", "bar")
-                .overlay_tag("bizz", "bazz");
             let orig_metric = metric::Telemetry::new("identity", 12.0).overlay_tag("foo", "bar");
+            let expected_metric = orig_metric.clone().overlay_tag("bizz", "bazz");
             let orig_event = metric::Event::new_telemetry(orig_metric);
             let expected_event = metric::Event::new_telemetry(expected_metric);
 
@@ -358,8 +354,16 @@ mod integration {
             assert_eq!(events.len(), 3);
             println!("EVENTS: {:?}", events);
             assert_eq!(events[2], metric::Event::TimerFlush(1));
-            assert_eq!(events[1],
-                       metric::Event::new_telemetry(metric::Telemetry::new("count_per_tick", 5.0)));
+            match events[1] {
+                metric::Event::Telemetry(ref mut m) => {
+                    let p = ::std::sync::Arc::make_mut(m).take().unwrap();
+                    assert_eq!(p.name, "count_per_tick");
+                    assert_eq!(p.value(), Some(5.0));
+                }
+                _ => {
+                    assert!(false);
+                }
+            }
             assert_eq!(events[0],
                        metric::Event::new_log(metric::LogLine::new("filters.keep_count",
                                                                    "count_per_tick: 5")));
@@ -376,8 +380,16 @@ mod integration {
             assert_eq!(events.len(), 3);
             println!("EVENTS: {:?}", events);
             assert_eq!(events[2], metric::Event::TimerFlush(2));
-            assert_eq!(events[1],
-                       metric::Event::new_telemetry(metric::Telemetry::new("count_per_tick", 2.0)));
+            match events[1] {
+                metric::Event::Telemetry(ref mut m) => {
+                    let p = ::std::sync::Arc::make_mut(m).take().unwrap();
+                    assert_eq!(p.name, "count_per_tick");
+                    assert_eq!(p.value(), Some(2.0));
+                }
+                _ => {
+                    assert!(false);
+                }
+            }
             assert_eq!(events[0],
                        metric::Event::new_log(metric::LogLine::new("filters.keep_count",
                                                                    "count_per_tick: 2")));


### PR DESCRIPTION
With the InfluxDB sink we're doing something different from the other sinks: no aggregation. InfluxDB is a proper timeseries database and has a rich query language. There's no need for cernan to do pre-aggregation. InfluxDB further has nanosecond timestamps so timestamp_ns has been added to the Telemetry struct to accommodate this.

This PR does not attempt to send all the points stored in the InfluxDB buffer at once. It opens a socket and then sends multiple payloads. That socket is re-used on error, though it's not clear if this is right to do or what errors might be bubbled up. Further, we add telemetry around reporting to InfluxDB.
