### PR TITLE
Add minimal error handling for empty host names for wavefront

### DIFF
--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -105,8 +105,16 @@ fn main() {
             .unwrap();
         sends.insert(config_path.clone(), wf_send);
         joins.push(thread::spawn(move || {
-                                     cernan::sink::Wavefront::new(config).run(wf_recv);
-                                 }));
+            match cernan::sink::Wavefront::new(config) {
+                Ok(mut w) => {
+                    w.run(wf_recv);
+                }
+                Err(e) => {
+                    error!("Configuration error for Wavefront: {}", e);
+                    process::exit(1);
+                }
+            }
+        }));
     }
     if let Some(config) = mem::replace(&mut args.prometheus, None) {
         let config_path = cfg_conf!(config);

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -303,7 +303,7 @@ mod test {
             percentiles: percentiles,
             flush_interval: 60,
         };
-        let mut wavefront = Wavefront::new(config);
+        let mut wavefront = Wavefront::new(config).unwrap();
         let dt_0 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 11, 00).timestamp();
         let dt_1 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 12, 00).timestamp();
         let dt_2 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 13, 00).timestamp();

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -89,16 +89,19 @@ fn get_from_cache<T>(cache: &mut Vec<(T, String)>, val: T) -> &str
 }
 
 impl Wavefront {
-    pub fn new(config: WavefrontConfig) -> Wavefront {
-        Wavefront {
-            host: config.host,
-            port: config.port,
-            aggrs: Buckets::new(config.bin_width),
-            delivery_attempts: 0,
-            percentiles: config.percentiles,
-            stats: String::with_capacity(8_192),
-            flush_interval: config.flush_interval,
+    pub fn new(config: WavefrontConfig) -> Result<Wavefront, String> {
+        if config.host == "" {
+            return Err("Host can not be empty".to_string());
         }
+        Ok(Wavefront {
+               host: config.host,
+               port: config.port,
+               aggrs: Buckets::new(config.bin_width),
+               delivery_attempts: 0,
+               percentiles: config.percentiles,
+               stats: String::with_capacity(8_192),
+               flush_interval: config.flush_interval,
+           })
     }
 
     /// Convert the buckets into a String that


### PR DESCRIPTION
Instead of later panicking, make Wavefront::new return a Result and
match on that.

Fixes: https://github.com/postmates/cernan/issues/224