### PR TITLE
Telemetry guaranteed error configurable

### DIFF
--- a/examples/configs/basic.toml
+++ b/examples/configs/basic.toml
@@ -3,6 +3,8 @@ scripts-directory = "examples/scripts/"
 
 flush-interval = 5
 
+telemetry-error = 0.005
+
 [tags]
 source = "cernan"
 

--- a/examples/configs/basic.toml
+++ b/examples/configs/basic.toml
@@ -3,7 +3,7 @@ scripts-directory = "examples/scripts/"
 
 flush-interval = 5
 
-telemetry-error = 0.005
+telemetry-error-bound = 0.005
 
 [tags]
 source = "cernan"

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -83,7 +83,7 @@ impl Buckets {
     /// ```
     /// extern crate cernan;
     ///
-    /// let metric = cernan::metric::Telemetry::new("foo", 1.0).aggr_sum();
+    /// let metric = cernan::metric::Telemetry::new("foo", 1.0, 0.001).aggr_sum();
     /// let mut buckets = cernan::buckets::Buckets::default();
     ///
     /// assert_eq!(true, buckets.is_empty());
@@ -121,7 +121,7 @@ impl Buckets {
     /// ```
     /// extern crate cernan;
     ///
-    /// let metric = cernan::metric::Telemetry::new("foo", 1.0).aggr_sum();
+    /// let metric = cernan::metric::Telemetry::new("foo", 1.0, 0.001).aggr_sum();
     /// let mut bucket = cernan::buckets::Buckets::default();
     /// bucket.add(metric);
     /// ```
@@ -200,9 +200,9 @@ mod test {
         //  * an ephemeral SET|SUM will have its value inherited by a persist SET|SUM
         //  * an ephemeral SET|SUM will not inherit the value of a persist SET|SUM
         let bin_width = 1;
-        let m0 = Telemetry::new("lO", 1.0).timestamp(0).aggr_set().ephemeral();
-        let m1 = Telemetry::new("lO", 2.0).timestamp(1).aggr_sum().persist();
-        let m2 = Telemetry::new("lO", 0.0).timestamp(1).aggr_set().ephemeral();
+        let m0 = Telemetry::new("lO", 1.0, 0.001).timestamp(0).aggr_set().ephemeral();
+        let m1 = Telemetry::new("lO", 2.0, 0.001).timestamp(1).aggr_sum().persist();
+        let m2 = Telemetry::new("lO", 0.0, 0.001).timestamp(1).aggr_set().ephemeral();
 
         let mut bkt = Buckets::new(bin_width);
         bkt.add(m0);
@@ -237,9 +237,9 @@ mod test {
     #[test]
     fn raw_test_variable() {
         let bin_width = 66;
-        let m0 = Telemetry::new("lO", 0.807).timestamp(18).aggr_set();
-        let m4 = Telemetry::new("lO", 0.361).timestamp(75).aggr_set();
-        let m7 = Telemetry::new("lO", 0.291).timestamp(42).aggr_set();
+        let m0 = Telemetry::new("lO", 0.807, 0.001).timestamp(18).aggr_set();
+        let m4 = Telemetry::new("lO", 0.361, 0.001).timestamp(75).aggr_set();
+        let m7 = Telemetry::new("lO", 0.291, 0.001).timestamp(42).aggr_set();
 
         let mut bkt = Buckets::new(bin_width);
         bkt.add(m0);
@@ -256,9 +256,9 @@ mod test {
     #[test]
     fn test_gauge_small_bin_width() {
         let bin_width = 1;
-        let m0 = Telemetry::new("lO", 3.211).timestamp(645181811).aggr_set();
-        let m1 = Telemetry::new("lO", 4.322).timestamp(645181812).aggr_set();
-        let m2 = Telemetry::new("lO", 5.433).timestamp(645181813).aggr_set();
+        let m0 = Telemetry::new("lO", 3.211, 0.001).timestamp(645181811).aggr_set();
+        let m1 = Telemetry::new("lO", 4.322, 0.001).timestamp(645181812).aggr_set();
+        let m2 = Telemetry::new("lO", 5.433, 0.001).timestamp(645181813).aggr_set();
 
         let mut bkt = Buckets::new(bin_width);
         bkt.add(m0);
@@ -336,11 +336,11 @@ mod test {
     #[test]
     fn test_add_gauge_metric_distinct_tags() {
         let mut buckets = Buckets::default();
-        let m0 = Telemetry::new("some.metric", 1.0)
+        let m0 = Telemetry::new("some.metric", 1.0, 0.001)
             .aggr_set()
             .timestamp(10)
             .overlay_tag("foo", "bar");
-        let m1 = Telemetry::new("some.metric", 1.0)
+        let m1 = Telemetry::new("some.metric", 1.0, 0.001)
             .aggr_set()
             .timestamp(10)
             .overlay_tag("foo", "bingo");
@@ -358,7 +358,7 @@ mod test {
     #[test]
     fn test_add_counter_metric() {
         let mut buckets = Buckets::default();
-        let metric = Telemetry::new("some.metric", 1.0).aggr_sum();
+        let metric = Telemetry::new("some.metric", 1.0, 0.001).aggr_sum();
         buckets.add(metric.clone());
 
         let rmname = String::from("some.metric");
@@ -373,7 +373,7 @@ mod test {
     #[test]
     fn test_reset_add_counter_metric() {
         let mut buckets = Buckets::default();
-        let m0 = Telemetry::new("some.metric", 1.0).aggr_sum().timestamp(101);
+        let m0 = Telemetry::new("some.metric", 1.0, 0.001).aggr_sum().timestamp(101);
         let m1 = m0.clone();
 
         buckets.add(m0);
@@ -399,9 +399,9 @@ mod test {
         let dt_2 = UTC.ymd(1996, 10, 7).and_hms_milli(10, 11, 13, 0).timestamp();
 
         let name = String::from("some.metric");
-        let m0 = Telemetry::new("some.metric", 1.0).timestamp(dt_0).aggr_summarize();
-        let m1 = Telemetry::new("some.metric", 2.0).timestamp(dt_1).aggr_summarize();
-        let m2 = Telemetry::new("some.metric", 3.0).timestamp(dt_2).aggr_summarize();
+        let m0 = Telemetry::new("some.metric", 1.0, 0.001).timestamp(dt_0).aggr_summarize();
+        let m1 = Telemetry::new("some.metric", 2.0, 0.001).timestamp(dt_1).aggr_summarize();
+        let m2 = Telemetry::new("some.metric", 3.0, 0.001).timestamp(dt_2).aggr_summarize();
 
         buckets.add(m0.clone());
         buckets.add(m1.clone());
@@ -432,7 +432,7 @@ mod test {
     #[test]
     fn test_add_histogram_metric_reset() {
         let mut buckets = Buckets::default();
-        let metric = Telemetry::new("some.metric", 1.0).aggr_summarize();
+        let metric = Telemetry::new("some.metric", 1.0, 0.001).aggr_summarize();
         buckets.add(metric.clone());
 
         buckets.reset();
@@ -442,7 +442,7 @@ mod test {
     #[test]
     fn test_add_timer_metric_reset() {
         let mut buckets = Buckets::default();
-        let metric = Telemetry::new("some.metric", 1.0).aggr_summarize();
+        let metric = Telemetry::new("some.metric", 1.0, 0.001).aggr_summarize();
         buckets.add(metric.clone());
 
         buckets.reset();
@@ -453,7 +453,7 @@ mod test {
     fn test_add_gauge_metric() {
         let mut buckets = Buckets::default();
         let rmname = String::from("some.metric");
-        let metric = Telemetry::new("some.metric", 11.5).aggr_set();
+        let metric = Telemetry::new("some.metric", 11.5, 0.001).aggr_set();
         buckets.add(metric);
         assert_eq!(Some(11.5), buckets.get(&rmname).unwrap()[0].value());
         assert_eq!(1, buckets.count());
@@ -467,10 +467,10 @@ mod test {
         // require this explicit reset, only the +/- on the metric value.
         let mut buckets = Buckets::default();
         let rmname = String::from("some.metric");
-        let metric = Telemetry::new("some.metric", 100.0).timestamp(0).aggr_set();
+        let metric = Telemetry::new("some.metric", 100.0, 0.001).timestamp(0).aggr_set();
         buckets.add(metric);
         let delta_metric =
-            Telemetry::new("some.metric", -11.5).timestamp(0).aggr_sum().persist();
+            Telemetry::new("some.metric", -11.5, 0.001).timestamp(0).aggr_sum().persist();
         buckets.add(delta_metric);
         assert_eq!(Some(88.5), buckets.get(&rmname).unwrap()[0].value());
         assert_eq!(1, buckets.count());
@@ -482,11 +482,11 @@ mod test {
     fn test_reset_add_delta_gauge_metric() {
         let mut buckets = Buckets::default();
         let rmname = String::from("some.metric");
-        let metric = Telemetry::new("some.metric", 100.0).aggr_set();
+        let metric = Telemetry::new("some.metric", 100.0, 0.001).aggr_set();
         buckets.add(metric);
-        let delta_metric = Telemetry::new("some.metric", -11.5).aggr_sum().persist();
+        let delta_metric = Telemetry::new("some.metric", -11.5, 0.001).aggr_sum().persist();
         buckets.add(delta_metric);
-        let reset_metric = Telemetry::new("some.metric", 2007.3).aggr_set();
+        let reset_metric = Telemetry::new("some.metric", 2007.3, 0.001).aggr_set();
         buckets.add(reset_metric);
         assert_eq!(Some(2007.3), buckets.get(&rmname).unwrap()[0].value());
         assert_eq!(1, buckets.count());
@@ -496,16 +496,16 @@ mod test {
     fn test_add_timer_metric() {
         let mut buckets = Buckets::default();
         let rmname = String::from("some.metric");
-        let metric = Telemetry::new("some.metric", 11.5).aggr_sum();
+        let metric = Telemetry::new("some.metric", 11.5, 0.001).aggr_sum();
         buckets.add(metric);
         assert_eq!(Some(11.5),
                    buckets.get(&rmname).expect("hwhap")[0].query(0.0));
 
-        let metric_two = Telemetry::new("some.metric", 99.5).aggr_sum();
+        let metric_two = Telemetry::new("some.metric", 99.5, 0.001).aggr_sum();
         buckets.add(metric_two);
 
         let romname = String::from("other.metric");
-        let metric_three = Telemetry::new("other.metric", 811.5).aggr_sum();
+        let metric_three = Telemetry::new("other.metric", 811.5, 0.001).aggr_sum();
         buckets.add(metric_three);
         assert_eq!(Some(811.5),
                    buckets.get(&romname).expect("hwhap")[0].query(0.0));
@@ -517,10 +517,10 @@ mod test {
         let dt_0 = UTC.ymd(2016, 9, 13).and_hms_milli(11, 30, 0, 0).timestamp();
         let dt_1 = UTC.ymd(2016, 9, 13).and_hms_milli(11, 30, 1, 0).timestamp();
 
-        buckets.add(Telemetry::new("some.metric", 1.0).timestamp(dt_0).aggr_set());
-        buckets.add(Telemetry::new("some.metric", 2.0).timestamp(dt_0).aggr_set());
-        buckets.add(Telemetry::new("some.metric", 3.0).timestamp(dt_0).aggr_set());
-        buckets.add(Telemetry::new("some.metric", 4.0).timestamp(dt_1).aggr_set());
+        buckets.add(Telemetry::new("some.metric", 1.0, 0.001).timestamp(dt_0).aggr_set());
+        buckets.add(Telemetry::new("some.metric", 2.0, 0.001).timestamp(dt_0).aggr_set());
+        buckets.add(Telemetry::new("some.metric", 3.0, 0.001).timestamp(dt_0).aggr_set());
+        buckets.add(Telemetry::new("some.metric", 4.0, 0.001).timestamp(dt_1).aggr_set());
 
         let mname = String::from("some.metric");
         let metrics = buckets.get(&mname).unwrap();
@@ -628,8 +628,8 @@ mod test {
     fn test_gauge_insertion() {
         let mut buckets = Buckets::default();
 
-        let m0 = Telemetry::new("test.gauge_0", 1.0).aggr_set();
-        let m1 = Telemetry::new("test.gauge_1", 1.0).aggr_set();
+        let m0 = Telemetry::new("test.gauge_0", 1.0, 0.001).aggr_set();
+        let m1 = Telemetry::new("test.gauge_1", 1.0, 0.001).aggr_set();
         buckets.add(m0.clone());
         buckets.add(m1.clone());
 
@@ -641,8 +641,8 @@ mod test {
     fn test_counter_insertion() {
         let mut buckets = Buckets::default();
 
-        let m0 = Telemetry::new("test.counter_0", 1.0).aggr_sum();
-        let m1 = Telemetry::new("test.counter_1", 1.0).aggr_sum();
+        let m0 = Telemetry::new("test.counter_0", 1.0, 0.001).aggr_sum();
+        let m1 = Telemetry::new("test.counter_1", 1.0, 0.001).aggr_sum();
         buckets.add(m0.clone());
         buckets.add(m1.clone());
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -316,6 +316,13 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                          })
                     .unwrap_or(args.flush_interval);
 
+                res.telemetry_error_bound = snk.get("telemetry_error_bound")
+                    .map(|fi| {
+                             fi.as_float()
+                                 .expect("could not parse sinks.wavefront.telemetry_error_bound")
+                         })
+                    .unwrap_or(args.telemetry_error_bound);
+
                 res.tags = global_tags.clone();
 
                 res
@@ -358,6 +365,12 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                              u64
                          })
                     .unwrap_or(args.flush_interval);
+
+                res.telemetry_error_bound = snk.get("telemetry_error_bound")
+                    .map(|fi| { fi.as_float()
+                                .expect("could not parse sinks.influxdb.telemetry_error_bound")
+                         })
+                    .unwrap_or(args.telemetry_error_bound);
 
                 res.telemetry_error_bound = args.telemetry_error_bound;
 
@@ -445,6 +458,12 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                          })
                     .unwrap_or(args.flush_interval);
 
+                res.telemetry_error_bound = snk.get("telemetry_error_bound")
+                    .map(|fi| { fi.as_float()
+                                .expect("could not parse sinks.elasticsearch.telemetry_error_bound")
+                         })
+                    .unwrap_or(args.telemetry_error_bound);
+
                 res.telemetry_error_bound = args.telemetry_error_bound;
 
                 res
@@ -502,6 +521,12 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                                  u64
                              })
                         .unwrap_or(args.flush_interval);
+
+                    res.telemetry_error_bound = tbl.get("telemetry_error_bound")
+                        .map(|fi| { fi.as_float()
+                                    .expect("could not parse sinks.firehose.telemetry_error_bound")
+                             })
+                        .unwrap_or(args.telemetry_error_bound);
 
                     res.batch_size = tbl.get("batch_size")
                         .map(|fi| {

--- a/src/config.rs
+++ b/src/config.rs
@@ -372,8 +372,6 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                          })
                     .unwrap_or(args.telemetry_error_bound);
 
-                res.telemetry_error_bound = args.telemetry_error_bound;
-
                 res.tags = global_tags.clone();
 
                 res
@@ -408,7 +406,12 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                     })
                     .unwrap_or(res.bin_width);
 
-                res.telemetry_error_bound = args.telemetry_error_bound;
+                res.telemetry_error_bound = snk.get("telemetry_error_bound")
+                    .map(|fi| { fi.as_float()
+                                .expect("could not parse sinks.prometheus.telemetry_error_bound")
+                         })
+                    .unwrap_or(args.telemetry_error_bound);
+
 
                 res
             });
@@ -463,8 +466,6 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                                 .expect("could not parse sinks.elasticsearch.telemetry_error_bound")
                          })
                     .unwrap_or(args.telemetry_error_bound);
-
-                res.telemetry_error_bound = args.telemetry_error_bound;
 
                 res
             });
@@ -1206,7 +1207,7 @@ scripts-directory = "/foo/bar"
         assert_eq!(prometheus.host, String::from("example.com"));
         assert_eq!(prometheus.port, 3131);
         assert_eq!(prometheus.bin_width, 9);
-        assert_eq!(prometheus.telemetry_error_bound, 0.003);
+        assert_eq!(prometheus.telemetry_error_bound, 0.005);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -918,6 +918,7 @@ scripts-directory = "/foo/bar"
   index-prefix = "prefix-"
   secure = true
   flush_interval = 2020
+  telemetry_error_bound = 0.002
 "#;
 
         let args = parse_config_file(config, 4);
@@ -930,6 +931,7 @@ scripts-directory = "/foo/bar"
         assert_eq!(es.index_prefix, Some("prefix-".into()));
         assert_eq!(es.secure, true);
         assert_eq!(es.flush_interval, 2020);
+        assert_eq!(es.telemetry_error_bound, 0.002);
     }
 
     #[test]
@@ -1117,6 +1119,7 @@ scripts-directory = "/foo/bar"
       host = "example.com"
       bin_width = 9
       flush_interval = 15
+      telemetry_error_bound = 0.002
     "#;
 
         let args = parse_config_file(config, 4);
@@ -1127,6 +1130,7 @@ scripts-directory = "/foo/bar"
         assert_eq!(wavefront.port, 3131);
         assert_eq!(wavefront.bin_width, 9);
         assert_eq!(wavefront.flush_interval, 15);
+        assert_eq!(wavefront.telemetry_error_bound, 0.002);
     }
 
     #[test]
@@ -1151,6 +1155,7 @@ scripts-directory = "/foo/bar"
         assert_eq!(wavefront.host, String::from("example.com"));
         assert_eq!(wavefront.port, 3131);
         assert_eq!(wavefront.bin_width, 9);
+        assert_eq!(wavefront.telemetry_error_bound, 0.001);
 
         assert_eq!(wavefront.percentiles.len(), 3);
         assert_eq!(wavefront.percentiles[0], ("max".to_string(), 1.0));
@@ -1168,6 +1173,7 @@ scripts-directory = "/foo/bar"
       db = "postmates"
       flush_interval = 70
       secure = true
+      telemetry_error_bound = 0.003
     "#;
 
         let args = parse_config_file(config, 4);
@@ -1179,6 +1185,7 @@ scripts-directory = "/foo/bar"
         assert_eq!(influxdb.port, 3131);
         assert_eq!(influxdb.flush_interval, 70);
         assert_eq!(influxdb.secure, true);
+        assert_eq!(influxdb.telemetry_error_bound, 0.003);
     }
 
     #[test]
@@ -1189,6 +1196,7 @@ scripts-directory = "/foo/bar"
       port = 3131
       host = "example.com"
       bin_width = 9
+      telemetry_error_bound = 0.005
     "#;
 
         let args = parse_config_file(config, 4);
@@ -1198,6 +1206,7 @@ scripts-directory = "/foo/bar"
         assert_eq!(prometheus.host, String::from("example.com"));
         assert_eq!(prometheus.port, 3131);
         assert_eq!(prometheus.bin_width, 9);
+        assert_eq!(prometheus.telemetry_error_bound, 0.003);
     }
 
     #[test]
@@ -1237,6 +1246,7 @@ scripts-directory = "/foo/bar"
       batch_size = 20
       flush_interval = 15
       region = "us-west-2"
+      telemetry_error_bound = 0.006
 
       [sinks.firehose.stream_two]
       delivery_stream = "stream_two"
@@ -1253,11 +1263,13 @@ scripts-directory = "/foo/bar"
         assert_eq!(firehosen[0].batch_size, 20);
         assert_eq!(firehosen[0].region, Some(Region::UsWest2));
         assert_eq!(firehosen[0].flush_interval, 15);
+        assert_eq!(firehosen[0].telemetry_error_bound, 0.006);
 
         assert_eq!(firehosen[1].delivery_stream, Some("stream_two".to_string()));
         assert_eq!(firehosen[1].batch_size, 800);
         assert_eq!(firehosen[1].region, Some(Region::UsEast1));
         assert_eq!(firehosen[1].flush_interval, 60); // default
+        assert_eq!(firehosen[1].telemetry_error_bound, 0.001);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -221,6 +221,7 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                             forwards: fwds,
                             config_path: Some(config_path.clone()),
                             tags: global_tags.clone(),
+                            telemetry_error: args.telemetry_error,
                         };
                         filters.insert(config_path, config);
                     }
@@ -358,6 +359,8 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                          })
                     .unwrap_or(args.flush_interval);
 
+                res.telemetry_error = args.telemetry_error;
+
                 res.tags = global_tags.clone();
 
                 res
@@ -391,6 +394,8 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                                  .expect("could not parse sinks.prometheus.bin_width")
                     })
                     .unwrap_or(res.bin_width);
+
+                res.telemetry_error = args.telemetry_error;
 
                 res
             });
@@ -439,6 +444,8 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                              u64
                          })
                     .unwrap_or(args.flush_interval);
