### PR TITLE
Introduce 'mean' into wavefront summarize reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lua 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quantiles 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quantiles 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -472,7 +472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quantiles"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1028,7 +1028,7 @@ dependencies = [
 "checksum openssl-sys 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "376c5c6084e5ea95eea9c3280801e46d0dcf51251d4f01b747e044fb64d1fb31"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3e2ed6fe8ff3b20b44bb4b4f54de12ac89dc38cb451dce8ae5e9dcd1507f738"
-"checksum quantiles 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5b3b5be43df9ffd0570cbd14f25ae72c8f2f9233e99dc186be959e7812358555"
+"checksum quantiles 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3ef2080d9bd8158eddd47a8944349ce185064ee990d94d10ac6701db151f2c2"
 "checksum quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "02c2411d418cea2364325b18a205664f9ef8252e06b2e911db97c0b0d98b1406"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ libc = "0.2"
 log = "0.3.6"
 lua = "0.0.10"
 protobuf = "1.2"
-quantiles = "0.3"
+quantiles = "0.4"
 rand = "0.3"
 rusoto = {version = "0.23.1", features = ["firehose"]}
 seahash = "3.0"

--- a/src/metric/telemetry.rs
+++ b/src/metric/telemetry.rs
@@ -383,6 +383,10 @@ impl Telemetry {
         self.value.count()
     }
 
+    pub fn mean(&self) -> f64 {
+        self.value.mean().unwrap()
+    }
+
     pub fn sum(&self) -> f64 {
         self.value.sum().unwrap()
     }
@@ -493,6 +497,18 @@ impl Value {
                 match self.many {
                     Some(ref ckms) => ckms.count(),
                     None => 0,
+                }
+            }
+        }
+    }
+
+    fn mean(&self) -> Option<f64> {
+        match self.kind {
+            ValueKind::Single => self.single,
+            ValueKind::Many => {
+                match self.many {
+                    Some(ref x) => x.cma(),
+                    None => None,
                 }
             }
         }

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -147,6 +147,19 @@ impl Wavefront {
                         self.stats.push_str(&tag_buf);
                         self.stats.push_str("\n");
 
+                        let mean = value.mean();
+                        self.stats.push_str(&value.name);
+                        self.stats.push_str(".mean");
+                        self.stats.push_str(" ");
+                        self.stats
+                            .push_str(get_from_cache(&mut value_cache, mean));
+                        self.stats.push_str(" ");
+                        self.stats
+                            .push_str(get_from_cache(&mut time_cache, value.timestamp));
+                        self.stats.push_str(" ");
+                        self.stats.push_str(&tag_buf);
+                        self.stats.push_str("\n");
+
                         tag_buf.clear();
                     }
                 }
@@ -335,6 +348,7 @@ mod test {
         assert!(lines.contains(&"test.timer.99 12.101 645181811 source=test-src"));
         assert!(lines.contains(&"test.timer.999 12.101 645181811 source=test-src"));
         assert!(lines.contains(&"test.timer.count 3 645181811 source=test-src"));
+        assert!(lines.contains(&"test.timer.mean 5.434333333333334 645181811 source=test-src"));
         assert!(lines.contains(&"test.raw 1 645181811 source=test-src"));
     }
 }


### PR DESCRIPTION
As of quantiles 0.4.0 it's possible to get the mean of a quantile
structure. Telemetry is now aware of its mean and we expose this
into the wavefront report, along with count.

This resolves #246

Signed-off-by: Brian L. Troutwine <blt@postmates.com>