### PR TITLE
Introduce String Cache

### DIFF
--- a/benches/metrics.rs
+++ b/benches/metrics.rs
@@ -21,8 +21,8 @@ fn bench_merge_tags_from_map(b: &mut Bencher) {
             .overlay_tag("two", "2")
             .overlay_tag("three", "3");
         let mut tm: TagMap = Default::default();
-        tm.insert(String::from("two"), String::from("22"));
-        tm.insert(String::from("four"), String::from("4"));
+        tm.insert("two", "22");
+        tm.insert("four", "4");
         m0.merge_tags_from_map(&tm);
     });
 }

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -396,7 +396,7 @@ mod test {
                 match mp.binary_search_by(|probe| probe.within(bin_width, &m)) {
                     Ok(idx) => mp[idx] += m,
                     Err(idx) => {
-                        if m.persist && idx > 0 && mp[idx - 1].name == m.name {
+                        if m.persist && idx > 0 && mp[idx - 1].name() == m.name() {
                             let mut cur = mp[idx - 1]
                                 .clone()
                                 .timestamp(m.timestamp)
@@ -418,7 +418,7 @@ mod test {
                 let time = v.timestamp;
                 let mut found_one = false;
                 for m in &mp {
-                    if (m.name == v.name) && (&m.kind() == kind) &&
+                    if (m.name() == v.name()) && (&m.kind() == kind) &&
                         within(bin_width, m.timestamp, time)
                     {
                         assert_eq!(Ordering::Equal, m.within(bin_width, &v));
@@ -785,12 +785,12 @@ mod test {
 
             let cnts: HashSet<String> =
                 ms.iter().fold(HashSet::default(), |mut acc, ref m| {
-                    acc.insert(m.name.clone());
+                    acc.insert(m.name().as_ref().clone());
                     acc
                 });
             let b_cnts: HashSet<String> =
                 bucket.iter().fold(HashSet::default(), |mut acc, v| {
-                    acc.insert(v.name.clone());
+                    acc.insert(v.name().as_ref().clone());
                     acc
                 });
             assert_eq!(cnts, b_cnts);
@@ -811,7 +811,7 @@ mod test {
 
             let mut coll: HashMap<String, HashSet<i64>> = HashMap::new();
             for m in ms {
-                let name = m.name;
+                let name = m.name().as_ref().to_string();
                 let time = m.timestamp;
 
                 let entry = coll.entry(name).or_insert(HashSet::new());
@@ -952,7 +952,7 @@ mod test {
 
             let mut cnts: HashMap<String, Vec<(i64, Value)>> = HashMap::default();
             for m in ms {
-                let c = cnts.entry(m.name.clone()).or_insert(vec![]);
+                let c = cnts.entry(m.name().as_ref().to_string()).or_insert(vec![]);
                 match c.binary_search_by_key(&m.timestamp, |&(a, _)| a) {
                     Ok(idx) => {
                         let val = c[idx].1.clone();
@@ -972,7 +972,7 @@ mod test {
             assert_eq!(len_cnts, bucket.count());
 
             for val in bucket.iter() {
-                if let Some(c_vs) = cnts.get(&val.name) {
+                if let Some(c_vs) = cnts.get(val.name().as_ref()) {
                     match c_vs.binary_search_by_key(
                         &val.timestamp,
                         |&(c_ts, _)| c_ts,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,0 +1,9 @@
+//! A module for caches
+//!
+//! There are many structure in cernan which are copied repeatedly in memory if
+//! we take the straightforward approach of allocating everything we need as we
+//! need it. The problem with this is we end up fragmenting memory, especially
+//! if the allocator keeps back memory from the operating system for lolspeed
+//! reasons.
+
+pub mod string;

--- a/src/cache/string.rs
+++ b/src/cache/string.rs
@@ -1,0 +1,38 @@
+//! Cache for strings
+//!
+//! This implementation is pretty bare-bones. We don't do any fancy tricks with
+//! automatic deref or the like. Clients are responsible for maintaining the ID
+//! we hand out from `store` and giving it back to us for lookups.
+
+use std::sync::{Arc, RwLock};
+use std::collections::HashMap; 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+lazy_static! {
+    static ref STRING: Arc<RwLock<HashMap<u64, Arc<String>>>> = Arc::new(RwLock::default());
+}
+
+/// Store a str into the string cache 
+///
+/// A new String will be allocated from the str if the map does not already
+/// contain str. Otherwise, this operation pays the cost of a lookup and not
+/// much more.
+pub fn store(value: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    let id = hasher.finish();
+
+    let mut w = STRING.write().unwrap();
+    w.entry(id).or_insert_with(|| Arc::new(value.to_string()));
+    id
+}
+
+/// Get a str from the string cache
+///
+/// If no such ID exists in the cache None will be returned
+#[inline]
+pub fn get(id: u64) -> Option<Arc<String>> {
+    let r = STRING.read().unwrap();
+    r.get(&id).map(|x| (*x).clone())
+}

--- a/src/cache/string.rs
+++ b/src/cache/string.rs
@@ -4,16 +4,16 @@
 //! automatic deref or the like. Clients are responsible for maintaining the ID
 //! we hand out from `store` and giving it back to us for lookups.
 
-use std::sync::{Arc, RwLock};
-use std::collections::HashMap; 
+use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::sync::{Arc, RwLock};
 
 lazy_static! {
     static ref STRING: Arc<RwLock<HashMap<u64, Arc<String>>>> = Arc::new(RwLock::default());
 }
 
-/// Store a str into the string cache 
+/// Store a str into the string cache
 ///
 /// A new String will be allocated from the str if the map does not already
 /// contain str. Otherwise, this operation pays the cost of a lookup and not

--- a/src/cache/string.rs
+++ b/src/cache/string.rs
@@ -4,13 +4,17 @@
 //! automatic deref or the like. Clients are responsible for maintaining the ID
 //! we hand out from `store` and giving it back to us for lookups.
 
+use seahash::SeaHasher;
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::hash::BuildHasherDefault;
 use std::sync::{Arc, RwLock};
 
+type HashMapFnv<K, V> = HashMap<K, V, BuildHasherDefault<SeaHasher>>;
+
 lazy_static! {
-    static ref STRING: Arc<RwLock<HashMap<u64, Arc<String>>>> = Arc::new(RwLock::default());
+    static ref STRING: Arc<RwLock<HashMapFnv<u64, Arc<String>>>> = Arc::new(RwLock::default());
 }
 
 /// Store a str into the string cache

--- a/src/config.rs
+++ b/src/config.rs
@@ -225,10 +225,7 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
             let mut tags = TagMap::default();
             let ttbl = tbl.as_table().unwrap();
             for (k, v) in ttbl.iter() {
-                tags.insert(
-                    String::from(k.clone()),
-                    String::from(v.as_str().unwrap().to_string()),
-                );
+                tags.insert(k.as_str(), v.as_str().unwrap());
             }
             tags
         }

--- a/src/filter/delay_filter.rs
+++ b/src/filter/delay_filter.rs
@@ -45,7 +45,7 @@ impl filter::Filter for DelayFilter {
     ) -> Result<(), filter::FilterError> {
         match event {
             metric::Event::Telemetry(m) => {
-                report_telemetry(format!("{}.telemetry", self.config_path), 1.0);
+                report_telemetry(&format!("{}.telemetry", self.config_path), 1.0);
                 if let Some(ref telem) = *m {
                     let telem = telem.clone();
                     if (telem.timestamp - time::now()).abs() < self.tolerance {
@@ -54,14 +54,14 @@ impl filter::Filter for DelayFilter {
                 }
             }
             metric::Event::Log(l) => if let Some(ref log) = *l {
-                report_telemetry(format!("{}.log", self.config_path), 1.0);
+                report_telemetry(&format!("{}.log", self.config_path), 1.0);
                 let log = log.clone();
                 if (log.time - time::now()).abs() < self.tolerance {
                     res.push(metric::Event::new_log(log));
                 }
             },
             metric::Event::TimerFlush(f) => {
-                report_telemetry(format!("{}.flush", self.config_path), 1.0);
+                report_telemetry(&format!("{}.flush", self.config_path), 1.0);
                 res.push(metric::Event::TimerFlush(f));
             }
         }

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -1,4 +1,3 @@
-
 use cache::string::{get, store};
 use filter;
 use libc::c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,3 +61,4 @@ pub mod source;
 pub mod filter;
 pub mod util;
 pub mod protocols;
+pub mod cache;

--- a/src/metric/logline.rs
+++ b/src/metric/logline.rs
@@ -1,5 +1,7 @@
 use metric::TagMap;
 use time;
+use std::sync;
+use cache::string::{store,get};
 
 /// An unstructured piece of text, plus associated metadata
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -8,7 +10,7 @@ pub struct LogLine {
     pub time: i64,
     /// The path that this `LogLine` originated from. May be a unix path or not,
     /// depending on origin.
-    pub path: String,
+    path: u64,
     /// The line read from the `LogLine` path
     pub value: String,
     /// Fields that may have been parsed out of the value, a key/value structure
@@ -25,17 +27,21 @@ impl LogLine {
     /// Create a new `LogLine`
     ///
     /// Please see `LogLine` struct documentation for more details.
-    pub fn new<S>(path: S, value: S) -> LogLine
-    where
-        S: Into<String>,
+    pub fn new(path: &str, value: &str) -> LogLine
     {
+        let id = store(path);
         LogLine {
-            path: path.into(),
-            value: value.into(),
+            path: id,
+            value: value.to_string(),
             time: time::now(),
             tags: Default::default(),
             fields: Default::default(),
         }
+    }
+
+    /// Return the path
+    pub fn path(&self) -> sync::Arc<String> {
+        get(self.path).unwrap().clone()
     }
 
     /// Set the time of the Logline
@@ -63,11 +69,8 @@ impl LogLine {
     /// supporting sinks. For instance, the firehose sink will put the field
     /// _into_ the payload where tags will be associated metadata that define
     /// groups of related LogLines.
-    pub fn insert_field<S>(mut self, key: S, val: S) -> LogLine
-    where
-        S: Into<String>,
-    {
-        self.fields.insert(key.into(), val.into());
+    pub fn insert_field(mut self, key: &str, val: &str) -> LogLine {
+        self.fields.insert(key, val);
         self
     }
 
@@ -75,11 +78,8 @@ impl LogLine {
     ///
     /// This function inserts a new key and value into the LogLine's tags. If
     /// the key was already present the old value is replaced.
-    pub fn overlay_tag<S>(mut self, key: S, val: S) -> LogLine
-    where
-        S: Into<String>,
-    {
-        self.tags.insert(key.into(), val.into());
+    pub fn overlay_tag(mut self, key: &str, val: &str) -> LogLine {
+        self.tags.insert(key, val);
         self
     }
 
@@ -88,8 +88,9 @@ impl LogLine {
     /// This function overlays a TagMap onto the LogLine's existing tags. If a
     /// key is present in both TagMaps the one from 'map' will be preferred.
     pub fn overlay_tags_from_map(mut self, map: &TagMap) -> LogLine {
-        for &(ref k, ref v) in map.iter() {
-            self.tags.insert(k.clone(), v.clone());
+        use cache::string::get;
+        for &(k, v) in map.iter() {
+            self.tags.insert(get(k).unwrap().as_ref(), get(v).unwrap().as_ref());
         }
         self
     }

--- a/src/metric/logline.rs
+++ b/src/metric/logline.rs
@@ -1,7 +1,8 @@
+
+use cache::string::{get, store};
 use metric::TagMap;
-use time;
 use std::sync;
-use cache::string::{store,get};
+use time;
 
 /// An unstructured piece of text, plus associated metadata
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -27,8 +28,7 @@ impl LogLine {
     /// Create a new `LogLine`
     ///
     /// Please see `LogLine` struct documentation for more details.
-    pub fn new(path: &str, value: &str) -> LogLine
-    {
+    pub fn new(path: &str, value: &str) -> LogLine {
         let id = store(path);
         LogLine {
             path: id,

--- a/src/metric/mod.rs
+++ b/src/metric/mod.rs
@@ -8,10 +8,9 @@ mod telemetry;
 
 pub use self::event::Event;
 pub use self::logline::LogLine;
+
+pub use self::tagmap::TagMap;
 pub use self::telemetry::{AggregationMethod, Telemetry};
 
 #[cfg(test)]
 pub use self::telemetry::Value;
-
-/// `TagMap` = `tagmap::TagMap<String, String>`
-pub type TagMap = self::tagmap::TagMap<String, String>;

--- a/src/metric/telemetry.rs
+++ b/src/metric/telemetry.rs
@@ -1,4 +1,3 @@
-
 use cache::string::get;
 use metric::TagMap;
 use metric::tagmap::cmp;

--- a/src/protocols/graphite.rs
+++ b/src/protocols/graphite.rs
@@ -60,32 +60,32 @@ mod tests {
         assert!(parse_graphite(pyld, &mut res, metric));
 
         assert_eq!(res[0].kind(), AggregationMethod::Set);
-        assert_eq!(res[0].name, "fst");
+        assert_eq!(res[0].name().as_ref(), "fst");
         assert_eq!(res[0].value(), Some(1.0));
         assert_eq!(res[0].timestamp, Utc.timestamp(101, 0).timestamp());
 
         assert_eq!(res[1].kind(), AggregationMethod::Set);
-        assert_eq!(res[1].name, "snd");
+        assert_eq!(res[1].name().as_ref(), "snd");
         assert_eq!(res[1].value(), Some(-2.0));
         assert_eq!(res[1].timestamp, Utc.timestamp(202, 0).timestamp());
 
         assert_eq!(res[2].kind(), AggregationMethod::Set);
-        assert_eq!(res[2].name, "thr");
+        assert_eq!(res[2].name().as_ref(), "thr");
         assert_eq!(res[2].value(), Some(3.0));
         assert_eq!(res[2].timestamp, Utc.timestamp(303, 0).timestamp());
 
         assert_eq!(res[3].kind(), AggregationMethod::Set);
-        assert_eq!(res[3].name, "fth@fth");
+        assert_eq!(res[3].name().as_ref(), "fth@fth");
         assert_eq!(res[3].value(), Some(4.0));
         assert_eq!(res[3].timestamp, Utc.timestamp(404, 0).timestamp());
 
         assert_eq!(res[4].kind(), AggregationMethod::Set);
-        assert_eq!(res[4].name, "fv%fv");
+        assert_eq!(res[4].name().as_ref(), "fv%fv");
         assert_eq!(res[4].value(), Some(5.0));
         assert_eq!(res[4].timestamp, Utc.timestamp(505, 0).timestamp());
 
         assert_eq!(res[5].kind(), AggregationMethod::Set);
-        assert_eq!(res[5].name, "s-th");
+        assert_eq!(res[5].name().as_ref(), "s-th");
         assert_eq!(res[5].value(), Some(6.0));
         assert_eq!(res[5].timestamp, Utc.timestamp(606, 0).timestamp());
     }

--- a/src/protocols/statsd.rs
+++ b/src/protocols/statsd.rs
@@ -282,7 +282,7 @@ mod tests {
             if parse_statsd(&lines, &mut res, metric) {
                 assert_eq!(res.len(), pyld.lines.len());
                 for (sline, telem) in pyld.lines.iter().zip(res.iter()) {
-                    assert_eq!(sline.name, telem.name);
+                    assert_eq!(&sline.name, telem.name().as_ref());
                     if sline.sampled {
                         assert!(
                             (sline.value * (1.0 / sline.sample_rate) -
@@ -332,15 +332,15 @@ mod tests {
             metric
         ));
         assert_eq!(res[0].kind(), AggregationMethod::Sum);
-        assert_eq!(res[0].name, "a.b");
+        assert_eq!(res[0].name().as_ref(), "a.b");
         assert_eq!(res[0].persist, false);
         assert_eq!(Some(3.1), res[0].value());
         assert_eq!(res[1].kind(), AggregationMethod::Sum);
-        assert_eq!(res[1].name, "a-b");
+        assert_eq!(res[1].name().as_ref(), "a-b");
         assert_eq!(res[1].persist, false);
         assert_eq!(Some(40.0), res[1].value());
         assert_eq!(res[2].kind(), AggregationMethod::Sum);
-        assert_eq!(res[2].name, "a-b");
+        assert_eq!(res[2].name().as_ref(), "a-b");
         assert_eq!(res[2].persist, false);
         assert_eq!(Some(26.0), res[2].value());
     }
@@ -352,7 +352,7 @@ mod tests {
         assert!(parse_statsd("fst:-1.1|ms\n", &mut res, metric));
 
         assert_eq!(res[0].kind(), AggregationMethod::Summarize);
-        assert_eq!(res[0].name, "fst");
+        assert_eq!(res[0].name().as_ref(), "fst");
         assert_eq!(res[0].persist, false);
         assert_eq!(res[0].query(1.0), Some(-1.1));
     }
@@ -364,7 +364,7 @@ mod tests {
         assert!(parse_statsd("A=:1|ms\n", &mut res, metric));
 
         assert_eq!(res[0].kind(), AggregationMethod::Summarize);
-        assert_eq!(res[0].name, "A=");
+        assert_eq!(res[0].name().as_ref(), "A=");
         assert_eq!(res[0].persist, false);
         assert_eq!(Some(1.0), res[0].query(1.0));
     }
@@ -376,7 +376,7 @@ mod tests {
         assert!(parse_statsd("A/:1|ms\n", &mut res, metric));
 
         assert_eq!(res[0].kind(), AggregationMethod::Summarize);
-        assert_eq!(res[0].name, "A/");
+        assert_eq!(res[0].name().as_ref(), "A/");
         assert_eq!(res[0].persist, false);
         assert_eq!(Some(1.0), res[0].query(1.0));
     }
@@ -392,22 +392,22 @@ mod tests {
         ));
         //                              0         A     F
         assert_eq!(res[0].kind(), AggregationMethod::Set);
-        assert_eq!(res[0].name, "foo");
+        assert_eq!(res[0].name().as_ref(), "foo");
         assert_eq!(res[0].persist, true);
         assert_eq!(Some(1.0 * (1.0 / 0.22)), res[0].set());
 
         assert_eq!(res[1].kind(), AggregationMethod::Set);
-        assert_eq!(res[1].name, "bar");
+        assert_eq!(res[1].name().as_ref(), "bar");
         assert_eq!(res[1].persist, true);
         assert_eq!(Some(101.0 * (1.0 / 2.0)), res[1].set());
 
         assert_eq!(res[2].kind(), AggregationMethod::Set);
-        assert_eq!(res[2].name, "baz");
+        assert_eq!(res[2].name().as_ref(), "baz");
         assert_eq!(res[2].persist, true);
         assert_eq!(Some(2.0 * (1.0 / 0.2)), res[2].set());
 
         assert_eq!(res[3].kind(), AggregationMethod::Set);
-        assert_eq!(res[3].name, "qux");
+        assert_eq!(res[3].name().as_ref(), "qux");
         assert_eq!(res[3].persist, true);
         assert_eq!(Some(4.0 * (1.0 / 0.1)), res[3].set());
     }
@@ -435,12 +435,12 @@ mod tests {
         assert_eq!(2, res.len());
 
         assert_eq!(res[0].kind(), AggregationMethod::Set);
-        assert_eq!(res[0].name, "a.b");
+        assert_eq!(res[0].name().as_ref(), "a.b");
         assert_eq!(res[0].persist, true);
         assert_eq!(Some(12.1), res[0].value());
 
         assert_eq!(res[1].kind(), AggregationMethod::Sum);
-        assert_eq!(res[1].name, "b_c");
+        assert_eq!(res[1].name().as_ref(), "b_c");
         assert_eq!(res[1].persist, false);
         assert_eq!(Some(13.2), res[1].value());
     }
@@ -453,12 +453,12 @@ mod tests {
         assert_eq!(2, res.len());
 
         assert_eq!(res[0].kind(), AggregationMethod::Set);
-        assert_eq!(res[0].name, "a.b");
+        assert_eq!(res[0].name().as_ref(), "a.b");
         assert_eq!(res[0].persist, true);
         assert_eq!(Some(12.1), res[0].value());
 
         assert_eq!(res[1].kind(), AggregationMethod::Sum);
-        assert_eq!(res[1].name, "b_c");
+        assert_eq!(res[1].name().as_ref(), "b_c");
         assert_eq!(res[1].persist, false);
         assert_eq!(Some(13.2), res[1].value());
     }
@@ -471,7 +471,7 @@ mod tests {
         assert!(parse_statsd(pyld, &mut res, metric));
 
         assert_eq!(res[0].kind(), AggregationMethod::Sum);
-        assert_eq!(res[0].name, "zrth");
+        assert_eq!(res[0].name().as_ref(), "zrth");
         assert_eq!(res[0].persist, true);
         assert_eq!(res[0].value(), Some(-1.0));
     }
@@ -484,12 +484,12 @@ mod tests {
         assert!(parse_statsd(pyld, &mut res, metric));
 
         assert_eq!(res[0].kind(), AggregationMethod::Set);
-        assert_eq!(res[0].name, "zrth");
+        assert_eq!(res[0].name().as_ref(), "zrth");
         assert_eq!(res[0].persist, true);
         assert_eq!(res[0].value(), Some(0.0));
 
         assert_eq!(res[1].kind(), AggregationMethod::Sum);
-        assert_eq!(res[1].name, "zrth");
+        assert_eq!(res[1].name().as_ref(), "zrth");
         assert_eq!(res[1].persist, true);
         assert_eq!(res[1].value(), Some(-1.0));
     }
@@ -520,42 +520,42 @@ mod tests {
         assert!(parse_statsd(pyld, &mut res, metric));
 
         assert_eq!(res[0].kind(), AggregationMethod::Set);
-        assert_eq!(res[0].name, "zrth");
+        assert_eq!(res[0].name().as_ref(), "zrth");
         assert_eq!(res[0].persist, true);
         assert_eq!(res[0].value(), Some(0.0));
 
         assert_eq!(res[1].kind(), AggregationMethod::Summarize);
-        assert_eq!(res[1].name, "fst");
+        assert_eq!(res[1].name().as_ref(), "fst");
         assert_eq!(res[1].persist, false);
         assert_eq!(res[1].query(1.0), Some(-1.1));
 
         assert_eq!(res[2].kind(), AggregationMethod::Sum);
-        assert_eq!(res[2].name, "snd");
+        assert_eq!(res[2].name().as_ref(), "snd");
         assert_eq!(res[2].persist, true);
         assert_eq!(res[2].value(), Some(2.2));
 
         assert_eq!(res[3].kind(), AggregationMethod::Summarize);
-        assert_eq!(res[3].name, "thd");
+        assert_eq!(res[3].name().as_ref(), "thd");
         assert_eq!(res[3].persist, false);
         assert_eq!(res[3].query(1.0), Some(3.3));
 
         assert_eq!(res[4].kind(), AggregationMethod::Sum);
-        assert_eq!(res[4].name, "fth");
+        assert_eq!(res[4].name().as_ref(), "fth");
         assert_eq!(res[4].persist, false);
         assert_eq!(res[4].value(), Some(4.0));
 
         assert_eq!(res[5].kind(), AggregationMethod::Sum);
-        assert_eq!(res[5].name, "fvth");
+        assert_eq!(res[5].name().as_ref(), "fvth");
         assert_eq!(res[5].persist, false);
         assert_eq!(res[5].value(), Some(55.0));
 
         assert_eq!(res[6].kind(), AggregationMethod::Sum);
-        assert_eq!(res[6].name, "sxth");
+        assert_eq!(res[6].name().as_ref(), "sxth");
         assert_eq!(res[6].persist, true);
         assert_eq!(res[6].value(), Some(-6.6));
 
         assert_eq!(res[7].kind(), AggregationMethod::Sum);
-        assert_eq!(res[7].name, "svth");
+        assert_eq!(res[7].name().as_ref(), "svth");
         assert_eq!(res[7].persist, true);
         assert_eq!(res[7].value(), Some(7.77));
     }

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -101,7 +101,7 @@ impl Sink for Console {
     fn flush(&mut self) {
         println!("Flushing lines: {}", Utc::now().to_rfc3339());
         for line in &self.buffer {
-            println!("{} {}: {}", format_time(line.time), line.path, line.value);
+            println!("{} {}: {}", format_time(line.time), line.path(), line.value);
         }
         self.buffer.clear();
 

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -120,7 +120,7 @@ impl Sink for Console {
                     let tgt = &mut sums;
                     if let Some(f) = telem.sum() {
                         tgt.push_str("    ");
-                        tgt.push_str(&telem.name);
+                        tgt.push_str(telem.name().as_ref());
                         tgt.push_str("(");
                         tgt.push_str(&telem.timestamp.to_string());
                         tgt.push_str("): ");
@@ -132,7 +132,7 @@ impl Sink for Console {
                     let tgt = &mut sets;
                     if let Some(f) = telem.set() {
                         tgt.push_str("    ");
-                        tgt.push_str(&telem.name);
+                        tgt.push_str(telem.name().as_ref());
                         tgt.push_str("(");
                         tgt.push_str(&telem.timestamp.to_string());
                         tgt.push_str("): ");
@@ -154,7 +154,7 @@ impl Sink for Console {
                         let quant: f64 = tup.1;
                         if let Some(f) = telem.query(quant) {
                             tgt.push_str("    ");
-                            tgt.push_str(&telem.name);
+                            tgt.push_str(telem.name().as_ref());
                             tgt.push_str(": ");
                             tgt.push_str(stat);
                             tgt.push_str(" ");

--- a/src/sink/elasticsearch.rs
+++ b/src/sink/elasticsearch.rs
@@ -1,11 +1,11 @@
+
+use cache::string::get;
 use chrono::DateTime;
 use chrono::naive::NaiveDateTime;
 use chrono::offset::Utc;
 use elastic::error::Result;
 use elastic::prelude::*;
-
 use metric::{LogLine, Telemetry};
-
 use sink::{Sink, Valve};
 use source::report_telemetry;
 use std::sync;
@@ -92,16 +92,22 @@ impl Elasticsearch {
             buffer.push('\n');
             let mut payload: Value = json!({
                 "uuid": uuid,
-                "path": m.path.clone(),
+                "path": m.path().to_string(),
                 "payload": m.value.clone(),
                 "timestamp": format_time(m.time),
             });
             let obj = payload.as_object_mut().unwrap();
-            for &(ref k, ref v) in m.tags.iter() {
-                obj.insert(k.clone(), Value::String(v.clone()));
+            for &(k, v) in m.tags.iter() {
+                obj.insert(
+                    get(k).unwrap().as_ref().to_string(),
+                    Value::String(get(v).unwrap().as_ref().to_string()),
+                );
             }
-            for &(ref k, ref v) in m.fields.iter() {
-                obj.insert(k.clone(), Value::String(v.clone()));
+            for &(k, v) in m.fields.iter() {
+                obj.insert(
+                    get(k).unwrap().as_ref().to_string(),
+                    Value::String(get(v).unwrap().as_ref().to_string()),
+                );
             }
             buffer.push_str(&to_string(&obj).unwrap());
             buffer.push('\n');

--- a/src/sink/elasticsearch.rs
+++ b/src/sink/elasticsearch.rs
@@ -1,4 +1,3 @@
-
 use cache::string::get;
 use chrono::DateTime;
 use chrono::naive::NaiveDateTime;

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -125,7 +125,7 @@ impl InfluxDB {
         for telem in telems.iter() {
             match telem.kind() {
                 AggregationMethod::Sum => if let Some(val) = telem.sum() {
-                    buffer.push_str(&telem.name);
+                    buffer.push_str(telem.name().as_ref());
                     buffer.push_str(",");
                     fmt_tags(&telem.tags, &mut tag_buf);
                     buffer.push_str(&tag_buf);
@@ -141,7 +141,7 @@ impl InfluxDB {
                     tag_buf.clear();
                 },
                 AggregationMethod::Set => if let Some(val) = telem.set() {
-                    buffer.push_str(&telem.name);
+                    buffer.push_str(telem.name().as_ref());
                     buffer.push_str(",");
                     fmt_tags(&telem.tags, &mut tag_buf);
                     buffer.push_str(&tag_buf);
@@ -162,7 +162,7 @@ impl InfluxDB {
                             Bound::Finite(x) => format!("le_{}", x),
                             Bound::PosInf => "le_inf".to_string(),
                         };
-                        buffer.push_str(&format!("{}.{}", &telem.name, bound_name));
+                        buffer.push_str(&format!("{}.{}", telem.name().as_ref(), bound_name));
                         buffer.push_str(",");
                         fmt_tags(&telem.tags, &mut tag_buf);
                         buffer.push_str(&tag_buf);
@@ -183,7 +183,7 @@ impl InfluxDB {
                     &[0.25, 0.50, 0.75, 0.90, 0.99, 1.0]
                 {
                     if let Some(val) = telem.query(*percentile) {
-                        buffer.push_str(&format!("{}.{}", &telem.name, percentile));
+                        buffer.push_str(&format!("{}.{}", telem.name().as_ref(), percentile));
                         buffer.push_str(",");
                         fmt_tags(&telem.tags, &mut tag_buf);
                         buffer.push_str(&tag_buf);

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -65,16 +65,18 @@ impl Default for InfluxDBConfig {
 
 #[inline]
 fn fmt_tags(tags: &TagMap, s: &mut String) -> () {
+    use cache::string::get;
+
     let mut iter = tags.iter();
-    if let Some(&(ref fk, ref fv)) = iter.next() {
-        s.push_str(fk);
+    if let Some(&(fk, fv)) = iter.next() {
+        s.push_str(get(fk).unwrap().as_ref());
         s.push_str("=");
-        s.push_str(fv);
-        for &(ref k, ref v) in iter {
+        s.push_str(get(fv).unwrap().as_ref());
+        for &(k, v) in iter {
             s.push_str(",");
-            s.push_str(k);
+            s.push_str(get(k).unwrap().as_ref());
             s.push_str("=");
-            s.push_str(v);
+            s.push_str(get(v).unwrap().as_ref());
         }
     }
 }
@@ -162,7 +164,9 @@ impl InfluxDB {
                             Bound::Finite(x) => format!("le_{}", x),
                             Bound::PosInf => "le_inf".to_string(),
                         };
-                        buffer.push_str(&format!("{}.{}", telem.name().as_ref(), bound_name));
+                        buffer.push_str(
+                            &format!("{}.{}", telem.name().as_ref(), bound_name),
+                        );
                         buffer.push_str(",");
                         fmt_tags(&telem.tags, &mut tag_buf);
                         buffer.push_str(&tag_buf);
@@ -179,26 +183,28 @@ impl InfluxDB {
                         tag_buf.clear();
                     }
                 },
-                AggregationMethod::Summarize => for percentile in
-                    &[0.25, 0.50, 0.75, 0.90, 0.99, 1.0]
-                {
-                    if let Some(val) = telem.query(*percentile) {
-                        buffer.push_str(&format!("{}.{}", telem.name().as_ref(), percentile));
-                        buffer.push_str(",");
-                        fmt_tags(&telem.tags, &mut tag_buf);
-                        buffer.push_str(&tag_buf);
-                        buffer.push_str(" ");
-                        buffer.push_str("value=");
-                        buffer.push_str(get_from_cache(&mut value_cache, val));
-                        buffer.push_str(" ");
-                        buffer.push_str(get_from_cache(
-                            &mut time_cache,
-                            telem.timestamp.saturating_mul(1_000_000_000) as u64,
-                        ));
-                        buffer.push_str("\n");
-                        tag_buf.clear();
+                AggregationMethod::Summarize => {
+                    for percentile in &[0.25, 0.50, 0.75, 0.90, 0.99, 1.0] {
+                        if let Some(val) = telem.query(*percentile) {
+                            buffer.push_str(
+                                &format!("{}.{}", telem.name().as_ref(), percentile),
+                            );
+                            buffer.push_str(",");
+                            fmt_tags(&telem.tags, &mut tag_buf);
+                            buffer.push_str(&tag_buf);
+                            buffer.push_str(" ");
+                            buffer.push_str("value=");
+                            buffer.push_str(get_from_cache(&mut value_cache, val));
+                            buffer.push_str(" ");
+                            buffer.push_str(get_from_cache(
+                                &mut time_cache,
+                                telem.timestamp.saturating_mul(1_000_000_000) as u64,
+                            ));
+                            buffer.push_str("\n");
+                            tag_buf.clear();
+                        }
                     }
-                },
+                }
             }
         }
     }

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -148,6 +148,8 @@ impl Sink for Native {
     }
 
     fn flush(&mut self) {
+        use cache::string::get;
+
         let mut points = Vec::with_capacity(1024);
         let mut lines = Vec::with_capacity(1024);
 
@@ -174,7 +176,10 @@ impl Sink for Native {
                     // Learn how to consume bits of the metric without having to
                     // clone like crazy
                     for (k, v) in &(*m.tags) {
-                        meta.insert(k.clone(), v.clone());
+                        meta.insert(
+                            get(*k).unwrap().as_ref().to_string(),
+                            get(*v).unwrap().as_ref().to_string(),
+                        );
                     }
                     telem.set_metadata(meta);
                     telem.set_timestamp_ms(m.timestamp * 1000); // FIXME #166
@@ -187,7 +192,7 @@ impl Sink for Native {
                 metric::Event::Log(mut l) => {
                     let l = sync::Arc::make_mut(&mut l).take().unwrap();
                     let mut ll = LogLine::new();
-                    ll.set_path(l.path);
+                    ll.set_path(l.path().to_string());
                     ll.set_value(l.value);
                     let mut meta = HashMap::new();
                     // TODO
@@ -195,7 +200,10 @@ impl Sink for Native {
                     // Learn how to consume bits of the metric without having to
                     // clone like crazy
                     for (k, v) in &l.tags {
-                        meta.insert(k.clone(), v.clone());
+                        meta.insert(
+                            get(*k).unwrap().as_ref().to_string(),
+                            get(*v).unwrap().as_ref().to_string(),
+                        );
                     }
                     ll.set_metadata(meta);
                     ll.set_timestamp_ms(l.time * 1000); // FIXME #166

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -8,7 +8,6 @@ use protocols::native::{AggregationMethod, LogLine, Payload, Telemetry};
 use sink::{Sink, Valve};
 use std::collections::HashMap;
 use std::io::BufWriter;
-use std::mem::replace;
 use std::net::{TcpStream, ToSocketAddrs};
 use std::sync;
 use time;
@@ -155,9 +154,9 @@ impl Sink for Native {
         for ev in self.buffer.drain(..) {
             match ev {
                 metric::Event::Telemetry(mut m) => {
-                    let mut m = sync::Arc::make_mut(&mut m).take().unwrap();
+                    let m = sync::Arc::make_mut(&mut m).take().unwrap();
                     let mut telem = Telemetry::new();
-                    telem.set_name(replace(&mut m.name, Default::default()));
+                    telem.set_name(m.name().to_string());
                     let method = match m.kind() {
                         metric::AggregationMethod::Histogram => AggregationMethod::BIN,
                         metric::AggregationMethod::Sum => AggregationMethod::SUM,

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -83,7 +83,7 @@ fn prometheus_cmp(
     l: &metric::Telemetry,
     r: &metric::Telemetry,
 ) -> Option<::std::cmp::Ordering> {
-    match l.name.partial_cmp(&r.name) {
+    match l.name().partial_cmp(&r.name()) {
         Some(::std::cmp::Ordering::Equal) => ::metric::tagmap::cmp(&l.tags, &r.tags),
         other => other,
     }
@@ -232,7 +232,7 @@ fn write_binary(aggrs: &[metric::Telemetry], mut res: Response) -> io::Result<()
     let mut res = res.start().unwrap();
     for m in aggrs {
         let mut metric_family = MetricFamily::new();
-        metric_family.set_name(m.name.clone());
+        metric_family.set_name(m.name().to_string());
         let mut metric = Metric::new();
         let mut label_pairs = Vec::with_capacity(8);
         for &(ref k, ref v) in m.tags.iter() {
@@ -272,7 +272,7 @@ fn write_text(aggrs: &[metric::Telemetry], mut res: Response) -> io::Result<()> 
         let sum_tags = m.tags.clone();
         let count_tags = m.tags.clone();
         for q in &[0.0, 1.0, 0.25, 0.5, 0.75, 0.90, 0.95, 0.99, 0.999] {
-            buf.push_str(&m.name);
+            buf.push_str(m.name().as_ref());
             buf.push_str("{quantile=\"");
             buf.push_str(&q.to_string());
             for (k, v) in &(*m.tags) {
@@ -285,7 +285,7 @@ fn write_text(aggrs: &[metric::Telemetry], mut res: Response) -> io::Result<()> 
             buf.push_str(&m.query(*q).unwrap().to_string());
             buf.push_str("\n");
         }
-        buf.push_str(&m.name);
+        buf.push_str(m.name().as_ref());
         buf.push_str("_sum ");
         buf.push_str("{");
         for (k, v) in &(*sum_tags) {
@@ -297,7 +297,7 @@ fn write_text(aggrs: &[metric::Telemetry], mut res: Response) -> io::Result<()> 
         buf.push_str("} ");
         buf.push_str(&m.samples_sum().to_string());
         buf.push_str("\n");
-        buf.push_str(&m.name);
+        buf.push_str(m.name().as_ref());
         buf.push_str("_count ");
         buf.push_str("{");
         for (k, v) in &(*count_tags) {
@@ -333,8 +333,8 @@ fn write_text(aggrs: &[metric::Telemetry], mut res: Response) -> io::Result<()> 
 /// In addition, we want to make sure nothing goofy happens to our metrics and
 /// so set the kind to Summarize. The prometheus sink _does not_ respect source
 /// metadata and stores everything as quantiles.
-fn sanitize(mut metric: metric::Telemetry) -> metric::Telemetry {
-    let name: String = mem::replace(&mut metric.name, Default::default());
+fn sanitize(metric: metric::Telemetry) -> metric::Telemetry {
+    let name: String = metric.name().to_string();
     let mut new_name: Vec<u8> = Vec::with_capacity(128);
     for c in name.as_bytes() {
         match *c {
@@ -345,7 +345,7 @@ fn sanitize(mut metric: metric::Telemetry) -> metric::Telemetry {
     metric
         .thaw()
         .name(
-            String::from_utf8(new_name).expect("wait, we bungled the conversion"),
+            &String::from_utf8(new_name).expect("wait, we bungled the conversion"),
         )
         .kind(metric::AggregationMethod::Summarize)
         .harden()
@@ -462,7 +462,7 @@ mod test {
                     assert_eq!(cur_cnt, aggr.count());
                     let new_t =
                         aggr.find_match(&telem).expect("could not find in test");
-                    assert_eq!(other.name, new_t.name);
+                    assert_eq!(other.name().as_ref(), new_t.name().as_ref());
                     assert_eq!(new_t.kind(), telem.kind());
                     // TODO
                     //
@@ -474,7 +474,6 @@ mod test {
                     // That's okay. In the future we'll be obeying the
                     // aggregation of the input Telemetry and then this will
                     // work.
-                    //
                     // assert_eq!(other.value(), new_t.value());
                 }
                 None => return TestResult::discard(),
@@ -511,7 +510,7 @@ mod test {
     fn test_sanitization() {
         fn inner(metric: metric::Telemetry) -> TestResult {
             let metric = sanitize(metric);
-            for c in metric.name.chars() {
+            for c in metric.name().as_ref().chars() {
                 match c {
                     'a'...'z' | 'A'...'Z' | '0'...'9' | ':' | '_' => continue,
                     _ => return TestResult::failed(),

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -1,4 +1,3 @@
-
 use cache::string::get;
 use hyper::server::{Handler, Listening, Request, Response, Server};
 use metric;

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -88,16 +88,18 @@ impl Default for WavefrontConfig {
 
 #[inline]
 fn fmt_tags(tags: &TagMap, s: &mut String) -> () {
+    use cache::string::get;
+
     let mut iter = tags.iter();
-    if let Some(&(ref fk, ref fv)) = iter.next() {
-        s.push_str(fk);
+    if let Some(&(fk, fv)) = iter.next() {
+        s.push_str(get(fk).unwrap().as_ref());
         s.push_str("=");
-        s.push_str(fv);
-        for &(ref k, ref v) in iter {
+        s.push_str(get(fv).unwrap().as_ref());
+        for &(k, v) in iter {
             s.push_str(" ");
-            s.push_str(k);
+            s.push_str(get(k).unwrap().as_ref());
             s.push_str("=");
-            s.push_str(v);
+            s.push_str(get(v).unwrap().as_ref());
         }
     }
 }

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -441,7 +441,7 @@ impl Wavefront {
                 unimplemented!();
             }
             AggregationMethod::Sum => if let Some(v) = value.sum() {
-                self.stats.push_str(&value.name);
+                self.stats.push_str(value.name().as_ref());
                 self.stats.push_str(" ");
                 self.stats.push_str(get_from_cache(&mut value_cache, v));
                 self.stats.push_str(" ");
@@ -454,7 +454,7 @@ impl Wavefront {
                 tag_buf.clear();
             },
             AggregationMethod::Set => if let Some(v) = value.set() {
-                self.stats.push_str(&value.name);
+                self.stats.push_str(value.name().as_ref());
                 self.stats.push_str(" ");
                 self.stats.push_str(get_from_cache(&mut value_cache, v));
                 self.stats.push_str(" ");
@@ -471,7 +471,7 @@ impl Wavefront {
                 for tup in &self.percentiles {
                     let stat: &String = &tup.0;
                     let quant: f64 = tup.1;
-                    self.stats.push_str(&value.name);
+                    self.stats.push_str(value.name().as_ref());
                     self.stats.push_str(".");
                     self.stats.push_str(stat);
                     self.stats.push_str(" ");
@@ -487,7 +487,7 @@ impl Wavefront {
                     self.stats.push_str("\n");
                 }
                 let count = value.count();
-                self.stats.push_str(&value.name);
+                self.stats.push_str(value.name().as_ref());
                 self.stats.push_str(".count");
                 self.stats.push_str(" ");
                 self.stats.push_str(get_from_cache(&mut count_cache, count));
@@ -498,7 +498,7 @@ impl Wavefront {
                 self.stats.push_str("\n");
 
                 let mean = value.mean();
-                self.stats.push_str(&value.name);
+                self.stats.push_str(value.name().as_ref());
                 self.stats.push_str(".mean");
                 self.stats.push_str(" ");
                 self.stats.push_str(get_from_cache(&mut value_cache, mean));

--- a/src/source/file.rs
+++ b/src/source/file.rs
@@ -275,7 +275,7 @@ impl Source for FileServer {
                                 if sz > 0 {
                                     lines_read += 1;
                                     buffer.pop();
-                                    let path_name = file.path
+                                    let path_name: &str = file.path
                                         .to_str()
                                         .expect("could not make path_name");
                                     report_full_telemetry(

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -55,8 +55,7 @@ impl Internal {
 /// Given a name and value, construct a Telemetry with Sum aggregation and push
 /// into Internal's queue. This queue will then be drained into operator
 /// configured forwards.
-pub fn report_telemetry(name: &str, value: f64) -> ()
-{
+pub fn report_telemetry(name: &str, value: f64) -> () {
     report_full_telemetry(name, value, None);
 }
 
@@ -69,8 +68,7 @@ pub fn report_full_telemetry(
     name: &str,
     value: f64,
     metadata: Option<Vec<(&str, &str)>>,
-) -> ()
-{
+) -> () {
     use metric::AggregationMethod;
     let mut telem = metric::Telemetry::new()
         .name(name)

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -55,9 +55,7 @@ impl Internal {
 /// Given a name and value, construct a Telemetry with Sum aggregation and push
 /// into Internal's queue. This queue will then be drained into operator
 /// configured forwards.
-pub fn report_telemetry<S>(name: S, value: f64) -> ()
-where
-    S: Into<String>,
+pub fn report_telemetry(name: &str, value: f64) -> ()
 {
     report_full_telemetry(name, value, None);
 }
@@ -67,13 +65,11 @@ where
 /// Given a name, value, possible aggregation and possible metadata construct a
 /// Telemetry with said aggregation and push into Internal's queue. This queue
 /// will then be drained into operator configured forwards.
-pub fn report_full_telemetry<S>(
-    name: S,
+pub fn report_full_telemetry(
+    name: &str,
     value: f64,
     metadata: Option<Vec<(&str, &str)>>,
 ) -> ()
-where
-    S: Into<String>,
 {
     use metric::AggregationMethod;
     let mut telem = metric::Telemetry::new()

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -115,7 +115,7 @@ fn handle_stream(mut chans: util::Channel, tags: metric::TagMap, stream: TcpStre
                         if smpls.is_empty() {
                             continue;
                         }
-                        let mut metric = metric::Telemetry::new().name(name);
+                        let mut metric = metric::Telemetry::new().name(&name);
                         metric = metric.value(smpls[0]);
                         metric = match aggr_type {
                             AggregationMethod::SET => {

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -136,7 +136,7 @@ fn handle_stream(mut chans: util::Channel, tags: metric::TagMap, stream: TcpStre
                         let mut metric = metric.harden().unwrap(); // todo don't unwrap
                         metric = metric.overlay_tags_from_map(&tags);
                         for (key, value) in meta.drain() {
-                            metric = metric.overlay_tag(key, value);
+                            metric = metric.overlay_tag(&key, &value);
                         }
                         for smpl in &smpls[1..] {
                             metric = metric.insert(*smpl);
@@ -150,11 +150,11 @@ fn handle_stream(mut chans: util::Channel, tags: metric::TagMap, stream: TcpStre
                         // FIXME #166
                         let ts: i64 = (line.get_timestamp_ms() as f64 * 0.001) as i64;
 
-                        let mut logline = metric::LogLine::new(path, value);
+                        let mut logline = metric::LogLine::new(&path, &value);
                         logline = logline.time(ts);
                         logline = logline.overlay_tags_from_map(&tags);
                         for (key, value) in meta.drain() {
-                            logline = logline.overlay_tag(key, value);
+                            logline = logline.overlay_tag(&key, &value);
                         }
                         util::send(&mut chans, metric::Event::new_log(logline));
 

--- a/tests/programmable_filter.rs
+++ b/tests/programmable_filter.rs
@@ -422,7 +422,7 @@ mod integration {
             match events[1] {
                 metric::Event::Telemetry(ref mut m) => {
                     let p = ::std::sync::Arc::make_mut(m).take().unwrap();
-                    assert_eq!(p.name, "count_per_tick");
+                    assert_eq!(p.name().as_ref(), "count_per_tick");
                     assert_eq!(p.set(), Some(5.0));
                 }
                 _ => {
@@ -452,7 +452,7 @@ mod integration {
             match events[1] {
                 metric::Event::Telemetry(ref mut m) => {
                     let p = ::std::sync::Arc::make_mut(m).take().unwrap();
-                    assert_eq!(p.name, "count_per_tick");
+                    assert_eq!(p.name().as_ref(), "count_per_tick");
                     assert_eq!(p.set(), Some(2.0));
                 }
                 _ => {
@@ -506,7 +506,7 @@ mod integration {
                 match event {
                     metric::Event::Telemetry(mut m) => {
                         let met = Arc::make_mut(&mut m).take().unwrap();
-                        assert_eq!(met.name, expected);
+                        assert_eq!(met.name().as_ref(), expected);
                     }
                     _ => {
                         assert!(false);
@@ -552,7 +552,7 @@ mod integration {
                 match event {
                     metric::Event::Telemetry(mut m) => {
                         let met = Arc::make_mut(&mut m).take().unwrap();
-                        assert_eq!(met.name, expected);
+                        assert_eq!(met.name().as_ref(), expected);
                     }
                     _ => {
                         assert!(false);


### PR DESCRIPTION
This pull-request is something we've been working toward for a while. #128 is the primary tracking issue. What we've done is introduce a straightforward string cache and have removed the small allocations in `Telemetry` and `LogLine` by forcing the name, path, tagmap to keep references to the cache, rather than the alloc'ed string itself. 

We don't do any fancy automatic dereferencing and the extra locking needed to make this work needs to be stress tested under realistic conditions. 