### PR TITLE
Correct 'paniced' to 'panicked'

### DIFF
--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -262,6 +262,6 @@ fn main() {
         // TODO Having sub-threads panic will not cause a bubble-up if that
         // thread is not the currently examined one. We're going to have to have
         // some manner of sub-thread communication going on.
-        jh.join().expect("Uh oh, child thread paniced!");
+        jh.join().expect("Uh oh, child thread panicked!");
     }
 }

--- a/src/source/graphite.rs
+++ b/src/source/graphite.rs
@@ -131,7 +131,7 @@ impl Source for Graphite {
             // TODO Having sub-threads panic will not cause a bubble-up if that
             // thread is not the currently examined one. We're going to have to have
             // some manner of sub-thread communication going on.
-            jh.join().expect("Uh oh, child thread paniced!");
+            jh.join().expect("Uh oh, child thread panicked!");
         }
     }
 }

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -156,6 +156,6 @@ impl Source for NativeServer {
         info!("server started on {}:{}", self.ip, self.port);
         let jh = thread::spawn(move || handle_tcp(chans, tags, listener));
 
-        jh.join().expect("Uh oh, child thread paniced!");
+        jh.join().expect("Uh oh, child thread panicked!");
     }
 }

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -111,7 +111,7 @@ impl Source for Statsd {
             // TODO Having sub-threads panic will not cause a bubble-up if that
             // thread is not the currently examined one. We're going to have to have
             // some manner of sub-thread communication going on.
-            jh.join().expect("Uh oh, child thread paniced!");
+            jh.join().expect("Uh oh, child thread panicked!");
         }
     }
 }


### PR DESCRIPTION
It turns out I cannot spell the word 'panicked'. Thanks to @kballard
for noticing.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>