+
+                res.telemetry_error = args.telemetry_error;
 
                 res
             });
@@ -619,6 +626,8 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
 
                         res.tags = global_tags.clone();
 
+                        res.telemetry_error = args.telemetry_error;
+
                         assert!(res.config_path.is_some());
                         assert!(!res.forwards.is_empty());
 
@@ -665,6 +674,8 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                             .unwrap_or(res.forwards);
 
                         res.tags = global_tags.clone();
+
+                        res.telemetry_error = args.telemetry_error;
 
                         assert!(res.config_path.is_some());
                         assert!(!res.forwards.is_empty());
@@ -744,6 +755,8 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                     .unwrap_or(res.forwards);
 
                 res.tags = global_tags.clone();
+
+                res.telemetry_error = args.telemetry_error;
 
                 res
             })

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,7 +54,7 @@ pub struct Args {
     pub data_directory: PathBuf,
     pub scripts_directory: PathBuf,
     pub flush_interval: u64,
-    pub telemetry_error: f64,
+    pub telemetry_error_bound: f64,
     pub verbose: u64,
     pub version: String,
     // filters
@@ -82,7 +82,7 @@ impl Default for Args {
             data_directory: default_data_directory(),
             scripts_directory: default_scripts_directory(),
             flush_interval: 60,
-            telemetry_error: DEFAULT_TELEMETRY_ERROR,
+            telemetry_error_bound: DEFAULT_TELEMETRY_ERROR,
             version: default_version(),
             verbose: 0,
             // filters
@@ -174,10 +174,10 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
         .map(|fi| fi.as_integer().expect("could not parse flush-interval") as u64)
         .unwrap_or(args.flush_interval);
 
-    args.telemetry_error = value
+    args.telemetry_error_bound = value
         .get("telemetry-error-bound")
         .map(|fi| fi.as_float().expect("could not parse telemetry-error-bound"))
-        .unwrap_or(args.telemetry_error);
+        .unwrap_or(args.telemetry_error_bound);
 
     let global_tags: TagMap = match value.get("tags") {
         Some(tbl) => {
@@ -221,7 +221,7 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                             forwards: fwds,
                             config_path: Some(config_path.clone()),
                             tags: global_tags.clone(),
-                            telemetry_error: args.telemetry_error,
+                            telemetry_error_bound: args.telemetry_error_bound,
                         };
                         filters.insert(config_path, config);
                     }
@@ -359,7 +359,7 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                          })
                     .unwrap_or(args.flush_interval);
 
