### PR TITLE
Wavefront zero padding

### DIFF
--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -226,9 +226,7 @@ impl Buckets {
 //
 #[cfg(test)]
 mod test {
-    extern crate quickcheck;
-
-    use self::quickcheck::{QuickCheck, TestResult};
+    use quickcheck::{QuickCheck, TestResult};
     use super::*;
     use chrono::{TimeZone, Utc};
     use metric::Telemetry;

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -90,27 +90,27 @@ impl Iterator for IntoIter {
     type Item = Telemetry;
 
     fn next(&mut self) -> Option<Telemetry> {
-        if let Some(value_index) = self.value_index {
-            let v = mem::replace(
-                &mut self.buckets.values[self.key_index][value_index],
-                Default::default(),
-            );
-            self.value_index = Some(value_index + 1);
-            Some(v)
-        } else {
-            let result = if self.key_index < self.buckets.keys.len() {
-                let v = mem::replace(
-                    &mut self.buckets.values[self.key_index][0],
-                    Default::default(),
-                );
-                Some(v)
+        while self.key_index < self.buckets.keys.len() {
+            if let Some(value_index) = self.value_index {
+                if value_index < self.buckets.values[self.key_index].len() {
+                    let v = mem::replace(
+                        &mut self.buckets.values[self.key_index][value_index],
+                        Default::default(),
+                    );
+                    self.value_index = Some(value_index + 1);
+                    return Some(v);
+                } else {
+                    self.value_index = None;
+                    self.key_index += 1;
+                }
             } else {
-                None
-            };
-            self.value_index = Some(1);
-            self.key_index += 1;
-            result
+                let v = mem::replace(&mut self.buckets.values[self.key_index][0],
+                                     Default::default());
+                self.value_index = Some(1);
+                return Some(v);
+            }
         }
+        return None
     }
 }
 
@@ -351,38 +351,36 @@ mod test {
                 }
             }
 
-            for vs in bucket.into_iter() {
-                for v in vs {
-                    let ref kind = v.aggr_method;
-                    let time = v.timestamp;
-                    let mut found_one = false;
-                    for m in &mp {
-                        if (m.name == v.name) && (&m.aggr_method == kind) &&
-                            within(bin_width, m.timestamp, time)
-                        {
-                            assert_eq!(Ordering::Equal, m.within(bin_width, v));
-                            found_one = true;
-                            debug_assert!(
-                                v.value() == m.value(),
-                                "{:?} != {:?} |::|::| MODEL: {:?} |::|::|
+            for v in bucket.into_iter() {
+                let ref kind = v.aggr_method;
+                let time = v.timestamp;
+                let mut found_one = false;
+                for m in &mp {
+                    if (m.name == v.name) && (&m.aggr_method == kind) &&
+                        within(bin_width, m.timestamp, time)
+                    {
+                        assert_eq!(Ordering::Equal, m.within(bin_width, &v));
+                        found_one = true;
+                        debug_assert!(
+                            v.value() == m.value(),
+                            "{:?} != {:?} |::|::| MODEL: {:?} |::|::|
     SUT: {:?}",
-                                v.value(),
-                                m.value(),
-                                mp,
-                                ms
-                            );
-                        }
+                            v.value(),
+                            m.value(),
+                            mp,
+                            ms
+                        );
                     }
-                    debug_assert!(
-                        found_one,
-                        "DID NOT FIND ONE FOR {:?} |::|::| MODEL: {:?}
+                }
+                debug_assert!(
+                    found_one,
+                    "DID NOT FIND ONE FOR {:?} |::|::| MODEL: {:?}
     |::|::| SUT: \
                                    {:?}",
-                        v,
-                        mp,
-                        ms
-                    );
-                }
+                    v,
+                    mp,
+                    ms
+                );
             }
             TestResult::passed()
         }
@@ -617,7 +615,7 @@ mod test {
                 });
             let b_cnts: HashSet<String> =
                 bucket.into_iter().fold(HashSet::default(), |mut acc, v| {
-                    acc.insert(v[0].name.clone());
+                    acc.insert(v.name.clone());
                     acc
                 });
             assert_eq!(cnts, b_cnts);
@@ -742,46 +740,56 @@ mod test {
                     }
                 }
             }
