### PR TITLE
Correct prefix issue in Elasticsearch sink

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -410,9 +410,9 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
 
                 res.index_prefix = snk.get("index-prefix")
                     .map(|p| {
-                             p.as_str()
+                        Some(p.as_str()
                                  .expect("could not parse sinks.elasticsearch.index-prefix")
-                                 .to_string()
+                                 .to_string())
                          })
                     .unwrap_or(res.index_prefix);
                 
@@ -852,7 +852,7 @@ scripts-directory = "/foo/bar"
 
         assert_eq!(es.port, 1234);
         assert_eq!(es.host, "example.com");
-        assert_eq!(es.index_prefix, "prefix-");
+        assert_eq!(es.index_prefix, Some("prefix-".into()));
         assert_eq!(es.secure, true);
         assert_eq!(es.flush_interval, 2020);
     }

--- a/src/sink/elasticsearch.rs
+++ b/src/sink/elasticsearch.rs
@@ -25,7 +25,7 @@ struct Payload {
 #[derive(Debug, Clone)]
 pub struct ElasticsearchConfig {
     pub config_path: Option<String>,
-    pub index_prefix: String,
+    pub index_prefix: Option<String>,
     pub secure: bool, // whether http or https
     pub host: String,
     pub port: usize,
@@ -38,7 +38,7 @@ impl Default for ElasticsearchConfig {
             config_path: Some("sinks.elasticsearch".to_string()),
             secure: false,
             host: "127.0.0.1".to_string(),
-            index_prefix: "".to_string(),
+            index_prefix: None,
             port: 9200,
             flush_interval: 10,
         }
@@ -48,7 +48,7 @@ impl Default for ElasticsearchConfig {
 pub struct Elasticsearch {
     buffer: VecDeque<LogLine>,
     client: Client,
-    index_prefix: String,
+    index_prefix: Option<String>,
     flush_interval: u64,
 }
 
@@ -180,8 +180,11 @@ fn format_time(time: i64) -> String {
 }
 
 #[inline]
-fn idx(prefix: &str, time: i64) -> String {
+fn idx(prefix: &Option<String>, time: i64) -> String {
     let naive_time = NaiveDateTime::from_timestamp(time, 0);
     let utc_time: DateTime<UTC> = DateTime::from_utc(naive_time, UTC);
-    format!("{}-{}", prefix, utc_time.format("%Y-%m-%d"))
+    match prefix {
+        &Some(ref p) => format!("{}-{}", p, utc_time.format("%Y-%m-%d")),
+        &None => format!("{}", utc_time.format("%Y-%m-%d")),
+    }
 }


### PR DESCRIPTION
When a prefix is not specified we were still dropping the '-' ahead
of the YYYY-MM-DD index. This is corrected by judicious use of Option.

Fixes #269

Signed-off-by: Brian L. Troutwine <blt@postmates.com>