-                res.telemetry_error = args.telemetry_error;
+                res.telemetry_error_bound = args.telemetry_error_bound;
 
                 res.tags = global_tags.clone();
 
@@ -395,7 +395,7 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                     })
                     .unwrap_or(res.bin_width);
 
-                res.telemetry_error = args.telemetry_error;
+                res.telemetry_error_bound = args.telemetry_error_bound;
 
                 res
             });
@@ -445,7 +445,7 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                          })
                     .unwrap_or(args.flush_interval);
 
-                res.telemetry_error = args.telemetry_error;
+                res.telemetry_error_bound = args.telemetry_error_bound;
 
                 res
             });
@@ -626,8 +626,6 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
 
                         res.tags = global_tags.clone();
 
-                        res.telemetry_error = args.telemetry_error;
-
                         assert!(res.config_path.is_some());
                         assert!(!res.forwards.is_empty());
 
@@ -674,8 +672,6 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                             .unwrap_or(res.forwards);
 
                         res.tags = global_tags.clone();
-
-                        res.telemetry_error = args.telemetry_error;
 
                         assert!(res.config_path.is_some());
                         assert!(!res.forwards.is_empty());
@@ -756,8 +752,6 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
 
                 res.tags = global_tags.clone();
 
-                res.telemetry_error = args.telemetry_error;
-
                 res
             })
             .unwrap_or(args.internal);
@@ -811,19 +805,19 @@ data-directory = "/foo/bar"
     }
 
     #[test]