+            let len_cnts = cnts.values().fold(0, |acc, ref x| acc + x.len());
 
-            for vals in bucket.into_iter() {
-                let mut v: Vec<Telemetry> = vals.to_vec();
-                v.sort_by_key(|ref m| m.timestamp);
+            assert_eq!(len_cnts, bucket.count());
 
-                let ref cnts_v = *cnts.get(&v[0].name).unwrap();
-                assert_eq!(cnts_v.len(), v.len());
+            for val in bucket.into_iter() {
+                if let Some(c_vs) = cnts.get(&val.name) {
+                    match c_vs.binary_search_by_key(
+                        &val.timestamp,
+                        |&(c_ts, _)| c_ts,
+                    ) {
+                        Ok(idx) => {
+                            let c_v = &c_vs[idx];
 
-                for (i, c_v) in cnts_v.iter().enumerate() {
-                    assert_eq!(c_v.0, v[i].timestamp);
-                    let l_ckms = c_v.1.clone();
-                    let r_ckms = v[i].ckms();
+                            let l_ckms = c_v.1.clone();
+                            let r_ckms = val.ckms();
+                            assert!(
+                                (l_ckms.sum().unwrap() - r_ckms.sum().unwrap())
+                                    .abs() < 0.0001
+                            );
+                            assert!(
+                                (l_ckms.cma().unwrap() - r_ckms.cma().unwrap())
+                                    .abs() < 0.0001
+                            );
+                            assert_eq!(l_ckms.count(), r_ckms.count());
+                            assert!(
+                                (l_ckms.query(0.5).unwrap().1 -
+                                     r_ckms.query(0.5).unwrap().1)
+                                    .abs() < 0.0001
+                            );
+                            assert!(
+                                (l_ckms.query(0.75).unwrap().1 -
+                                     r_ckms.query(0.75).unwrap().1)
+                                    .abs() < 0.0001
+                            );
+                            assert!(
+                                (l_ckms.query(0.99).unwrap().1 -
+                                     r_ckms.query(0.99).unwrap().1)
+                                    .abs() < 0.0001
+                            );
+                            assert!(
+                                (l_ckms.query(0.999).unwrap().1 -
+                                     r_ckms.query(0.999).unwrap().1)
+                                    .abs() < 0.0001
+                            );
+                        }
+                        Err(_) => return TestResult::failed(),
+                    }
 
-                    assert!(
-                        (l_ckms.sum().unwrap() - r_ckms.sum().unwrap()).abs() < 0.0001
-                    );
-                    assert!(
-                        (l_ckms.cma().unwrap() - r_ckms.cma().unwrap()).abs() < 0.0001
-                    );
-                    assert_eq!(l_ckms.count(), r_ckms.count());
-                    assert!(
-                        (l_ckms.query(0.5).unwrap().1 -
-                             r_ckms.query(0.5).unwrap().1)
-                            .abs() < 0.0001
-                    );
-                    assert!(
-                        (l_ckms.query(0.75).unwrap().1 -
-                             r_ckms.query(0.75).unwrap().1)
-                            .abs() < 0.0001
-                    );
-                    assert!(
-                        (l_ckms.query(0.99).unwrap().1 -
-                             r_ckms.query(0.99).unwrap().1)
-                            .abs() < 0.0001
-                    );
-                    assert!(
-                        (l_ckms.query(0.999).unwrap().1 -
-                             r_ckms.query(0.999).unwrap().1)
-                            .abs() < 0.0001
-                    );
+                } else {
+                    return TestResult::failed();
                 }
             }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -415,14 +415,13 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                 })
                 .unwrap_or(res.secure);
 
