### PR TITLE
Introduce 'delay_filter'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cernan"
-version = "0.6.3-pre"
+version = "0.7.0-pre"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.6.3-pre"
+version = "0.7.0-pre"
 
 [[bin]]
 name = "cernan"

--- a/src/filter/delay_filter.rs
+++ b/src/filter/delay_filter.rs
@@ -1,0 +1,72 @@
+/// Filter streams to within a bounded interval of current time.
+///
+/// This filter is intended to remove items from the stream which are too old,
+/// as defined by the current time and the configured `tolerance`. That is, if
+/// for some time `T`, `(T - time::now()).abs() > tolerance` the item associated
+/// with `T` will be rejected.
+
+use filter;
+use metric;
+use source::report_telemetry;
+use time;
+
+pub struct DelayFilter {
+    config_path: String,
+    tolerance: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct DelayFilterConfig {
+    pub config_path: Option<String>,
+    pub forwards: Vec<String>,
+    pub tolerance: i64,
+}
+
+impl DelayFilter {
+    pub fn new(config: DelayFilterConfig) -> DelayFilter {
+        DelayFilter {
+            config_path: config
+                .config_path
+                .expect("must supply config_path for delay filter"),
+            tolerance: config.tolerance,
+        }
+    }
+}
+
+impl filter::Filter for DelayFilter {
+    fn process(
+        &mut self,
+        event: metric::Event,
+        res: &mut Vec<metric::Event>,
+    ) -> Result<(), filter::FilterError> {
+        match event {
+            metric::Event::Telemetry(m) => {
+                report_telemetry(format!("{}.telemetry", self.config_path), 1.0);
+                match *m {
+                    Some(ref telem) => {
+                        let telem = telem.clone();
+                        if (telem.timestamp - time::now()).abs() < self.tolerance {
+                            res.push(metric::Event::new_telemetry(telem));
+                        }
+                    }
+                    None => {}
+                }
+            }
+            metric::Event::Log(l) => match *l {
+                Some(ref log) => {
+                    report_telemetry(format!("{}.log", self.config_path), 1.0);
+                    let log = log.clone();
+                    if (log.time - time::now()).abs() < self.tolerance {
+                        res.push(metric::Event::new_log(log));
+                    }
+                }
+                None => {}
+            },
+            metric::Event::TimerFlush(f) => {
+                report_telemetry(format!("{}.flush", self.config_path), 1.0);
+                res.push(metric::Event::TimerFlush(f));
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -4,7 +4,9 @@ use time;
 use util;
 
 mod programmable_filter;
+mod delay_filter;
 
+pub use self::delay_filter::{DelayFilter, DelayFilterConfig};
 pub use self::programmable_filter::{ProgrammableFilter, ProgrammableFilterConfig};
 
 #[derive(Debug)]
@@ -30,6 +32,7 @@ pub trait Filter {
         event: metric::Event,
         res: &mut Vec<metric::Event>,
     ) -> Result<(), FilterError>;
+
     fn run(
         &mut self,
         recv: hopper::Receiver<metric::Event>,


### PR DESCRIPTION
This is the first hard-coded filter introduced into cernan. The
intention is that the filter will drop any metric::Event which
comes through and is too old, as configured by the filter's
tolerance.

I've changed the version in Cargo.toml to 0.7.0-pre as the config
file changes are not backward compatible with 0.6.x. We'll have to
update the wiki separately.

Related to #295

Signed-off-by: Brian L. Troutwine <blt@postmates.com>