-    fn config_file_telemetry_error() {
+    fn config_file_telemetry_error_bound() {
         let config = r#"telemetry-error-bound = 0.002"#;
         let args = parse_config_file(config, 4);
 
-        assert_eq!(args.telemetry_error, 0.002);
+        assert_eq!(args.telemetry_error_bound, 0.002);
     }
 
     #[test]
-    fn config_file_telemetry_error_default() {
+    fn config_file_telemetry_error_bound_default() {
         let config = r#""#;
         let args = parse_config_file(config, 4);
 
-        assert_eq!(args.telemetry_error, 0.001);
+        assert_eq!(args.telemetry_error_bound, 0.001);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -175,8 +175,8 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
         .unwrap_or(args.flush_interval);
 
     args.telemetry_error = value
-        .get("telemetry-error")
-        .map(|fi| fi.as_float().expect("could not parse telemetry-error"))
+        .get("telemetry-error-bound")
+        .map(|fi| fi.as_float().expect("could not parse telemetry-error-bound"))
         .unwrap_or(args.telemetry_error);
 
     let global_tags: TagMap = match value.get("tags") {
@@ -812,7 +812,7 @@ data-directory = "/foo/bar"
 
     #[test]
     fn config_file_telemetry_error() {
-        let config = r#"telemetry-error = 0.002"#;
+        let config = r#"telemetry-error-bound = 0.002"#;
         let args = parse_config_file(config, 4);
 
         assert_eq!(args.telemetry_error, 0.002);

--- a/src/metric/telemetry.rs
+++ b/src/metric/telemetry.rs
@@ -108,7 +108,7 @@ impl Telemetry {
     /// ```
     /// use cernan::metric::{Telemetry,AggregationMethod};
     ///
-    /// let m = Telemetry::new("foo", 1.1);
+    /// let m = Telemetry::new("foo", 1.1, 0.001);
     ///
     /// assert_eq!(m.aggr_method, AggregationMethod::Summarize);
     /// assert_eq!(m.name, "foo");
@@ -141,7 +141,7 @@ impl Telemetry {
     /// ```
     /// use cernan::metric::Telemetry;
     ///
-    /// let mut m = Telemetry::new("foo", 1.1);
+    /// let mut m = Telemetry::new("foo", 1.1, 0.001);
     ///
     /// assert!(m.tags.is_empty());
     ///
@@ -169,7 +169,7 @@ impl Telemetry {
     /// ```
     /// use cernan::metric::{Telemetry,TagMap};
     ///
-    /// let mut m = Telemetry::new("foo", 1.1);
+    /// let mut m = Telemetry::new("foo", 1.1, 0.001);
     ///
     /// assert!(m.tags.is_empty());
     ///
@@ -203,7 +203,7 @@ impl Telemetry {
     /// ```
     /// use cernan::metric::{Telemetry,TagMap};
     ///
-    /// let mut m = Telemetry::new("foo", 1.1);
+    /// let mut m = Telemetry::new("foo", 1.1, 0.001);
     ///
     /// assert!(m.tags.is_empty());
     ///
@@ -238,7 +238,7 @@ impl Telemetry {
     /// ```
     /// use cernan::metric::Telemetry;
     ///
-    /// let m = Telemetry::new("foo", 1.1).set_value(10.10);
+    /// let m = Telemetry::new("foo", 1.1, 0.001).set_value(10.10);
     ///
     /// assert_eq!(m.value(), Some(10.10));
     /// ```
@@ -307,7 +307,7 @@ impl Telemetry {
     /// ```
     /// use cernan::metric::Telemetry;
     ///
-    /// let m = Telemetry::new("foo", 1.1).timestamp(10101).aggr_set();
+    /// let m = Telemetry::new("foo", 1.1, 0.001).timestamp(10101).aggr_set();
     /// assert!(m.is_set());
     /// ```
     pub fn aggr_set(mut self) -> Telemetry {
@@ -329,7 +329,7 @@ impl Telemetry {
     /// ```
     /// use cernan::metric::Telemetry;
     ///
-    /// let m = Telemetry::new("foo", 1.1).timestamp(10101).aggr_sum();
+    /// let m = Telemetry::new("foo", 1.1, 0.001).timestamp(10101).aggr_sum();
     /// assert!(m.is_sum());
     /// ```
     pub fn aggr_sum(mut self) -> Telemetry {
@@ -352,7 +352,7 @@ impl Telemetry {
     /// ```
     /// use cernan::metric::Telemetry;
     ///
-    /// let m = Telemetry::new("foo", 1.1).timestamp(10101).aggr_summarize();
+    /// let m = Telemetry::new("foo", 1.1, 0.001).timestamp(10101).aggr_summarize();
     /// assert!(m.is_summarize());
     /// ```
     pub fn aggr_summarize(mut self) -> Telemetry {
@@ -375,7 +375,7 @@ impl Telemetry {
     /// ```
     /// use cernan::metric::Telemetry;
     ///
-    /// let m = Telemetry::new("foo", 1.1).timestamp(10101);
+    /// let m = Telemetry::new("foo", 1.1, 0.001).timestamp(10101);
     ///
     /// assert_eq!(10101, m.timestamp);
     /// ```
@@ -562,24 +562,24 @@ mod tests {
 
     #[test]
     fn partial_ord_equal() {
-        let mc = Telemetry::new("l6", 0.7913855).aggr_sum().timestamp(47);
-        let mg = Telemetry::new("l6", 0.9683).aggr_set().timestamp(47);
+        let mc = Telemetry::new("l6", 0.7913855, 0.001).aggr_sum().timestamp(47);
+        let mg = Telemetry::new("l6", 0.9683, 0.001).aggr_set().timestamp(47);
 
         assert_eq!(Some(cmp::Ordering::Equal), mc.partial_cmp(&mg));
     }
 
     #[test]
     fn partial_ord_distinct() {
-        let mc = Telemetry::new("l6", 0.7913855).aggr_sum().timestamp(7);
-        let mg = Telemetry::new("l6", 0.9683).aggr_set().timestamp(47);
+        let mc = Telemetry::new("l6", 0.7913855, 0.001).aggr_sum().timestamp(7);
+        let mg = Telemetry::new("l6", 0.9683, 0.001).aggr_set().timestamp(47);
 
         assert_eq!(Some(cmp::Ordering::Less), mc.partial_cmp(&mg));
     }
 
     #[test]
     fn partial_ord_gauges() {
-        let mdg = Telemetry::new("l6", 0.7913855).aggr_set().persist().timestamp(47);
-        let mg = Telemetry::new("l6", 0.9683).aggr_set().timestamp(47);
+        let mdg = Telemetry::new("l6", 0.7913855, 0.001).aggr_set().persist().timestamp(47);
+        let mg = Telemetry::new("l6", 0.9683, 0.001).aggr_set().timestamp(47);
 
         assert_eq!(Some(cmp::Ordering::Equal), mg.partial_cmp(&mdg));
         assert_eq!(Some(cmp::Ordering::Equal), mdg.partial_cmp(&mg));
@@ -610,7 +610,7 @@ mod tests {
             let time: i64 = g.gen_range(0, 100);
             let time_ns: u64 = (time as u64) * 1_000_000_000;
             let mut mb =
-                Telemetry::new(name, val).timestamp(time).timestamp_ns(time_ns);
+                Telemetry::new(name, val, 0.001).timestamp(time).timestamp_ns(time_ns);
             mb = match kind {
                 AggregationMethod::Set => mb.aggr_set(),
                 AggregationMethod::Sum => mb.aggr_sum(),
@@ -655,8 +655,8 @@ mod tests {
     #[test]
     fn test_metric_add_assign() {
         fn inner(lhs: f64, rhs: f64, kind: AggregationMethod) -> TestResult {
-            let mut mlhs = Telemetry::new("foo", lhs);
-            let mut mrhs = Telemetry::new("foo", rhs);
+            let mut mlhs = Telemetry::new("foo", lhs, 0.001);
+            let mut mrhs = Telemetry::new("foo", rhs, 0.001);
             mlhs = match kind {
                 AggregationMethod::Sum => mlhs.aggr_sum(),
                 AggregationMethod::Set => mlhs.aggr_set(),
@@ -690,7 +690,7 @@ mod tests {
 
     #[test]
     fn test_negative_timer() {
-        let m = Telemetry::new("timer", -1.0).aggr_summarize();
+        let m = Telemetry::new("timer", -1.0, 0.001).aggr_summarize();
 
         assert_eq!(m.aggr_method, AggregationMethod::Summarize);
         assert_eq!(m.query(1.0), Some(-1.0));
@@ -699,7 +699,7 @@ mod tests {
 
     #[test]
     fn test_postive_delta_gauge() {
-        let m = Telemetry::new("dgauge", 1.0).persist().aggr_set();
+        let m = Telemetry::new("dgauge", 1.0, 0.001).persist().aggr_set();
 
         assert_eq!(m.aggr_method, AggregationMethod::Set);
         assert_eq!(m.value(), Some(1.0));

--- a/src/metric/telemetry.rs
+++ b/src/metric/telemetry.rs
@@ -16,6 +16,7 @@ pub struct Telemetry {
     pub tags: sync::Arc<TagMap>,
     pub timestamp: i64, // seconds, see #166
     pub timestamp_ns: u64,
+    pub error: f64,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -29,6 +30,7 @@ pub struct Value {
     kind: ValueKind,
     single: Option<f64>,
     many: Option<CKMS<f64>>,
+    error: f64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, PartialOrd, Eq, Hash)]
@@ -80,14 +82,16 @@ impl PartialOrd for Telemetry {
 
 impl Default for Telemetry {
     fn default() -> Telemetry {
+        let default_error = 0.001;
         Telemetry {
             name: String::from(""),
-            value: Value::new(Default::default()),
+            value: Value::new(Default::default(), default_error),
             persist: false,
             aggr_method: AggregationMethod::Summarize,
             tags: sync::Arc::new(TagMap::default()),
             timestamp: time::now(),
             timestamp_ns: time::now_ns(),
+            error: default_error,
         }
     }
 }
@@ -110,10 +114,10 @@ impl Telemetry {
     /// assert_eq!(m.name, "foo");
     /// assert_eq!(m.value(), Some(1.1));
     /// ```
-    pub fn new<S>(name: S, value: f64) -> Telemetry
+    pub fn new<S>(name: S, value: f64, error: f64) -> Telemetry
         where S: Into<String>
     {
-        let val = Value::new(value);
+        let val = Value::new(value, error);
         Telemetry {
             aggr_method: AggregationMethod::Summarize,
             name: name.into(),
@@ -122,6 +126,7 @@ impl Telemetry {
             timestamp_ns: time::now_ns(),
             value: val,
             persist: false,
+            error: error,
         }
     }
 
@@ -238,7 +243,7 @@ impl Telemetry {
     /// assert_eq!(m.value(), Some(10.10));
     /// ```
     pub fn set_value(mut self, value: f64) -> Telemetry {
-        self.value = Value::new(value);
+        self.value = Value::new(value, self.error);
         self
     }
 
@@ -433,11 +438,12 @@ impl AddAssign for Value {
 }
 
 impl Value {
-    fn new(value: f64) -> Value {
+    fn new(value: f64, error: f64) -> Value {
         Value {
             kind: ValueKind::Single,
             single: Some(value),
             many: None,
+            error: error
         }
     }
 
@@ -451,7 +457,7 @@ impl Value {
     fn insert(&mut self, value: f64) -> () {
         match self.kind {
             ValueKind::Single => {
-                let mut ckms = CKMS::new(0.001);
+                let mut ckms = CKMS::new(self.error);
                 ckms.insert(self.single.expect("NOT SINGLE IN METRICVALUE INSERT"));
                 ckms.insert(value);
                 self.many = Some(ckms);

--- a/src/sink/firehose.rs
+++ b/src/sink/firehose.rs
@@ -24,6 +24,7 @@ pub struct FirehoseConfig {
     pub region: Option<Region>,
     pub config_path: Option<String>,
     pub flush_interval: u64,
+    pub telemetry_error: f64,
 }
 
 impl Default for FirehoseConfig {
@@ -34,6 +35,7 @@ impl Default for FirehoseConfig {
             region: None,
             config_path: None,
             flush_interval: 60,
+            telemetry_error: 0.001,
         }
     }
 }
@@ -44,6 +46,7 @@ pub struct Firehose {
     region: Region,
     batch_size: usize,
     flush_interval: u64,
+    telemetry_error: f64,
 }
 
 impl Firehose {
@@ -55,6 +58,7 @@ impl Firehose {
             region: config.region.expect("region cannot be None"),
             batch_size: config.batch_size,
             flush_interval: config.flush_interval,
+            telemetry_error: config.telemetry_error,
         }
     }
 }
@@ -109,12 +113,14 @@ impl Sink for Firehose {
                                prbi.delivery_stream_name);
                         report_full_telemetry("cernan.sinks.firehose.records.delivery",
                                               1.0,
+                                              self.telemetry_error,
                                               None,
                                               Some(vec![("delivery_stream_name",
                                                          prbi.delivery_stream_name
                                                              .as_str())]));
                         report_full_telemetry("cernan.sinks.firehose.records.total_delivered",
                                               prbi.records.len() as f64,
+                                              self.telemetry_error,
                                               None,
                                               Some(vec![("delivery_stream_name",
                                                          prbi.delivery_stream_name
@@ -123,6 +129,7 @@ impl Sink for Firehose {
                         if failed_put_count > 0 {
                             report_full_telemetry("cernan.sinks.firehose.records.total_failed",
                                                   failed_put_count as f64,
+                                                  self.telemetry_error,
                                                   None,
                                                   Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -142,6 +149,7 @@ impl Sink for Firehose {
                             ResourceNotFound(rnf_err) => {
                                 report_full_telemetry("cernan.sinks.firehose.error.resource_not_found",
                                                  1.0,
+                                                 self.telemetry_error,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -153,6 +161,7 @@ impl Sink for Firehose {
                             InvalidArgument(ia_err) => {
                                 report_full_telemetry("cernan.sinks.firehose.error.invalid_argument",
                                                  1.0,
+                                                 self.telemetry_error,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -164,6 +173,7 @@ impl Sink for Firehose {
                             HttpDispatch(hd_err) => {
                                 report_full_telemetry("cernan.sinks.firehose.error.http_dispatch",
                                                  1.0,
+                                                 self.telemetry_error,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -174,6 +184,7 @@ impl Sink for Firehose {
                             Validation(v_err) => {
                                 report_full_telemetry("cernan.sinks.firehose.error.validation",
                                                  1.0,
+                                                 self.telemetry_error,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -185,6 +196,7 @@ impl Sink for Firehose {
                             Unknown(u_err) => {
                                 report_full_telemetry("cernan.sinks.firehose.error.unknown",
                                                  1.0,
+                                                 self.telemetry_error,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -196,6 +208,7 @@ impl Sink for Firehose {
                             Credentials(c_err) => {
                                 report_full_telemetry("cernan.sinks.firehose.error.credentials",
                                                  1.0,
+                                                 self.telemetry_error,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -206,6 +219,7 @@ impl Sink for Firehose {
                             ServiceUnavailable(su_err) => {
                                 report_full_telemetry("cernan.sinks.firehose.error.service_unavailable",
                                                  1.0,
+                                                 self.telemetry_error,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name

--- a/src/sink/firehose.rs
+++ b/src/sink/firehose.rs
@@ -13,7 +13,7 @@ use serde_json;
 use serde_json::Map;
 use serde_json::value::Value;
 use sink::{Sink, Valve};
-use source::report_full_telemetry;
+use source::report_telemetry5;
 use std::sync;
 use uuid::Uuid;
 
@@ -24,7 +24,7 @@ pub struct FirehoseConfig {
     pub region: Option<Region>,
     pub config_path: Option<String>,
     pub flush_interval: u64,
-    pub telemetry_error: f64,
+    pub telemetry_error_bound: f64,
 }
 
 impl Default for FirehoseConfig {
@@ -35,7 +35,7 @@ impl Default for FirehoseConfig {
             region: None,
             config_path: None,
             flush_interval: 60,
-            telemetry_error: 0.001,
+            telemetry_error_bound: 0.001,
         }
     }
 }
@@ -46,7 +46,7 @@ pub struct Firehose {
     region: Region,
     batch_size: usize,
     flush_interval: u64,
-    telemetry_error: f64,
+    telemetry_error_bound: f64,
 }
 
 impl Firehose {
@@ -58,7 +58,7 @@ impl Firehose {
             region: config.region.expect("region cannot be None"),
             batch_size: config.batch_size,
             flush_interval: config.flush_interval,
-            telemetry_error: config.telemetry_error,
+            telemetry_error_bound: config.telemetry_error_bound,
         }
     }
 }
@@ -111,25 +111,25 @@ impl Sink for Firehose {
                         debug!("Wrote {} records to delivery stream {}",
                                prbi.records.len(),
                                prbi.delivery_stream_name);
-                        report_full_telemetry("cernan.sinks.firehose.records.delivery",
+                        report_telemetry5("cernan.sinks.firehose.records.delivery",
                                               1.0,
-                                              self.telemetry_error,
+                                              self.telemetry_error_bound,
                                               None,
                                               Some(vec![("delivery_stream_name",
                                                          prbi.delivery_stream_name
                                                              .as_str())]));
-                        report_full_telemetry("cernan.sinks.firehose.records.total_delivered",
+                        report_telemetry5("cernan.sinks.firehose.records.total_delivered",
                                               prbi.records.len() as f64,
-                                              self.telemetry_error,
+                                              self.telemetry_error_bound,
                                               None,
                                               Some(vec![("delivery_stream_name",
                                                          prbi.delivery_stream_name
                                                              .as_str())]));
                         let failed_put_count = prbo.failed_put_count;
                         if failed_put_count > 0 {
-                            report_full_telemetry("cernan.sinks.firehose.records.total_failed",
+                            report_telemetry5("cernan.sinks.firehose.records.total_failed",
                                                   failed_put_count as f64,
-                                                  self.telemetry_error,
+                                                  self.telemetry_error_bound,
                                                   None,
                                                   Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -147,9 +147,9 @@ impl Sink for Firehose {
                             // the payload being wonky. This is an optimization for
                             // the future.
                             ResourceNotFound(rnf_err) => {
-                                report_full_telemetry("cernan.sinks.firehose.error.resource_not_found",
+                                report_telemetry5("cernan.sinks.firehose.error.resource_not_found",
                                                  1.0,
-                                                 self.telemetry_error,
+                                                 self.telemetry_error_bound,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -159,9 +159,9 @@ impl Sink for Firehose {
                                 break;
                             }
                             InvalidArgument(ia_err) => {
-                                report_full_telemetry("cernan.sinks.firehose.error.invalid_argument",
+                                report_telemetry5("cernan.sinks.firehose.error.invalid_argument",
                                                  1.0,
-                                                 self.telemetry_error,
+                                                 self.telemetry_error_bound,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -171,9 +171,9 @@ impl Sink for Firehose {
                                 break;
                             }
                             HttpDispatch(hd_err) => {
-                                report_full_telemetry("cernan.sinks.firehose.error.http_dispatch",
+                                report_telemetry5("cernan.sinks.firehose.error.http_dispatch",
                                                  1.0,
-                                                 self.telemetry_error,
+                                                 self.telemetry_error_bound,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -182,9 +182,9 @@ impl Sink for Firehose {
                                 break;
                             }
                             Validation(v_err) => {
-                                report_full_telemetry("cernan.sinks.firehose.error.validation",
+                                report_telemetry5("cernan.sinks.firehose.error.validation",
                                                  1.0,
-                                                 self.telemetry_error,
+                                                 self.telemetry_error_bound,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -194,9 +194,9 @@ impl Sink for Firehose {
                                 break;
                             }
                             Unknown(u_err) => {
-                                report_full_telemetry("cernan.sinks.firehose.error.unknown",
+                                report_telemetry5("cernan.sinks.firehose.error.unknown",
                                                  1.0,
-                                                 self.telemetry_error,
+                                                 self.telemetry_error_bound,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -206,9 +206,9 @@ impl Sink for Firehose {
                             }
                             // The following errors are recoverable, potentially.
                             Credentials(c_err) => {
-                                report_full_telemetry("cernan.sinks.firehose.error.credentials",
+                                report_telemetry5("cernan.sinks.firehose.error.credentials",
                                                  1.0,
-                                                 self.telemetry_error,
+                                                 self.telemetry_error_bound,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name
@@ -217,9 +217,9 @@ impl Sink for Firehose {
                                        c_err);
                             }
                             ServiceUnavailable(su_err) => {
-                                report_full_telemetry("cernan.sinks.firehose.error.service_unavailable",
+                                report_telemetry5("cernan.sinks.firehose.error.service_unavailable",
                                                  1.0,
-                                                 self.telemetry_error,
+                                                 self.telemetry_error_bound,
                                                  None,
                                                  Some(vec![("delivery_stream_name",
                                                         prbi.delivery_stream_name

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -246,52 +246,53 @@ mod test {
             config_path: Some("sinks.influxdb".to_string()),
             tags: tags.clone(),
             flush_interval: 60,
+            telemetry_error: 0.001,
         };
         let mut influxdb = InfluxDB::new(config);
         let dt_0 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 11, 00);
         let dt_1 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 12, 00);
         let dt_2 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 13, 00);
-        influxdb.deliver(Arc::new(Some(Telemetry::new("test.counter", -1.0)
+        influxdb.deliver(Arc::new(Some(Telemetry::new("test.counter", -1.0, 0.001)
                                            .timestamp_and_ns(dt_0.timestamp(), dt_0.timestamp_subsec_nanos())
                                            .aggr_sum()
                                            .overlay_tags_from_map(&tags))));
-        influxdb.deliver(Arc::new(Some(Telemetry::new("test.counter", 2.0)
+        influxdb.deliver(Arc::new(Some(Telemetry::new("test.counter", 2.0, 0.001)
                                            .timestamp_and_ns(dt_0.timestamp(), dt_0.timestamp_subsec_nanos())
                                            .aggr_sum()
                                            .overlay_tags_from_map(&tags))));
-        influxdb.deliver(Arc::new(Some(Telemetry::new("test.counter", 3.0)
+        influxdb.deliver(Arc::new(Some(Telemetry::new("test.counter", 3.0, 0.001)
                                            .timestamp_and_ns(dt_1.timestamp(), dt_1.timestamp_subsec_nanos())
                                            .aggr_sum()
                                            .overlay_tags_from_map(&tags))));
-        influxdb.deliver(Arc::new(Some(Telemetry::new("test.gauge", 3.211)
+        influxdb.deliver(Arc::new(Some(Telemetry::new("test.gauge", 3.211, 0.001)
                                            .timestamp_and_ns(dt_0.timestamp(), dt_0.timestamp_subsec_nanos())
                                            .aggr_set()
                                            .overlay_tags_from_map(&tags))));
-        influxdb.deliver(Arc::new(Some(Telemetry::new("test.gauge", 4.322)
+        influxdb.deliver(Arc::new(Some(Telemetry::new("test.gauge", 4.322, 0.001)
                                            .timestamp_and_ns(dt_1.timestamp(), dt_1.timestamp_subsec_nanos())
                                            .aggr_set()
                                            .overlay_tags_from_map(&tags))));
-        influxdb.deliver(Arc::new(Some(Telemetry::new("test.gauge", 5.433)
+        influxdb.deliver(Arc::new(Some(Telemetry::new("test.gauge", 5.433, 0.001)
                                            .timestamp_and_ns(dt_2.timestamp(), dt_2.timestamp_subsec_nanos())
                                            .aggr_set()
                                            .overlay_tags_from_map(&tags))));
-        influxdb.deliver(Arc::new(Some(Telemetry::new("test.timer", 12.101)
+        influxdb.deliver(Arc::new(Some(Telemetry::new("test.timer", 12.101, 0.001)
                                            .timestamp_and_ns(dt_0.timestamp(), dt_0.timestamp_subsec_nanos())
                                            .aggr_summarize()
                                            .overlay_tags_from_map(&tags))));
-        influxdb.deliver(Arc::new(Some(Telemetry::new("test.timer", 1.101)
+        influxdb.deliver(Arc::new(Some(Telemetry::new("test.timer", 1.101, 0.001)
                                            .timestamp_and_ns(dt_0.timestamp(), dt_0.timestamp_subsec_nanos())
                                            .aggr_summarize()
                                            .overlay_tags_from_map(&tags))));
-        influxdb.deliver(Arc::new(Some(Telemetry::new("test.timer", 3.101)
+        influxdb.deliver(Arc::new(Some(Telemetry::new("test.timer", 3.101, 0.001)
                                            .timestamp_and_ns(dt_0.timestamp(), dt_0.timestamp_subsec_nanos())
                                            .aggr_summarize()
                                            .overlay_tags_from_map(&tags))));
-        influxdb.deliver(Arc::new(Some(Telemetry::new("test.raw", 1.0)
+        influxdb.deliver(Arc::new(Some(Telemetry::new("test.raw", 1.0, 0.001)
                                            .timestamp_and_ns(dt_0.timestamp(), dt_0.timestamp_subsec_nanos())
                                            .aggr_set()
                                            .overlay_tags_from_map(&tags))));
-        influxdb.deliver(Arc::new(Some(Telemetry::new("test.raw", 2.0)
+        influxdb.deliver(Arc::new(Some(Telemetry::new("test.raw", 2.0, 0.001)
                                            .timestamp_and_ns(dt_1.timestamp(), dt_1.timestamp_subsec_nanos())
                                            .aggr_set()
                                            .overlay_tags_from_map(&tags))));

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -26,6 +26,7 @@ pub struct PrometheusConfig {
     pub host: String,
     pub port: u16,
     pub config_path: Option<String>,
+    pub telemetry_error: f64,
 }
 
 impl Default for PrometheusConfig {
@@ -35,12 +36,14 @@ impl Default for PrometheusConfig {
             host: "localhost".to_string(),
             port: 8086,
             config_path: None,
+            telemetry_error: 0.001,
         }
     }
 }
 
 struct SenderHandler {
     aggr: sync::Arc<Mutex<PrometheusAggr>>,
+    telemetry_error: f64,
 }
 
 /// The specialized aggr for Prometheus
@@ -149,9 +152,11 @@ impl Handler for SenderHandler {
         let mut aggr = self.aggr.lock().unwrap();
         let reportable: Vec<metric::Telemetry> = aggr.reportable();
         report_telemetry("cernan.sinks.prometheus.aggregation.reportable",
-                         reportable.len() as f64);
+                         reportable.len() as f64,
+                         self.telemetry_error);
         report_telemetry("cernan.sinks.prometheus.aggregation.remaining",
-                         aggr.count() as f64);
+                         aggr.count() as f64,
+                         self.telemetry_error);
         // Typed hyper::mime is challenging to use. In particular, matching does
         // not seem to work like I expect and handling all other MIME cases in
         // the existing enum strikes me as a fool's errand, on account of there
@@ -174,14 +179,20 @@ impl Handler for SenderHandler {
             }
         }
         let res = if accept_proto {
-            report_telemetry("cernan.sinks.prometheus.write.binary", 1.0);
+            report_telemetry("cernan.sinks.prometheus.write.binary",
+                             1.0,
+                             self.telemetry_error);
             write_binary(&reportable, res)
         } else {
-            report_telemetry("cernan.sinks.prometheus.write.text", 1.0);
+            report_telemetry("cernan.sinks.prometheus.write.text",
+                             1.0,
+                             self.telemetry_error);
             write_text(&reportable, res)
         };
         if res.is_err() {
-            report_telemetry("cernan.sinks.prometheus.report_error", 1.0);
+            report_telemetry("cernan.sinks.prometheus.report_error",
+                             1.0,
+                             self.telemetry_error);
             aggr.recombine(reportable);
         }
     }
@@ -193,7 +204,11 @@ impl Prometheus {
         let srv_aggrs = aggrs.clone();
         let listener = Server::http((config.host.as_str(), config.port))
             .unwrap()
-            .handle_threads(SenderHandler { aggr: srv_aggrs }, 1)
+            .handle_threads(
+                SenderHandler {
+                    aggr: srv_aggrs,
+                    telemetry_error: config.telemetry_error},
+                1)
             .unwrap();
 
         Prometheus {

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -313,52 +313,53 @@ mod test {
             tags: tags.clone(),
             percentiles: percentiles,
             flush_interval: 60,
+            telemetry_error: 0.001,
         };
         let mut wavefront = Wavefront::new(config).unwrap();
         let dt_0 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 11, 00).timestamp();
         let dt_1 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 12, 00).timestamp();
         let dt_2 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 13, 00).timestamp();
-        wavefront.deliver(Arc::new(Some(Telemetry::new("test.counter", -1.0)
+        wavefront.deliver(Arc::new(Some(Telemetry::new("test.counter", -1.0, 0.001)
                                             .timestamp(dt_0)
                                             .aggr_sum()
                                             .overlay_tags_from_map(&tags))));
-        wavefront.deliver(Arc::new(Some(Telemetry::new("test.counter", 2.0)
+        wavefront.deliver(Arc::new(Some(Telemetry::new("test.counter", 2.0, 0.001)
                                             .timestamp(dt_0)
                                             .aggr_sum()
                                             .overlay_tags_from_map(&tags))));
-        wavefront.deliver(Arc::new(Some(Telemetry::new("test.counter", 3.0)
+        wavefront.deliver(Arc::new(Some(Telemetry::new("test.counter", 3.0, 0.001)
                                             .timestamp(dt_1)
                                             .aggr_sum()
                                             .overlay_tags_from_map(&tags))));
-        wavefront.deliver(Arc::new(Some(Telemetry::new("test.gauge", 3.211)
+        wavefront.deliver(Arc::new(Some(Telemetry::new("test.gauge", 3.211, 0.001)
                                             .timestamp(dt_0)
                                             .aggr_set()
                                             .overlay_tags_from_map(&tags))));
-        wavefront.deliver(Arc::new(Some(Telemetry::new("test.gauge", 4.322)
+        wavefront.deliver(Arc::new(Some(Telemetry::new("test.gauge", 4.322, 0.001)
                                             .timestamp(dt_1)
                                             .aggr_set()
                                             .overlay_tags_from_map(&tags))));
-        wavefront.deliver(Arc::new(Some(Telemetry::new("test.gauge", 5.433)
+        wavefront.deliver(Arc::new(Some(Telemetry::new("test.gauge", 5.433, 0.001)
                                             .timestamp(dt_2)
                                             .aggr_set()
                                             .overlay_tags_from_map(&tags))));
-        wavefront.deliver(Arc::new(Some(Telemetry::new("test.timer", 12.101)
+        wavefront.deliver(Arc::new(Some(Telemetry::new("test.timer", 12.101, 0.001)
                                             .timestamp(dt_0)
                                             .aggr_summarize()
                                             .overlay_tags_from_map(&tags))));
-        wavefront.deliver(Arc::new(Some(Telemetry::new("test.timer", 1.101)
+        wavefront.deliver(Arc::new(Some(Telemetry::new("test.timer", 1.101, 0.001)
                                             .timestamp(dt_0)
                                             .aggr_summarize()
                                             .overlay_tags_from_map(&tags))));
-        wavefront.deliver(Arc::new(Some(Telemetry::new("test.timer", 3.101)
+        wavefront.deliver(Arc::new(Some(Telemetry::new("test.timer", 3.101, 0.001)
                                             .timestamp(dt_0)
                                             .aggr_summarize()
                                             .overlay_tags_from_map(&tags))));
-        wavefront.deliver(Arc::new(Some(Telemetry::new("test.raw", 1.0)
+        wavefront.deliver(Arc::new(Some(Telemetry::new("test.raw", 1.0, 0.001)
                                             .timestamp(dt_0)
                                             .aggr_set()
                                             .overlay_tags_from_map(&tags))));
-        wavefront.deliver(Arc::new(Some(Telemetry::new("test.raw", 2.0)
+        wavefront.deliver(Arc::new(Some(Telemetry::new("test.raw", 2.0, 0.001)
                                             .timestamp(dt_1)
                                             .aggr_set()
                                             .overlay_tags_from_map(&tags))));

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -1,7 +1,7 @@
 use buckets::Buckets;
 use metric::{AggregationMethod, LogLine, TagMap, Telemetry};
 use sink::{Sink, Valve};
-use source::report_telemetry;
+use source::report_telemetry3;
 use std::cmp;
 use std::io::Write as IoWrite;
 use std::net::TcpStream;
@@ -18,7 +18,7 @@ pub struct Wavefront {
     percentiles: Vec<(String, f64)>,
     pub stats: String,
     flush_interval: u64,
-    pub telemetry_error: f64,
+    pub telemetry_error_bound: f64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -30,7 +30,7 @@ pub struct WavefrontConfig {
     pub percentiles: Vec<(String, f64)>,
     pub tags: TagMap,
     pub flush_interval: u64,
-    pub telemetry_error: f64,
+    pub telemetry_error_bound: f64,
 }
 
 impl Default for WavefrontConfig {
@@ -56,7 +56,7 @@ impl Default for WavefrontConfig {
             percentiles: percentiles,
             tags: TagMap::default(),
             flush_interval: 60,
-            telemetry_error: 0.001,
+            telemetry_error_bound: 0.001,
         }
     }
 }
@@ -104,7 +104,7 @@ impl Wavefront {
                percentiles: config.percentiles,
                stats: String::with_capacity(8_192),
                flush_interval: config.flush_interval,
-               telemetry_error: config.telemetry_error,
+               telemetry_error_bound: config.telemetry_error_bound,
            })
     }
 
@@ -120,23 +120,23 @@ impl Wavefront {
             for value in values {
                 match value.aggr_method {
                     AggregationMethod::Sum => {
-                        report_telemetry("cernan.sinks.wavefront.aggregation.sum",
+                        report_telemetry3("cernan.sinks.wavefront.aggregation.sum",
                                          1.0,
-                                         self.telemetry_error)
+                                         self.telemetry_error_bound)
                     }
                     AggregationMethod::Set => {
-                        report_telemetry("cernan.sinks.wavefront.aggregation.set",
+                        report_telemetry3("cernan.sinks.wavefront.aggregation.set",
                                          1.0,
-                                         self.telemetry_error)
+                                         self.telemetry_error_bound)
                     }
                     AggregationMethod::Summarize => {
-                        report_telemetry("cernan.sinks.wavefront.aggregation.summarize",
+                        report_telemetry3("cernan.sinks.wavefront.aggregation.summarize",
                                          1.0,
-                                         self.telemetry_error);
-                        report_telemetry("cernan.sinks.wavefront.aggregation.\
+                                         self.telemetry_error_bound);
+                        report_telemetry3("cernan.sinks.wavefront.aggregation.\
                                           summarize.total_percentiles",
                                          self.percentiles.len() as f64,
-                                         self.telemetry_error);
+                                         self.telemetry_error_bound);
                     }
                 };
                 match value.aggr_method {
@@ -218,9 +218,9 @@ impl Sink for Wavefront {
 
     fn flush(&mut self) {
         loop {
-            report_telemetry("cernan.sinks.wavefront.delivery_attempts",
+            report_telemetry3("cernan.sinks.wavefront.delivery_attempts",
                              self.delivery_attempts as f64,
-                             self.telemetry_error);
+                             self.telemetry_error_bound);
             if self.delivery_attempts > 0 {
                 debug!("delivery attempts: {}", self.delivery_attempts);
             }
@@ -313,7 +313,7 @@ mod test {
             tags: tags.clone(),
             percentiles: percentiles,
             flush_interval: 60,
-            telemetry_error: 0.001,
+            telemetry_error_bound: 0.001,
         };
         let mut wavefront = Wavefront::new(config).unwrap();
         let dt_0 = UTC.ymd(1990, 6, 12).and_hms_milli(9, 10, 11, 00).timestamp();

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -33,6 +33,7 @@ pub struct FileServer {
     path: PathBuf,
     max_read_lines: usize,
     tags: metric::TagMap,
+    telemetry_error: f64,
 }
 
 /// The configuration struct for `FileServer`.
@@ -50,6 +51,9 @@ pub struct FileServerConfig {
     pub forwards: Vec<String>,
     /// The configured name of FileServer.
     pub config_path: Option<String>,
+    /// Telemetry is reported with some approximation, this is an error
+    /// of this approximation, check the `quantiles` library docs
+    pub telemetry_error: f64,
 }
 
 impl Default for FileServerConfig {
@@ -60,6 +64,7 @@ impl Default for FileServerConfig {
             tags: metric::TagMap::default(),
             forwards: Vec::default(),
             config_path: None,
+            telemetry_error: 0.001,
         }
     }
 }
@@ -73,6 +78,7 @@ impl FileServer {
             path: config.path.expect("must specify a 'path' for FileServer"),
             tags: config.tags,
             max_read_lines: config.max_read_lines,
+            telemetry_error: config.telemetry_error,
         }
     }
 }
@@ -89,6 +95,7 @@ struct FileWatcher {
     reader: io::BufReader<fs::File>,
     offset: u64,
     file_id: (u64, u64), // (dev, ino)
+    telemetry_error: f64,
 }
 
 impl FileWatcher {
@@ -97,7 +104,7 @@ impl FileWatcher {
     /// The input path will be used by `FileWatcher` to prime its state
     /// machine. A `FileWatcher` tracks _only one_ file. This function returns
     /// None if the path does not exist or is not readable by cernan.
-    pub fn new(path: PathBuf) -> Option<FileWatcher> {
+    pub fn new(path: PathBuf, telemetry_error: f64) -> Option<FileWatcher> {
         match fs::File::open(&path) {
             Ok(f) => {
                 let mut rdr = io::BufReader::new(f);
@@ -112,6 +119,7 @@ impl FileWatcher {
                          reader: rdr,
                          offset: offset,
                          file_id: (dev, ino),
+                         telemetry_error: telemetry_error,
                      })
             }
             Err(_) => None,
@@ -126,6 +134,7 @@ impl FileWatcher {
             if (dev, ino) != self.file_id {
                 report_full_telemetry("cernan.sources.file.switch",
                                  1.0,
+                                 self.telemetry_error,
                                  None,
                                  Some(vec![("file_path",
                                             &self.path.to_str().expect("could not make path"))]));
@@ -236,7 +245,7 @@ impl Source for FileServer {
                 match entry {
                     Ok(path) => {
                         let entry = fp_map.entry(path.clone());
-                        if let Some(fw) = FileWatcher::new(path) {
+                        if let Some(fw) = FileWatcher::new(path, self.telemetry_error) {
                             entry.or_insert(fw);
                         };
                     }
@@ -267,6 +276,7 @@ impl Source for FileServer {
                                     let path_name = file.path.to_str().expect("could not make path_name");
                                     report_full_telemetry("cernan.sources.file.lines_read",
                                                           1.0,
+                                                          self.telemetry_error,
                                                           None,
                                                           Some(vec![("file_path",
                                                                      path_name)]));

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -354,7 +354,7 @@ mod test {
             let path = dir.path().join("a_file.log");
             let mut fp = fs::File::create(&path).expect("could not create");
             let mut fw =
-                FileWatcher::new(path.clone()).expect("must be able to create");
+                FileWatcher::new(path.clone(), 0.001).expect("must be able to create");
 
             let mut expected_read = Vec::new();
 

--- a/src/source/graphite.rs
+++ b/src/source/graphite.rs
@@ -17,6 +17,7 @@ pub struct Graphite {
     host: String,
     port: u16,
     tags: Arc<metric::TagMap>,
+    telemetry_error: f64,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -26,6 +27,7 @@ pub struct GraphiteConfig {
     pub tags: metric::TagMap,
     pub forwards: Vec<String>,
     pub config_path: Option<String>,
+    pub telemetry_error: f64,
 }
 
 impl Default for GraphiteConfig {
@@ -36,6 +38,7 @@ impl Default for GraphiteConfig {
             tags: metric::TagMap::default(),
             forwards: Vec::new(),
             config_path: Some("sources.graphite".to_string()),
+            telemetry_error: 0.001,
         }
     }
 }
@@ -47,24 +50,26 @@ impl Graphite {
             host: config.host,
             port: config.port,
             tags: Arc::new(config.tags),
+            telemetry_error: config.telemetry_error,
         }
     }
 }
 
 fn handle_tcp(chans: util::Channel,
               tags: Arc<metric::TagMap>,
-              listner: TcpListener)
+              listner: TcpListener,
+              telemetry_error: f64)
               -> thread::JoinHandle<()> {
     thread::spawn(move || for stream in listner.incoming() {
                       if let Ok(stream) = stream {
-                          report_telemetry("cernan.graphite.new_peer", 1.0);
+                          report_telemetry("cernan.graphite.new_peer", 1.0, telemetry_error);
                           debug!("new peer at {:?} | local addr for peer {:?}",
                                  stream.peer_addr(),
                                  stream.local_addr());
                           let tags = tags.clone();
                           let chans = chans.clone();
                           thread::spawn(move || {
-                                            handle_stream(chans, tags, stream);
+                                            handle_stream(chans, tags, stream, telemetry_error);
                                         });
                       }
                   })
@@ -73,7 +78,8 @@ fn handle_tcp(chans: util::Channel,
 
 fn handle_stream(mut chans: util::Channel,
                  tags: Arc<metric::TagMap>,
-                 stream: TcpStream) {
+                 stream: TcpStream,
+                 telemetry_error: f64) {
     thread::spawn(move || {
         let mut line = String::new();
         let mut res = Vec::new();
@@ -83,13 +89,13 @@ fn handle_stream(mut chans: util::Channel,
         while let Some(len) = line_reader.read_line(&mut line).ok() {
             if len > 0 {
                 if parse_graphite(&line, &mut res, basic_metric.clone()) {
-                    report_telemetry("cernan.graphite.packet", 1.0);
+                    report_telemetry("cernan.graphite.packet", 1.0, telemetry_error);
                     for m in res.drain(..) {
                         send(&mut chans, metric::Event::Telemetry(Arc::new(Some(m))));
                     }
                     line.clear();
                 } else {
-                    report_telemetry("cernan.graphite.bad_packet", 1.0);
+                    report_telemetry("cernan.graphite.bad_packet", 1.0, telemetry_error);
                     error!("bad packet: {:?}", line);
                     line.clear();
                 }
@@ -114,8 +120,9 @@ impl Source for Graphite {
                     let chans = self.chans.clone();
                     let tags = self.tags.clone();
                     info!("server started on {:?} {}", addr, self.port);
+                    let error = self.telemetry_error;
                     joins.push(thread::spawn(move || {
-                                                 handle_tcp(chans, tags, listener)
+                                                 handle_tcp(chans, tags, listener, error)
                                              }));
                 }
             }

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -5,6 +5,8 @@ use std::sync;
 use time;
 use util;
 
+const DEFAULT_TELEMETRY_ERROR_BOUND: f64 = 0.001;
+
 lazy_static! {
     static ref Q: sync::Mutex<VecDeque<metric::Telemetry>> = sync::Mutex::new(VecDeque::new());
 }
@@ -28,7 +30,6 @@ pub struct InternalConfig {
     /// The default tags to apply to each Telemetry that comes through the
     /// queue.
     pub tags: metric::TagMap,
-    pub telemetry_error: f64,
 }
 
 impl Default for InternalConfig {
@@ -37,7 +38,6 @@ impl Default for InternalConfig {
             tags: metric::TagMap::default(),
             forwards: Vec::new(),
             config_path: Some("sources.internal".to_string()),
-            telemetry_error: 0.001,
         }
     }
 }
@@ -51,15 +51,16 @@ impl Internal {
     }
 }
 
-/// Push telemetry into the Internal queue
-///
-/// Given a name and value, construct a Telemetry with Sum aggregation and push
-/// into Internal's queue. This queue will then be drained into operator
-/// configured forwards.
-pub fn report_telemetry<S>(name: S, value: f64, error: f64) -> ()
+/// see comment for the report_telemetry5
+pub fn report_telemetry2<S>(name: S, value: f64) -> ()
     where S: Into<String>
 {
-    report_full_telemetry(name, value, error, None, None);
+    report_telemetry5(name, value, DEFAULT_TELEMETRY_ERROR_BOUND, None, None);
+}
+pub fn report_telemetry3<S>(name: S, value: f64, error: f64) -> ()
+    where S: Into<String>
+{
+    report_telemetry5(name, value, error, None, None);
 }
 
 /// Push telemetry into the Internal queue
@@ -67,7 +68,7 @@ pub fn report_telemetry<S>(name: S, value: f64, error: f64) -> ()
 /// Given a name, value, possible aggregation and possible metadata construct a
 /// Telemetry with said aggregation and push into Internal's queue. This queue
 /// will then be drained into operator configured forwards.
-pub fn report_full_telemetry<S>(name: S,
+pub fn report_telemetry5<S>(name: S,
                                 value: f64,
                                 error: f64,
                                 aggr: Option<metric::AggregationMethod>,

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -28,6 +28,7 @@ pub struct InternalConfig {
     /// The default tags to apply to each Telemetry that comes through the
     /// queue.
     pub tags: metric::TagMap,
+    pub telemetry_error: f64,
 }
 
 impl Default for InternalConfig {
@@ -36,6 +37,7 @@ impl Default for InternalConfig {
             tags: metric::TagMap::default(),
             forwards: Vec::new(),
             config_path: Some("sources.internal".to_string()),
+            telemetry_error: 0.001,
         }
     }
 }
@@ -54,10 +56,10 @@ impl Internal {
 /// Given a name and value, construct a Telemetry with Sum aggregation and push
 /// into Internal's queue. This queue will then be drained into operator
 /// configured forwards.
-pub fn report_telemetry<S>(name: S, value: f64) -> ()
+pub fn report_telemetry<S>(name: S, value: f64, error: f64) -> ()
     where S: Into<String>
 {
-    report_full_telemetry(name, value, None, None);
+    report_full_telemetry(name, value, error, None, None);
 }
 
 /// Push telemetry into the Internal queue
@@ -67,12 +69,13 @@ pub fn report_telemetry<S>(name: S, value: f64) -> ()
 /// will then be drained into operator configured forwards.
 pub fn report_full_telemetry<S>(name: S,
                                 value: f64,
+                                error: f64,
                                 aggr: Option<metric::AggregationMethod>,
                                 metadata: Option<Vec<(&str, &str)>>)
                                 -> ()
     where S: Into<String>
 {
-    let mut telem = metric::Telemetry::new(name, value);
+    let mut telem = metric::Telemetry::new(name, value, error);
     telem = match aggr {
         Some(metric::AggregationMethod::Sum) |
         None => telem.aggr_sum(),

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -8,8 +8,8 @@ mod statsd;
 pub use self::file::{FileServer, FileServerConfig};
 pub use self::flush::FlushTimer;
 pub use self::graphite::{Graphite, GraphiteConfig};
-pub use self::internal::{Internal, InternalConfig, report_full_telemetry,
-                         report_telemetry};
+pub use self::internal::{Internal, InternalConfig,
+                         report_telemetry2, report_telemetry3, report_telemetry5};
 pub use self::native::{NativeServer, NativeServerConfig};
 pub use self::statsd::{Statsd, StatsdConfig};
 

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -16,6 +16,7 @@ pub struct NativeServer {
     ip: String,
     port: u16,
     tags: metric::TagMap,
+    telemetry_error: f64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -25,6 +26,7 @@ pub struct NativeServerConfig {
     pub tags: metric::TagMap,
     pub forwards: Vec<String>,
     pub config_path: Option<String>,
+    pub telemetry_error: f64,
 }
 
 impl Default for NativeServerConfig {
@@ -35,6 +37,7 @@ impl Default for NativeServerConfig {
             tags: metric::TagMap::default(),
             forwards: Vec::default(),
             config_path: None,
+            telemetry_error: 0.001,
         }
     }
 }
@@ -48,13 +51,15 @@ impl NativeServer {
             ip: config.ip,
             port: config.port,
             tags: config.tags,
+            telemetry_error: config.telemetry_error,
         }
     }
 }
 
 fn handle_tcp(chans: util::Channel,
               tags: metric::TagMap,
-              listner: TcpListener)
+              listner: TcpListener,
+              telemetry_error: f64)
               -> thread::JoinHandle<()> {
     thread::spawn(move || for stream in listner.incoming() {
                       if let Ok(stream) = stream {
@@ -64,13 +69,16 @@ fn handle_tcp(chans: util::Channel,
                           let tags = tags.clone();
                           let chans = chans.clone();
                           thread::spawn(move || {
-                                            handle_stream(chans, tags, stream);
+                                            handle_stream(chans, tags, stream, telemetry_error);
                                         });
                       }
                   })
 }
 
-fn handle_stream(mut chans: util::Channel, tags: metric::TagMap, stream: TcpStream) {
+fn handle_stream(mut chans: util::Channel,
+                 tags: metric::TagMap,
+                 stream: TcpStream,
+                 telemetry_error: f64) {
     thread::spawn(move || {
         let mut reader = io::BufReader::new(stream);
         let mut buf = Vec::with_capacity(4000);
@@ -96,7 +104,7 @@ fn handle_stream(mut chans: util::Channel, tags: metric::TagMap, stream: TcpStre
                         if smpls.is_empty() {
                             continue;
                         }
-                        let mut metric = metric::Telemetry::new(name, smpls[0]);
+                        let mut metric = metric::Telemetry::new(name, smpls[0], telemetry_error);
                         for smpl in &smpls[1..] {
                             metric = metric.insert_value(*smpl);
                         }
@@ -154,7 +162,8 @@ impl Source for NativeServer {
         let chans = self.chans.clone();
         let tags = self.tags.clone();
         info!("server started on {}:{}", self.ip, self.port);
-        let jh = thread::spawn(move || handle_tcp(chans, tags, listener));
+        let error = self.telemetry_error;
+        let jh = thread::spawn(move || handle_tcp(chans, tags, listener, error));
 
         jh.join().expect("Uh oh, child thread panicked!");
     }

--- a/tests/programmable_filter.rs
+++ b/tests/programmable_filter.rs
@@ -22,7 +22,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.identity".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -52,7 +52,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.clear_metrics".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -80,7 +80,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.clear_logs".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -110,7 +110,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.remove_keys".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -148,7 +148,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.remove_keys".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -179,7 +179,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.no_args_no_crash".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -210,7 +210,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.missing_func".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -239,7 +239,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.demonstrate_require".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -277,7 +277,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.add_keys".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -315,7 +315,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.add_keys".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -346,7 +346,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.keep_count".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -438,7 +438,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.collectd_scrub".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -481,7 +481,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.collectd_scrub".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -523,7 +523,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.json_parse".to_string()),
                 tags: Default::default(),
-                telemetry_error: 0.001,
+                telemetry_error_bound: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 

--- a/tests/programmable_filter.rs
+++ b/tests/programmable_filter.rs
@@ -22,10 +22,11 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.identity".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
-            let metric = metric::Telemetry::new("identity", 12.0)
+            let metric = metric::Telemetry::new("identity", 12.0, 0.001)
                 .overlay_tag("foo", "bar")
                 .overlay_tag("bizz", "bazz");
             let event = metric::Event::new_telemetry(metric);
@@ -51,10 +52,11 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.clear_metrics".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
-            let metric = metric::Telemetry::new("clear_me", 12.0)
+            let metric = metric::Telemetry::new("clear_me", 12.0, 0.001)
                 .overlay_tag("foo", "bar")
                 .overlay_tag("bizz", "bazz");
             let event = metric::Event::new_telemetry(metric);
@@ -78,6 +80,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.clear_logs".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -107,6 +110,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.remove_keys".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -144,10 +148,11 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.remove_keys".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
-            let expected_metric = metric::Telemetry::new("identity", 12.0)
+            let expected_metric = metric::Telemetry::new("identity", 12.0, 0.001)
                 .overlay_tag("foo", "bar");
             let orig_metric = expected_metric.clone().overlay_tag("bizz", "bazz");
             let orig_event = metric::Event::new_telemetry(orig_metric);
@@ -174,10 +179,11 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.no_args_no_crash".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
-            let orig_metric = metric::Telemetry::new("identity", 12.0)
+            let orig_metric = metric::Telemetry::new("identity", 12.0, 0.001)
                 .overlay_tag("foo", "bar")
                 .overlay_tag("bizz", "bazz");
 
@@ -204,10 +210,11 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.missing_func".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
-            let orig_metric = metric::Telemetry::new("identity", 12.0)
+            let orig_metric = metric::Telemetry::new("identity", 12.0, 0.001)
                 .overlay_tag("foo", "bar")
                 .overlay_tag("bizz", "bazz");
 
@@ -232,6 +239,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.demonstrate_require".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -269,6 +277,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.add_keys".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -306,11 +315,12 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.add_keys".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
             let orig_metric =
-                metric::Telemetry::new("identity", 12.0).overlay_tag("foo", "bar");
+                metric::Telemetry::new("identity", 12.0, 0.001).overlay_tag("foo", "bar");
             let expected_metric = orig_metric.clone().overlay_tag("bizz", "bazz");
             let orig_event = metric::Event::new_telemetry(orig_metric);
             let expected_event = metric::Event::new_telemetry(expected_metric);
@@ -336,15 +346,19 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.keep_count".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
             let metric0 = metric::Event::new_telemetry(metric::Telemetry::new("identity",
-                                                                              12.0));
+                                                                              12.0,
+                                                                              0.001));
             let metric1 = metric::Event::new_telemetry(metric::Telemetry::new("identity",
-                                                                              13.0));
+                                                                              13.0,
+                                                                              0.001));
             let metric2 = metric::Event::new_telemetry(metric::Telemetry::new("identity",
-                                                                              14.0));
+                                                                              14.0,
+                                                                              0.001));
 
             let log0 = metric::Event::new_log(metric::LogLine::new("identity",
                                                                    "a log line"));
@@ -424,6 +438,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.collectd_scrub".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
@@ -431,7 +446,7 @@ mod integration {
                         protocol_counter-TCPFastOpenActive";
             let expected = "collectd.protocols-TcpExt.protocol_counter-TCPFastOpenActive";
 
-            let metric = metric::Telemetry::new(orig, 12.0);
+            let metric = metric::Telemetry::new(orig, 12.0, 0.001);
             let event = metric::Event::new_telemetry(metric);
 
             let mut events = Vec::new();
@@ -466,13 +481,14 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.collectd_scrub".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 
             let orig = "totally_fine.interface-lo.if_errors.tx 0 1478751126";
             let expected = "totally_fine.interface-lo.if_errors.tx 0 1478751126";
 
-            let metric = metric::Telemetry::new(orig, 12.0);
+            let metric = metric::Telemetry::new(orig, 12.0, 0.001);
             let event = metric::Event::new_telemetry(metric);
 
             let mut events = Vec::new();
@@ -507,6 +523,7 @@ mod integration {
                 forwards: Vec::new(),
                 config_path: Some("filters.json_parse".to_string()),
                 tags: Default::default(),
+                telemetry_error: 0.001,
             };
             let mut cs = ProgrammableFilter::new(config);
 


### PR DESCRIPTION
It's an attempt to fix https://github.com/postmates/cernan/issues/162
The diff is quite large, though, all the changes to all the files looks very similar. I'd rather checked it by commits.
The most important things to note:
- The change looks very similar to what was needed for 'flush-interval' to work. Though, for the current change we don't need separated configuration for all the sinks/sources, the one global value is used.
- I'm not sure that I've picked the best way to do it