-            res.flush_interval =
-                snk.get("flush_interval")
-                    .map(|fi| {
-                        fi.as_integer().expect(
+            res.flush_interval = snk.get("flush_interval")
+                .map(|fi| {
+                    fi.as_integer().expect(
                             "could not parse sinks.elasticsearch.flush_interval",
                         ) as u64
-                    })
-                    .unwrap_or(args.flush_interval);
+                })
+                .unwrap_or(args.flush_interval);
 
             res
         });

--- a/src/metric/telemetry.rs
+++ b/src/metric/telemetry.rs
@@ -24,6 +24,7 @@ impl Hash for Telemetry {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.name.hash(state);
         self.tags.hash(state);
+        self.aggr_method.hash(state);
     }
 }
 
@@ -63,13 +64,10 @@ impl fmt::Debug for Telemetry {
         write!(
             f,
             "Telemetry {{ aggr_method: {:#?}, name: {}, timestamp: {}, \
-             timestamp_ns: {}, persist: {}, tags: {:?}, value: {:?} }}",
+             value: {:?} }}",
             self.aggr_method,
             self.name,
             self.timestamp,
-            self.timestamp_ns,
-            self.persist,
-            self.tags,
             self.value()
         )
     }
@@ -300,6 +298,7 @@ impl Telemetry {
         let mut hasher = DefaultHasher::new();
         self.name.hash(&mut hasher);
         self.tags.hash(&mut hasher);
+        self.aggr_method.hash(&mut hasher);
         hasher.finish()
     }
 

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -110,54 +110,52 @@ impl Sink for Console {
         let mut sets = String::new();
         let mut summaries = String::new();
 
-        for values in &self.aggrs {
-            for value in values {
-                match value.aggr_method {
-                    AggregationMethod::Sum => {
-                        let mut tgt = &mut sums;
-                        if let Some(f) = value.value() {
+        for value in self.aggrs.iter() {
+            match value.aggr_method {
+                AggregationMethod::Sum => {
+                    let mut tgt = &mut sums;
+                    if let Some(f) = value.value() {
+                        tgt.push_str("    ");
+                        tgt.push_str(&value.name);
+                        tgt.push_str("(");
+                        tgt.push_str(&value.timestamp.to_string());
+                        tgt.push_str("): ");
+                        tgt.push_str(&f.to_string());
+                        tgt.push_str("\n");
+                    }
+                }
+                AggregationMethod::Set => {
+                    let mut tgt = &mut sets;
+                    if let Some(f) = value.value() {
+                        tgt.push_str("    ");
+                        tgt.push_str(&value.name);
+                        tgt.push_str("(");
+                        tgt.push_str(&value.timestamp.to_string());
+                        tgt.push_str("): ");
+                        tgt.push_str(&f.to_string());
+                        tgt.push_str("\n");
+                    }
+                }
+                AggregationMethod::Summarize => {
+                    let mut tgt = &mut summaries;
+                    for tup in &[
+                        ("min", 0.0),
+                        ("max", 1.0),
+                        ("50", 0.5),
+                        ("90", 0.90),
+                        ("99", 0.99),
+                        ("999", 0.999),
+                    ] {
+                        let stat: &str = tup.0;
+                        let quant: f64 = tup.1;
+                        if let Some(f) = value.query(quant) {
                             tgt.push_str("    ");
                             tgt.push_str(&value.name);
-                            tgt.push_str("(");
-                            tgt.push_str(&value.timestamp.to_string());
-                            tgt.push_str("): ");
+                            tgt.push_str(": ");
+                            tgt.push_str(stat);
+                            tgt.push_str(" ");
                             tgt.push_str(&f.to_string());
                             tgt.push_str("\n");
-                        }
-                    }
-                    AggregationMethod::Set => {
-                        let mut tgt = &mut sets;
-                        if let Some(f) = value.value() {
-                            tgt.push_str("    ");
-                            tgt.push_str(&value.name);
-                            tgt.push_str("(");
-                            tgt.push_str(&value.timestamp.to_string());
-                            tgt.push_str("): ");
-                            tgt.push_str(&f.to_string());
-                            tgt.push_str("\n");
-                        }
-                    }
-                    AggregationMethod::Summarize => {
-                        let mut tgt = &mut summaries;
-                        for tup in &[
-                            ("min", 0.0),
-                            ("max", 1.0),
-                            ("50", 0.5),
-                            ("90", 0.90),
-                            ("99", 0.99),
-                            ("999", 0.999),
-                        ] {
-                            let stat: &str = tup.0;
-                            let quant: f64 = tup.1;
-                            if let Some(f) = value.query(quant) {
-                                tgt.push_str("    ");
-                                tgt.push_str(&value.name);
-                                tgt.push_str(": ");
-                                tgt.push_str(stat);
-                                tgt.push_str(" ");
-                                tgt.push_str(&f.to_string());
-                                tgt.push_str("\n");
-                            }
                         }
                     }
                 }

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -205,7 +205,7 @@ impl Wavefront {
 
     /// Convert the buckets into a String that
     /// can be sent to the the wavefront proxy
-    pub fn format_stats(&mut self, _: i64) -> () {
+    pub fn format_stats(&mut self) -> () {
         let mut time_cache: Vec<(i64, String)> = Vec::with_capacity(128);
         let mut count_cache: Vec<(usize, String)> = Vec::with_capacity(128);
         let mut value_cache: Vec<(f64, String)> = Vec::with_capacity(128);
@@ -308,7 +308,7 @@ impl Sink for Wavefront {
     }
 
     fn flush(&mut self) {
-        self.format_stats(time::now());
+        self.format_stats();
         loop {
             report_telemetry(
                 "cernan.sinks.wavefront.delivery_attempts",
@@ -567,7 +567,7 @@ mod test {
                 .aggr_set()
                 .overlay_tags_from_map(&tags),
         )));
-        wavefront.format_stats(dt_2);
+        wavefront.format_stats();
         let lines: Vec<&str> = wavefront.stats.lines().collect();
 
         //println!("{:?}", lines);

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -570,7 +570,7 @@ mod test {
         wavefront.format_stats();
         let lines: Vec<&str> = wavefront.stats.lines().collect();
 
-        //println!("{:?}", lines);
+        println!("{:?}", lines);
         assert!(lines.contains(&"test.counter 1 645181811 source=test-src"));
         assert!(lines.contains(&"test.counter 3 645181812 source=test-src"));
         assert!(lines.contains(&"test.gauge 3.211 645181811 source=test-src"));


### PR DESCRIPTION
This pull-request introduces 'padding' into the wavefront sink. The behaviour is discussed [here](https://github.com/postmates/cernan/issues/247#issuecomment-314837565). The main show is in the property tests for the new padding iterator, as well as the commented iterator routine itself. 

Rust iterators are an odd breed. The padding iterator, specifically, is an "into" iterator, meaning that it takes ownership of the original iterator's members. You'll note that this means we have to be careful not to drop the formatted wavefront payload if there's a flush error because it cannot be recreated once that payload goes out of scope. 

This PR does _not_ address padding across flushes. Consider in the original issue a sequence like so was proposed: `[1,1,nul,1] -> [1,1,0,nul,0,1]`. If there were a flush after the nul `[1,1,nul,FLUSH,1]` then one interpretation of #247 would be to emit `[1,1,0,nul,0,1]` still. This implies added storage so that the sink can 'remember' what it's flushed previously. Also, when do we properly consider a sequence to terminate? That is, if a sequence is not reported on for N flushes is there some value of N for which that missing, departed sequence should be laid to rest? At present N = 0. 

This PR does _not_ address eliding extra zeros. That will come in a later pull request.

Please see individual commits for details. 

Part of the work to address #247 
