### PR TITLE
Shift InfluxDB to use the http/s interface, not UDP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hopper 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -25,6 +26,7 @@ dependencies = [
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -586,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -609,7 +611,7 @@ dependencies = [
  "md5 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_codegen 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1047,7 +1049,7 @@ dependencies = [
 "checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
 "checksum reqwest 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bef9ed8fdfcc30947d6b774938dc0c3f369a474efe440df2c7f278180b2d2e6"
 "checksum retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29460f6011a25fc70b22010e796bd98330baccaa0005cba6f90b858a510dec0d"
-"checksum ring 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "66f03581d6c7ff60d4068ccee9bcb53982e055bda76ec7bb49d6cc44fd63c63c"
+"checksum ring 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6210568620e7b9d3f6e27f4bef63140cb88a15fbfb49b041bd3343b92c109166"
 "checksum rusoto 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de544c629614ed2d5ea19769d15ff0628c77c52f6bbfb8deab1ffe89bfdd6f2e"
 "checksum rusoto_codegen 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6abc5c06c51d596124af8bcc0af8f1e7f0073632181d979ca4f1ed46ccf14feb"
 "checksum rusoto_credential 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d0d7f808ae960d8bc1cc3d95ae4692c56d50a993b4475b19666a3159248fdc2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ flate2 = "0.2"
 glob = "0.2.11"
 hopper = "0.2.1"
 hyper = "0.10"
+hyper-native-tls = "0.2"
 lazy_static = "0.2.1"
 libc = "0.2"
 log = "0.3.6"
@@ -35,6 +36,7 @@ serde = "0.9"
 serde_derive = "0.9"
 serde_json = "0.9"
 toml = "0.2.0"
+url = "1.4.0"
 uuid = {version = "0.4", features = ["v4"]}
 
 [dev-dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -326,6 +326,12 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                      .as_integer()
                      .map(|i| i as u16)
                      .expect("could not parse sinks.influxdb.port"),
+                 secure: value
+                     .lookup("influxdb.secure")
+                     .or(value.lookup("sinks.influxdb.secure"))
+                     .unwrap_or(&Value::Boolean(true))
+                     .as_bool()
+                     .expect("could not parse sinks.influxdb.secure"),
                  host: value
                      .lookup("influxdb.host")
                      .or(value.lookup("sinks.influxdb.host"))
@@ -333,12 +339,13 @@ pub fn parse_config_file(buffer: String, verbosity: u64) -> Args {
                      .as_str()
                      .map(|s| s.to_string())
                      .expect("could not parse sinks.influxdb.host"),
-                 bin_width: value
-                     .lookup("influxdb.bin_width")
-                     .or(value.lookup("sinks.influxdb.bin_width"))
-                     .unwrap_or(&Value::Integer(1))
-                     .as_integer()
-                     .expect("could not parse sinks.influxdb.bin_width"),
+                 db: value
+                     .lookup("influxdb.db")
+                     .or(value.lookup("sinks.influxdb.db"))
+                     .unwrap_or(&Value::String("cernan".to_string()))
+                     .as_str()
+                     .map(|s| s.to_string())
+                     .expect("could not parse sinks.influxdb.db"),
                  config_path: "sinks.influxdb".to_string(),
                  tags: tags.clone(),
                  flush_interval: value
@@ -1291,7 +1298,7 @@ bin_width = 9
 [influxdb]
 port = 3131
 host = "example.com"
-bin_width = 9
+secure = false
 "#
                 .to_string();
 
@@ -1300,8 +1307,9 @@ bin_width = 9
         assert!(args.influxdb.is_some());
         let influxdb = args.influxdb.unwrap();
         assert_eq!(influxdb.host, String::from("example.com"));
+        assert_eq!(influxdb.db, String::from("cernan"));
         assert_eq!(influxdb.port, 3131);
-        assert_eq!(influxdb.bin_width, 9);
+        assert_eq!(influxdb.secure, false);
     }
 
     #[test]
@@ -1311,8 +1319,9 @@ bin_width = 9
   [sinks.influxdb]
   port = 3131
   host = "example.com"
-  bin_width = 9
+  db = "postmates"
   flush_interval = 70
+  secure = true
 "#
                 .to_string();
 
@@ -1321,9 +1330,10 @@ bin_width = 9
         assert!(args.influxdb.is_some());
         let influxdb = args.influxdb.unwrap();
         assert_eq!(influxdb.host, String::from("example.com"));
+        assert_eq!(influxdb.db, String::from("postmates"));
         assert_eq!(influxdb.port, 3131);
-        assert_eq!(influxdb.bin_width, 9);
         assert_eq!(influxdb.flush_interval, 70);
+        assert_eq!(influxdb.secure, true);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ extern crate serde;
 extern crate serde_json;
 extern crate toml;
 extern crate uuid;
+extern crate url;
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
This commit modifies the InfluxDB sink so that it uses the HTTP/S
interface of InfluxDB. Previously we were using UDP which is nice
and all but requires special support from InfluxDB operators and
is lossy, with the technique that we were using.

Best to default to reliable and slow than unreliable and fast, I
guess.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>