### PR TITLE
Introduce a 'test' dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+docker/test/Dockerfile

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:edge
+
+RUN echo '@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
+
+RUN apk add --no-cache --update \
+  alpine-sdk \
+  perl \
+  openssl-dev \
+  cargo@testing \
+  rust@testing
+
+ENV PATH=/root/.cargo/bin:$PATH
+RUN cargo install rustfmt


### PR DESCRIPTION
This will be the base of test work for cernan. The intention is that
the CI system will use this for running tests, doing auto-formatting
etc. We're a little in the hole here as alpine only provides stable
rust but oh well.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>