### PR TITLE
Fix the name mangling issue with self-telemetry

### DIFF
--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -2,7 +2,7 @@ use glob::glob;
 use metric;
 use seahash::SeaHasher;
 use source::Source;
-use source::internal::report_telemetry;
+use source::internal::report_full_telemetry;
 use std::collections::HashMap;
 use std::fs;
 use std::hash::BuildHasherDefault;
@@ -124,9 +124,11 @@ impl FileWatcher {
             let ino = metadata.ino();
 
             if (dev, ino) != self.file_id {
-                report_telemetry(format!("cernan.sources.file.{}.switch",
-                                         &self.path.to_str().expect("could not make path")),
-                                 1.0);
+                report_full_telemetry("cernan.sources.file.switch",
+                                 1.0,
+                                 None,
+                                 Some(vec![("file_path",
+                                            &self.path.to_str().expect("could not make path"))]));
                 if let Ok(f) = fs::File::open(&self.path) {
                     self.file_id = (dev, ino);
                     self.reader = io::BufReader::new(f);
@@ -263,9 +265,11 @@ impl Source for FileServer {
                                     lines_read += 1;
                                     buffer.pop();
                                     let path_name = file.path.to_str().expect("could not make path_name");
-                                    report_telemetry(format!("cernan.sources.file.{}.lines_read",
-                                                             path_name),
-                                                     1.0);
+                                    report_full_telemetry("cernan.sources.file.lines_read",
+                                                          1.0,
+                                                          None,
+                                                          Some(vec![("file_path",
+                                                                     path_name)]));
                                     trace!("{} | {}", path_name, buffer);
                                     lines.push(metric::LogLine::new(path_name, &buffer).overlay_tags_from_map(&self.tags));
                                     buffer.clear();

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -8,7 +8,8 @@ mod statsd;
 pub use self::file::{FileServer, FileServerConfig};
 pub use self::flush::FlushTimer;
 pub use self::graphite::{Graphite, GraphiteConfig};
-pub use self::internal::{Internal, InternalConfig, report_telemetry};
+pub use self::internal::{Internal, InternalConfig, report_full_telemetry,
+                         report_telemetry};
 pub use self::native::{NativeServer, NativeServerConfig};
 pub use self::statsd::{Statsd, StatsdConfig};
 


### PR DESCRIPTION
When the internal metric source was created we implicitly encoded
a graphite-like scheme for metric naming, which, since cernan intends
to be agnostic to sink, was not ideal. This commit corrects that
mistake, allowing callers to report_telemetry to expand their
use to report_full_telemetry, a function which admits metadata and
changing the aggregation type.

This resolves #262

Signed-off-by: Brian L. Troutwine <blt@postmates.com>
