### PR TITLE
Correct our use of Arbitrary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,6 @@ dependencies = [
  "protobuf 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quantiles 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_firehose 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ log = "0.3.6"
 lua = { git = "https://github.com/blt/rust-lua53.git", branch = "master" }
 protobuf = "1.2"
 quantiles = { version = "0.5", features = ["serde_support"] }
-rand = "0.3"
 seahash = "3.0"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"

--- a/benches/buckets.rs
+++ b/benches/buckets.rs
@@ -3,14 +3,12 @@
 extern crate test;
 extern crate cernan;
 extern crate chrono;
-extern crate rand;
 
 use self::test::Bencher;
 use cernan::buckets;
 use cernan::metric::Telemetry;
 
 use chrono::{TimeZone, UTC};
-use rand::Rng;
 
 #[bench]
 fn bench_single_timer(b: &mut Bencher) {
@@ -65,21 +63,6 @@ fn bench_single_timer_1000(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_single_timer_rand_1000(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
-
-    b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
-        let mut rng = rand::thread_rng();
-
-        for _ in 0..1000 {
-            let i: usize = rng.gen_range(0, 1000);
-            bucket.add(Telemetry::new("a", i as f64).timestamp(dt_0).aggr_summarize());
-        }
-    });
-}
-
-#[bench]
 fn bench_single_timer_10000(b: &mut Bencher) {
     let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
 
@@ -88,21 +71,6 @@ fn bench_single_timer_10000(b: &mut Bencher) {
 
         for _ in 0..10000 {
             bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
-        }
-    });
-}
-
-#[bench]
-fn bench_single_timer_rand_10000(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
-
-    b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
-        let mut rng = rand::thread_rng();
-
-        for _ in 0..10000 {
-            let i: usize = rng.gen_range(0, 10000);
-            bucket.add(Telemetry::new("a", i as f64).timestamp(dt_0).aggr_summarize());
         }
     });
 }
@@ -132,21 +100,6 @@ fn bench_single_histogram_100(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_single_histogram_rand_100(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
-
-    b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
-        let mut rng = rand::thread_rng();
-
-        for _ in 0..100 {
-            let i: usize = rng.gen_range(0, 100);
-            bucket.add(Telemetry::new("a", i as f64).timestamp(dt_0).aggr_summarize());
-        }
-    });
-}
-
-#[bench]
 fn bench_single_histogram_1000(b: &mut Bencher) {
     let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
 
@@ -160,21 +113,6 @@ fn bench_single_histogram_1000(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_single_histogram_rand_1000(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
-
-    b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
-        let mut rng = rand::thread_rng();
-
-        for _ in 0..1_000 {
-            let i: usize = rng.gen_range(0, 1_000);
-            bucket.add(Telemetry::new("a", i as f64).timestamp(dt_0).aggr_summarize());
-        }
-    });
-}
-
-#[bench]
 fn bench_single_histogram_10000(b: &mut Bencher) {
     let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
 
@@ -183,21 +121,6 @@ fn bench_single_histogram_10000(b: &mut Bencher) {
 
         for _ in 0..10_000 {
             bucket.add(Telemetry::new("a", 1.0).timestamp(dt_0).aggr_summarize());
-        }
-    });
-}
-
-#[bench]
-fn bench_single_histogram_rand_10000(b: &mut Bencher) {
-    let dt_0 = UTC.ymd(1972, 12, 11).and_hms_milli(11, 59, 49, 0).timestamp();
-
-    b.iter(|| {
-        let mut bucket = buckets::Buckets::default();
-        let mut rng = rand::thread_rng();
-
-        for _ in 0..10_000 {
-            let i: usize = rng.gen_range(0, 10_000);
-            bucket.add(Telemetry::new("a", i as f64).timestamp(dt_0).aggr_summarize());
         }
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,6 @@ extern crate libc;
 extern crate lua;
 extern crate protobuf;
 extern crate quantiles;
-extern crate rand;
 extern crate rusoto_core;
 extern crate rusoto_firehose;
 extern crate seahash;
@@ -48,6 +47,9 @@ extern crate lazy_static;
 
 #[macro_use]
 extern crate serde_derive;
+
+#[cfg(test)]
+extern crate quickcheck;
 
 pub mod sink;
 pub mod buckets;

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -357,27 +357,17 @@ impl Sink for Prometheus {
 
 #[cfg(test)]
 mod test {
-    extern crate quickcheck;
-    extern crate rand;
-
-    use self::quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
-    use self::rand::{Rand, Rng};
     use super::*;
     use metric;
-
-    impl Rand for PrometheusAggr {
-        fn rand<R: Rng>(rng: &mut R) -> PrometheusAggr {
-            let total_inner_sz: usize = rng.gen_range(0, 256);
-            let mut inner: Vec<metric::Telemetry> =
-                rng.gen_iter::<metric::Telemetry>().take(total_inner_sz).collect();
-            inner.sort_by(|a, b| prometheus_cmp(a, b).unwrap());
-            PrometheusAggr { inner: inner }
-        }
-    }
+    use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
 
     impl Arbitrary for PrometheusAggr {
-        fn arbitrary<G: Gen>(g: &mut G) -> PrometheusAggr {
-            g.gen()
+        fn arbitrary<G>(g: &mut G) -> Self
+            where G: Gen
+        {
+            let mut inner: Vec<metric::Telemetry> = Arbitrary::arbitrary(g);
+            inner.sort_by(|a, b| prometheus_cmp(a, b).unwrap());
+            PrometheusAggr { inner: inner }
         }
     }
 

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -302,13 +302,10 @@ impl Source for FileServer {
 
 #[cfg(test)]
 mod test {
-    extern crate quickcheck;
-    extern crate rand;
     extern crate tempdir;
 
-    use self::quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
-    use self::rand::{Rand, Rng};
     use super::*;
+    use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
     use std::fs;
 
     // actions that apply to a single FileWatcher
@@ -322,19 +319,15 @@ mod test {
     }
 
     impl Arbitrary for FWAction {
-        fn arbitrary<G: Gen>(g: &mut G) -> FWAction {
-            g.gen()
-        }
-    }
-
-    impl Rand for FWAction {
-        fn rand<R: Rng>(rng: &mut R) -> FWAction {
-            let i: usize = rng.gen_range(0, 100);
-            let ln_sz = rng.gen_range(0, 256);
-            let pause = rng.gen_range(1, 3);
+        fn arbitrary<G>(g: &mut G) -> FWAction
+            where G: Gen
+        {
+            let i: usize = g.gen_range(0, 100);
+            let ln_sz = g.gen_range(0, 256);
+            let pause = g.gen_range(1, 3);
             match i {
                 0...50 => {
-                    FWAction::WriteLine(rng.gen_ascii_chars().take(ln_sz).collect())
+                    FWAction::WriteLine(g.gen_ascii_chars().take(ln_sz).collect())
                 }
                 51...75 => FWAction::Pause(pause),
                 76...85 => FWAction::RotateFile,


### PR DESCRIPTION
Because I didn't rightly misunderstand how to write these out
when cernan started there was a pattern of Rand + Arbitrary through
the codebase. We only needed Arbitrary. This is now corrected. Little
has changed but the code is somewhat cleaner as a result.

We've dropped the explicit dependency on rand.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>