### PR TITLE
Explicitly add ca-certificates to the release image

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -2,12 +2,15 @@ FROM alpine:edge
 
 RUN echo '@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
 
-RUN apk add --no-cache --update \
-  llvm-libunwind@testing \ 
-  openssl
-
 RUN apk update \
   && apk upgrade --no-cache
+
+RUN apk add --no-cache --update \
+  ca-certificates \
+  llvm-libunwind@testing \ 
+  openssl && \
+  update-ca-certificates && \
+  rm -rf /var/cache/apk/*
 
 ARG DIST_ROOT="target/bindir"
 


### PR DESCRIPTION
It occurs to me that maybe the firehose issue we're seeing is a
lack of certs sitting inside the release image. If this commit
finds its way to the master branch this was the case.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>