### PR TITLE
Implement 'sustain' for wavefront sink

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -302,6 +302,14 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                 })
                 .unwrap_or(args.flush_interval);
 
+            res.sustain = snk.get("sustain")
+                .map(|fi| {
+                    fi.as_integer()
+                        .expect("could not parse sinks.wavefront.sustain") as
+                        u32
+                })
+                .unwrap_or(res.sustain);
+
             res.tags = global_tags.clone();
 
             res


### PR DESCRIPTION
This commit implements a 'sustain' notion for wavefront. That is,
time series will continue on after the last point for 'sustain' flush
intervals. The implementation is, uh, a little pokey because of the
clones but it can't be helped without a fundamental rethink of how
we maintain Telemetry in-memory in the Wavefront sink. Nothing came
to mind though.

Part of the work to address #247

Signed-off-by: Brian L. Troutwine <blt@postmates.com>