### PR TITLE
Correct Overload Issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,11 +5,12 @@ dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "coco 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "elastic 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "elastic_types 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "hopper 0.3.0 (git+https://github.com/postmates/hopper.git?branch=removed_unbounded_member)",
+ "hopper 0.3.0",
  "hyper 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -185,6 +186,15 @@ dependencies = [
 [[package]]
 name = "coco"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "coco"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -458,7 +468,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "hopper"
 version = "0.3.0"
-source = "git+https://github.com/postmates/hopper.git?branch=removed_unbounded_member#bb446dcd4d949c12406adbe50458195f2553079d"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1351,6 +1360,7 @@ dependencies = [
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2267a8fdd4dce6956ba6649e130f62fb279026e5e84b92aa939ac8f85ce3f9f0"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
+"checksum coco 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c23b760e580931ed3dddc1575ea09a0e63af097607b00339ddc12006e575fcd3"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
@@ -1380,7 +1390,6 @@ dependencies = [
 "checksum geohash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7afe5835562c47d5b81395f412ffe960020392a4172ad8477e7ff6d184e54e6"
 "checksum geojson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b7e92af77b6bd45cf336b9f77d73218d9cff1b040aedd3c344e091d6c31dbed"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum hopper 0.3.0 (git+https://github.com/postmates/hopper.git?branch=removed_unbounded_member)" = "<none>"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
 "checksum hyper 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)" = "0f01e4a20f5dfa5278d7762b7bdb7cab96e24378b9eca3889fbd4b5e94dc7063"
 "checksum hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72332e4a35d3059583623b50e98e491b78f8b96c5521fcb3f428167955aa56e8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "elastic_types 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "hopper 0.3.0",
+ "hopper 0.3.0 (git+https://github.com/postmates/hopper.git?branch=removed_unbounded_member)",
  "hyper 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -468,6 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "hopper"
 version = "0.3.0"
+source = "git+https://github.com/postmates/hopper.git?branch=removed_unbounded_member#bb446dcd4d949c12406adbe50458195f2553079d"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1390,6 +1391,7 @@ dependencies = [
 "checksum geohash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7afe5835562c47d5b81395f412ffe960020392a4172ad8477e7ff6d184e54e6"
 "checksum geojson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b7e92af77b6bd45cf336b9f77d73218d9cff1b040aedd3c344e091d6c31dbed"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum hopper 0.3.0 (git+https://github.com/postmates/hopper.git?branch=removed_unbounded_member)" = "<none>"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
 "checksum hyper 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)" = "0f01e4a20f5dfa5278d7762b7bdb7cab96e24378b9eca3889fbd4b5e94dc7063"
 "checksum hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72332e4a35d3059583623b50e98e491b78f8b96c5521fcb3f428167955aa56e8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "elastic_types 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "hopper 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopper 0.3.0 (git+https://github.com/postmates/hopper.git?branch=removed_unbounded_member)",
  "hyper 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -26,7 +26,7 @@ dependencies = [
  "serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -91,7 +91,7 @@ dependencies = [
  "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -100,7 +100,7 @@ name = "backtrace-sys"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -259,7 +259,7 @@ name = "elastic"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "elastic_reqwest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elastic_reqwest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "elastic_types 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -276,7 +276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "elastic_reqwest"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "elastic_requests 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -308,7 +308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "elastic_types_derive 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "geo 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "geohash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -323,7 +323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "elastic_types_derive 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "geo 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "geohash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -418,12 +418,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gcc"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "geo"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -436,7 +436,7 @@ name = "geohash"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "geo 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -444,7 +444,7 @@ name = "geojson"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "geo 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -458,7 +458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "hopper"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/postmates/hopper.git?branch=removed_unbounded_member#bb446dcd4d949c12406adbe50458195f2553079d"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -548,7 +548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libflate"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -566,7 +566,7 @@ version = "0.0.11"
 source = "git+https://github.com/blt/rust-lua53.git#44c0a8168e5fb2bd2f8292ca8966e6372e7a7c7e"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -621,10 +621,10 @@ name = "native-tls"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "openssl 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "schannel 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "security-framework 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "security-framework-sys 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -675,24 +675,25 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.9.15"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.15"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -771,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -829,7 +830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libflate 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libflate 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -850,7 +851,7 @@ name = "ring"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -902,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -953,18 +954,18 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "security-framework-sys 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1192,13 +1193,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "toml"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1292,6 +1293,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,7 +1362,7 @@ dependencies = [
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum elastic 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)" = "30ca56398e57e3aac5a761d5d680c95c695a69f3134311631833d74c23cf3177"
 "checksum elastic_requests 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f434fff5309dfaacdb0ef92abb3b3dbcc3d254043f5ec66a36180bd3c8ee19ce"
-"checksum elastic_reqwest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5480ea7a17ec0eee084976df7f520004d8e098ab80841c041c4674c3dc523074"
+"checksum elastic_reqwest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cc3fbbafd957623f4c3026418aef6029de16c8c9ac3316b50fa5b7b5ff4dd049"
 "checksum elastic_responses 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f5cabc558a52e0c6f26fb1df4e68340ac9493c240810435d5846c934ca69446d"
 "checksum elastic_types 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "40a92a076553384d49542391579ffb753a866e2a534822005cd9efa95ababd6f"
 "checksum elastic_types 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dfe7cec6665806ce3cb8bfbe67351fa15bb1d51b4d7f6ac5d544347c4d70fc94"
@@ -1369,12 +1375,12 @@ dependencies = [
 "checksum fern 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89273e0d0e210f69600048a209a00e163560b51e3ef51c3942304e9b8aa8b47a"
 "checksum foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e4056b9bd47f8ac5ba12be771f77a0dae796d1bbaaf5fd0b9c2d38b69b8a29d"
 "checksum futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4b63a4792d4f8f686defe3b39b92127fea6344de5d38202b2ee5a11bbbf29d6a"
-"checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
-"checksum geo 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e63cba3b230a18ca08c2f0f8576a902eb1651f5d713fafd8a10653936ded8a9b"
+"checksum gcc 0.3.52 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7d19683108136d21d32723077e69cd5df2bfd6d102c74a01d743cf2b65cf97"
+"checksum geo 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "03421e9865903f0015426358027cafe76d4a3858031adaa1a1f1be5e62cdbb82"
 "checksum geohash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7afe5835562c47d5b81395f412ffe960020392a4172ad8477e7ff6d184e54e6"
 "checksum geojson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b7e92af77b6bd45cf336b9f77d73218d9cff1b040aedd3c344e091d6c31dbed"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum hopper 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b010fa3b741026e29ae6f6f35532e4da18b0b5fc57604573f892f8e1afe9836b"
+"checksum hopper 0.3.0 (git+https://github.com/postmates/hopper.git?branch=removed_unbounded_member)" = "<none>"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
 "checksum hyper 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)" = "0f01e4a20f5dfa5278d7762b7bdb7cab96e24378b9eca3889fbd4b5e94dc7063"
 "checksum hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72332e4a35d3059583623b50e98e491b78f8b96c5521fcb3f428167955aa56e8"
@@ -1385,7 +1391,7 @@ dependencies = [
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "8a014d9226c2cc402676fbe9ea2e15dd5222cd1dd57f576b5b283178c944a264"
-"checksum libflate 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "bb9e5c68bd981985afa70d22a81f339bb0ea8a071760e99894d6d393417e4a29"
+"checksum libflate 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "a2aa04ec0100812d31a5366130ff9e793291787bc31da845bede4a00ea329830"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum lua 0.0.11 (git+https://github.com/blt/rust-lua53.git)" = "<none>"
 "checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
@@ -1401,8 +1407,8 @@ dependencies = [
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
-"checksum openssl 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f776f1d8af832fd2c637ee182c801e8f7ea8895718a2be9914cca001f6e2c40a"
-"checksum openssl-sys 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "ad95f8160d1c150c4f44d4c4959732e048ac046c37f597fe362f8bf57561ffb4"
+"checksum openssl 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)" = "085aaedcc89a2fac1eb2bc19cd66f29d4ea99fec60f82a5f3a88a6be7dbd90b5"
+"checksum openssl-sys 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7e3a9845a4c9fdb321931868aae5549e96bb7b979bf9af7de03603d74691b5f3"
 "checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum protobuf 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "568a15e4d572d9a5e63ae3a55f84328c984842887db179b40b4cc6a608bac6a4"
@@ -1413,7 +1419,7 @@ dependencies = [
 "checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
 "checksum rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7febc28567082c345f10cddc3612c6ea020fc3297a1977d472cf9fdb73e6e493"
-"checksum redox_syscall 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9309631a35303bffb47e397198e3668cb544fe8834cd3da2a744441e70e524"
+"checksum redox_syscall 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "8312fba776a49cf390b7b62f3135f9b294d8617f7a7592cfd0ac2492b658cd7b"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
@@ -1425,15 +1431,15 @@ dependencies = [
 "checksum rusoto_core 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "552127218884b4397d23b0453d1bc77b41e3af79af89c37c71ca69d13e826d6f"
 "checksum rusoto_credential 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2e36e3f3b2f9972ac78ced1a8f67ce4f11d09f577736b103562f25b63ba42c2"
 "checksum rusoto_firehose 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b2c9c2b1523db6eaadb2cb3cfaf72afa10a9d3f6af81e522031a0fee07ddb3f"
-"checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
+"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum schannel 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "14a5f8491ae5fc8c51aded1f5806282a0218b4d69b1b76913a0559507e559b90"
 "checksum scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c79eb2c3ac4bc2507cda80e7f3ac5b88bd8eae4c0914d5663e6a8933994be918"
 "checksum seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e048636bed25842fcdc36e5ad1ec6295b72d4b5b8a4b759b64915a4ce2b9d09d"
 "checksum secur32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f412dfa83308d893101dd59c10d6fda8283465976c28c287c5c855bf8d216bc"
-"checksum security-framework 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2715b5d3f24775c3213a715276f0ce2eca746ca604d7b78fc71ddc2fd6951d"
-"checksum security-framework-sys 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f15de3b59a3dc60c6ef2ce3d3ed098e5db03b55946f290e8434e2a491c3d12"
+"checksum security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfa44ee9c54ce5eecc9de7d5acbad112ee58755239381f687e564004ba4a2332"
+"checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f7726f29ddf9731b17ff113c461e362c381d9d69433f79de4f3dd572488823e9"
@@ -1459,7 +1465,7 @@ dependencies = [
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
 "checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
-"checksum toml 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3e5e16033aacf7eead46cbcb62d06cf9d1c2aa1b12faa4039072f7ae5921103b"
+"checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
@@ -1474,6 +1480,7 @@ dependencies = [
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
+"checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ fern = "0.4"
 elastic = "0.13"
 elastic_types = "0.19"
 glob = "0.2.11"
-hopper = "0.3"
+hopper = { git = "https://github.com/postmates/hopper.git", branch = "removed_unbounded_member" }
 hyper = "0.10"
 hyper-native-tls = "0.2"
 lazy_static = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ fern = "0.4"
 elastic = "0.13"
 elastic_types = "0.19"
 glob = "0.2.11"
-hopper = { git = "https://github.com/postmates/hopper.git", branch = "removed_unbounded_member" }
+hopper = "0.3.1"
 hyper = "0.10"
 hyper-native-tls = "0.2"
 lazy_static = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ doc = false
 byteorder = "1.0"
 chrono = "0.4"
 clap = "2.20.5"
+coco = "0.2.0"
 fern = "0.4"
 elastic = "0.13"
 elastic_types = "0.19"

--- a/examples/configs/basic.toml
+++ b/examples/configs/basic.toml
@@ -8,60 +8,21 @@ source = "cernan"
 
 [sources]
   [sources.internal]
-  forwards = ["sinks.console", "sinks.null"]
-
-  [sources.statsd.primary]
-  enabled = true
-  port = 8125
-  forwards = ["sinks.console", "sinks.null", "sinks.influxdb", "sinks.prometheus"]
-
-  [sources.native.primary]
-  ip = "127.0.0.1"
-  port = 1972
-  forwards = ["sinks.console", "sinks.null", "sinks.influxdb", "sinks.prometheus"]
+  # forwards = ["filters.delay.two_seconds"]
+  forwards = ["sinks.console"]
 
   [sources.graphite.primary]
-  enabled = true
   port = 2004
-  forwards = ["filters.collectd_scrub"]
-
-  [sources.files]
-  [sources.files.example_log]
-  path = "example.log"
-  forwards = ["sinks.firehose.stream_two"]
-
-  [sources.files.foo_log]
-  path = "foo.log"
-  forwards = ["sinks.firehose.stream_two"]
+  forwards = ["filters.delay.two_seconds"]
 
 [filters]
-  [filters.collectd_scrub]
-  script = "collectd_scrub.lua"
-  forwards = ["sinks.console", "sinks.null", "sinks.influxdb", "sinks.prometheus"]
+  [filters.delay.two_seconds]
+  tolerance = 2
+  forwards = ["sinks.console"]
+
+#   [filters.flush_boundary.four_seconds]
+#   tolerance = 4
+#   forwards = ["sinks.console", "sinks.null"]
 
 [sinks]
   [sinks.console]
-  bin_width = 1
-
-  [sinks.null]
-
-  # [sinks.wavefront]
-  # port = 2878
-  # host = "127.0.0.1"
-  # bin_width = 1
-
-  [sinks.influxdb]
-  port = 8089
-  host = "127.0.0.1"
-  bin_width = 1
-
-  [sinks.prometheus]
-  port = 8080
-  host = "127.0.0.1"
-  bin_width = 1
-
-  [sinks.firehose.stream_two]
-  delivery_stream = "stream_two"
-  batch_size = 800
-  region = "us-east-1"
-

--- a/examples/configs/basic.toml
+++ b/examples/configs/basic.toml
@@ -8,21 +8,22 @@ source = "cernan"
 
 [sources]
   [sources.internal]
-  # forwards = ["filters.delay.two_seconds"]
   forwards = ["sinks.console"]
 
   [sources.graphite.primary]
   port = 2004
-  forwards = ["filters.delay.two_seconds"]
+  forwards = ["filters.delay.smallish"]
+  # forwards = ["sinks.console"]
 
 [filters]
-  [filters.delay.two_seconds]
+  [filters.delay.smallish]
   tolerance = 2
   forwards = ["sinks.console"]
+  # forwards = ["filters.flush_boundary.smallish"]
 
-#   [filters.flush_boundary.four_seconds]
-#   tolerance = 4
-#   forwards = ["sinks.console", "sinks.null"]
+  # [filters.flush_boundary.smallish]
+  # tolerance = 4
+  # forwards = ["sinks.console"]
 
 [sinks]
   [sinks.console]

--- a/examples/configs/basic.toml
+++ b/examples/configs/basic.toml
@@ -8,22 +8,67 @@ source = "cernan"
 
 [sources]
   [sources.internal]
-  forwards = ["sinks.console"]
+  forwards = ["sinks.console", "sinks.null"]
+
+  [sources.statsd.primary]
+  enabled = true
+  port = 8125
+  forwards = ["sinks.console", "filters.delay.two_seconds"]
+
+  [sources.native.primary]
+  ip = "127.0.0.1"
+  port = 1972
+  forwards = ["filters.delay.two_seconds"]
 
   [sources.graphite.primary]
+  enabled = true
   port = 2004
-  forwards = ["filters.delay.smallish"]
-  # forwards = ["sinks.console"]
+  forwards = ["filters.programmable.collectd_scrub"]
+
+  [sources.files]
+  [sources.files.example_log]
+  path = "example.log"
+  forwards = ["sinks.firehose.stream_two"]
+
+  [sources.files.foo_log]
+  path = "foo.log"
+  forwards = ["sinks.firehose.stream_two"]
 
 [filters]
-  [filters.delay.smallish]
-  tolerance = 2
-  forwards = ["sinks.console"]
-  # forwards = ["filters.flush_boundary.smallish"]
+  [filters.programmable.collectd_scrub]
+  script = "collectd_scrub.lua"
+  forwards = ["filters.delay.two_seconds"]
 
-  # [filters.flush_boundary.smallish]
-  # tolerance = 4
-  # forwards = ["sinks.console"]
+  [filters.delay.two_seconds]
+  tolerance = 2
+  forwards = ["filters.flush_boundary.two_seconds"]
+
+  [filters.flush_boundary.two_seconds]
+  tolerance = 2
+  forwards = ["sinks.console", "sinks.null", "sinks.influxdb", "sinks.prometheus"]
 
 [sinks]
   [sinks.console]
+  bin_width = 1
+
+  [sinks.null]
+
+  # [sinks.wavefront]
+  # port = 2878
+  # host = "127.0.0.1"
+  # bin_width = 1
+
+  [sinks.influxdb]
+  port = 8089
+  host = "127.0.0.1"
+  bin_width = 1
+
+  [sinks.prometheus]
+  port = 8080
+  host = "127.0.0.1"
+  bin_width = 1
+
+  [sinks.firehose.stream_two]
+  delivery_stream = "stream_two"
+  batch_size = 800
+  region = "us-east-1"

--- a/src/filter/delay_filter.rs
+++ b/src/filter/delay_filter.rs
@@ -1,7 +1,26 @@
+//! Filter streams to within a bounded interval of current time.
+//!
+//! This filter is intended to remove items from the stream which are too old,
+//! as defined by the current time and the configured `tolerance`. That is, if
+//! for some time `T`, `(T - time::now()).abs() > tolerance` the item associated
+//! with `T` will be rejected.
 use filter;
 use metric;
 use time;
 use util;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+lazy_static! {
+    /// Total number of telemetry rejected for age 
+    pub static ref DELAY_TELEM_REJECT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    /// Total number of telemetry accepted for age 
+    pub static ref DELAY_TELEM_ACCEPT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    /// Total number of logline rejected for age 
+    pub static ref DELAY_LOG_REJECT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    /// Total number of logline accepted for age 
+    pub static ref DELAY_LOG_ACCEPT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+}
 
 /// Filter streams to within a bounded interval of current time.
 ///
@@ -47,13 +66,19 @@ impl filter::Filter for DelayFilter {
             metric::Event::Telemetry(m) => if let Some(ref telem) = *m {
                 let telem = telem.clone();
                 if (telem.timestamp - time::now()).abs() < self.tolerance {
+                    DELAY_TELEM_ACCEPT.fetch_add(1, Ordering::Release);
                     res.push(metric::Event::new_telemetry(telem));
+                } else {
+                    DELAY_TELEM_REJECT.fetch_add(1, Ordering::Release);
                 }
             },
             metric::Event::Log(l) => if let Some(ref log) = *l {
                 let log = log.clone();
                 if (log.time - time::now()).abs() < self.tolerance {
+                    DELAY_LOG_ACCEPT.fetch_add(1, Ordering::Release);
                     res.push(metric::Event::new_log(log));
+                } else {
+                    DELAY_LOG_REJECT.fetch_add(1, Ordering::Release);
                 }
             },
             metric::Event::TimerFlush(f) => {

--- a/src/filter/delay_filter.rs
+++ b/src/filter/delay_filter.rs
@@ -4,21 +4,22 @@
 //! as defined by the current time and the configured `tolerance`. That is, if
 //! for some time `T`, `(T - time::now()).abs() > tolerance` the item associated
 //! with `T` will be rejected.
+
 use filter;
 use metric;
-use time;
-use util;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use time;
+use util;
 
 lazy_static! {
-    /// Total number of telemetry rejected for age 
+    /// Total number of telemetry rejected for age
     pub static ref DELAY_TELEM_REJECT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of telemetry accepted for age 
+    /// Total number of telemetry accepted for age
     pub static ref DELAY_TELEM_ACCEPT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of logline rejected for age 
+    /// Total number of logline rejected for age
     pub static ref DELAY_LOG_REJECT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of logline accepted for age 
+    /// Total number of logline accepted for age
     pub static ref DELAY_LOG_ACCEPT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
 }
 
@@ -66,19 +67,19 @@ impl filter::Filter for DelayFilter {
             metric::Event::Telemetry(m) => if let Some(ref telem) = *m {
                 let telem = telem.clone();
                 if (telem.timestamp - time::now()).abs() < self.tolerance {
-                    DELAY_TELEM_ACCEPT.fetch_add(1, Ordering::Release);
+                    DELAY_TELEM_ACCEPT.fetch_add(1, Ordering::Relaxed);
                     res.push(metric::Event::new_telemetry(telem));
                 } else {
-                    DELAY_TELEM_REJECT.fetch_add(1, Ordering::Release);
+                    DELAY_TELEM_REJECT.fetch_add(1, Ordering::Relaxed);
                 }
             },
             metric::Event::Log(l) => if let Some(ref log) = *l {
                 let log = log.clone();
                 if (log.time - time::now()).abs() < self.tolerance {
-                    DELAY_LOG_ACCEPT.fetch_add(1, Ordering::Release);
+                    DELAY_LOG_ACCEPT.fetch_add(1, Ordering::Relaxed);
                     res.push(metric::Event::new_log(log));
                 } else {
-                    DELAY_LOG_REJECT.fetch_add(1, Ordering::Release);
+                    DELAY_LOG_REJECT.fetch_add(1, Ordering::Relaxed);
                 }
             },
             metric::Event::TimerFlush(f) => {

--- a/src/filter/delay_filter.rs
+++ b/src/filter/delay_filter.rs
@@ -1,3 +1,4 @@
+use util;
 use filter;
 use metric;
 use source::report_telemetry;
@@ -38,6 +39,10 @@ impl DelayFilter {
 }
 
 impl filter::Filter for DelayFilter {
+    fn valve_state(&self) -> util::Valve {
+        util::Valve::Open
+    }
+
     fn process(
         &mut self,
         event: metric::Event,

--- a/src/filter/flush_boundary_filter.rs
+++ b/src/filter/flush_boundary_filter.rs
@@ -2,7 +2,6 @@ use filter;
 use metric;
 use std::mem;
 use util;
-use source;
 
 /// Buffer events for a set period of flushes
 ///
@@ -56,17 +55,15 @@ impl FlushBoundaryFilter {
 
     /// Count the number of stored events in the filter
     pub fn count(&self) -> usize {
-        self.holds.iter().fold(0, |acc, ref hld| acc + hld.events.len())
+        self.holds.iter().fold(0, |acc, hld| acc + hld.events.len())
     }
 }
 
 impl filter::Filter for FlushBoundaryFilter {
     fn valve_state(&self) -> util::Valve {
-        if self.count() > 1000 {
-            source::report_telemetry("cernan.filter.flush_boundary.valve.closed", 1.0);
+        if self.count() > 10_000 {
             util::Valve::Closed
         } else {
-            source::report_telemetry("cernan.filter.flush_boundary.valve.open", 1.0);
             util::Valve::Open
         }
     }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -11,7 +11,7 @@ use time;
 use util;
 
 mod programmable_filter;
-mod delay_filter;
+pub mod delay_filter;
 mod flush_boundary_filter;
 
 pub use self::delay_filter::{DelayFilter, DelayFilterConfig};

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -54,6 +54,10 @@ pub trait Filter {
         res: &mut Vec<metric::Event>,
     ) -> Result<(), FilterError>;
 
+    /// Lookup the `Filter` valve state. See `Valve` documentation for more
+    /// information.
+    fn valve_state(&self) -> util::Valve;
+
     /// Run the Filter
     ///
     /// It is not expected that most Filters will re-implement this. If this is
@@ -73,7 +77,8 @@ pub trait Filter {
                 None => attempts += 1,
                 Some(event) => {
                     attempts = 0;
-                    match self.process(event, &mut events) {
+                    match self.valve_state() {
+                        util::Valve::Open => match self.process(event, &mut events) {
                         Ok(()) => {
                             for ev in events.drain(..) {
                                 util::send(&mut chans, ev)
@@ -87,8 +92,14 @@ pub trait Filter {
                             let event = event_in_fe(fe);
                             util::send(&mut chans, event);
                         }
+                        },
+                        util::Valve::Closed => {
+                            attempts += 1;
+                            continue;
+                        }
                     }
                 }
+                
             }
         }
     }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -79,19 +79,19 @@ pub trait Filter {
                     attempts = 0;
                     match self.valve_state() {
                         util::Valve::Open => match self.process(event, &mut events) {
-                        Ok(()) => {
+                            Ok(()) => {
                             for ev in events.drain(..) {
                                 util::send(&mut chans, ev)
                             }
                         }
-                        Err(fe) => {
-                            error!(
-                                "Failed to run filter with error: {:?}",
-                                name_in_fe(&fe)
-                            );
-                            let event = event_in_fe(fe);
-                            util::send(&mut chans, event);
-                        }
+                            Err(fe) => {
+                                error!(
+                                    "Failed to run filter with error: {:?}",
+                                    name_in_fe(&fe)
+                                );
+                                let event = event_in_fe(fe);
+                                util::send(&mut chans, event);
+                            }
                         },
                         util::Valve::Closed => {
                             attempts += 1;
@@ -99,7 +99,7 @@ pub trait Filter {
                         }
                     }
                 }
-                
+
             }
         }
     }

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -1,12 +1,12 @@
 use filter;
 use libc::c_int;
-use util;
 use lua;
 use lua::{Function, State, ThreadStatus};
 use lua::ffi::lua_State;
 use metric;
 use std::path::PathBuf;
 use std::sync;
+use util;
 
 struct Payload<'a> {
     metrics: Vec<Box<metric::Telemetry>>,

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -1,6 +1,6 @@
 use filter;
 use libc::c_int;
-
+use util;
 use lua;
 use lua::{Function, State, ThreadStatus};
 use lua::ffi::lua_State;
@@ -508,6 +508,10 @@ impl ProgrammableFilter {
 }
 
 impl filter::Filter for ProgrammableFilter {
+    fn valve_state(&self) -> util::Valve {
+        util::Valve::Open
+    }
+
     fn process(
         &mut self,
         event: metric::Event,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ extern crate rusoto_core;
 extern crate rusoto_firehose;
 extern crate seahash;
 extern crate serde;
+extern crate coco;
 #[macro_use]
 extern crate serde_json;
 extern crate toml;

--- a/src/metric/tagmap.rs
+++ b/src/metric/tagmap.rs
@@ -41,7 +41,9 @@ where
         if self.inner.len() != other.inner.len() {
             false
         } else {
-            for (&(ref k, ref v), &(ref o_k, ref o_v)) in self.inner.iter().zip(other.inner.iter()) {
+            for (&(ref k, ref v), &(ref o_k, ref o_v)) in
+                self.inner.iter().zip(other.inner.iter())
+            {
                 if (k != o_k) || (v != o_v) {
                     return false;
                 }

--- a/src/sink/elasticsearch.rs
+++ b/src/sink/elasticsearch.rs
@@ -1,16 +1,29 @@
+//! ElasticSearch is a documentation indexing engine. 
 use chrono::DateTime;
 use chrono::naive::NaiveDateTime;
 use chrono::offset::Utc;
 use elastic::error::Result;
 use elastic::prelude::*;
-
 use metric::{LogLine, Telemetry};
-
 use sink::{Sink, Valve};
-use source::report_telemetry;
 use std::sync;
 use time;
 use uuid::Uuid;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+lazy_static! {
+    /// Total deliveries made
+    pub static ref ELASTIC_RECORDS_DELIVERY: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    /// Total records delivered in the last delivery
+    pub static ref ELASTIC_RECORDS_TOTAL_DELIVERED: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    /// Total records that failed to be delivered due to error
+    pub static ref ELASTIC_RECORDS_TOTAL_FAILED: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    /// Total errors during attempted delivery 
+    pub static ref ELASTIC_ERROR_ATTEMPTS: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    /// Total errors during attempted delivery, unknown
+    pub static ref ELASTIC_ERROR_UNKNOWN: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+}
 
 /// Configuration for the Elasticsearch sink
 ///
@@ -132,33 +145,18 @@ impl Sink for Elasticsearch {
             match bulk_resp {
                 Ok(bulk) => {
                     self.buffer.clear();
-                    report_telemetry(
-                        "cernan.sinks.elasticsearch.records.delivery",
-                        1.0,
-                    );
-                    report_telemetry(
-                        "cernan.sinks.elasticsearch.records.total_delivered",
-                        bulk.items.ok.len() as f64,
-                    );
+                    ELASTIC_RECORDS_DELIVERY.fetch_add(1, Ordering::Release);
+                    ELASTIC_RECORDS_TOTAL_DELIVERED.fetch_add(1, Ordering::Release);
                     let failed_count = bulk.items.err.len();
                     if failed_count > 0 {
-                        report_telemetry(
-                            "cernan.sinks.elasticsearch.records.total_failed",
-                            failed_count as f64,
-                        );
+                        ELASTIC_RECORDS_TOTAL_FAILED.fetch_add(1, Ordering::Release);
                         error!("Failed to write {} put records", failed_count);
                     }
                     return;
                 }
                 Err(err) => {
-                    report_telemetry(
-                        "cernan.sinks.elasticsearch.error.attempts",
-                        attempts as f64,
-                    );
-                    report_telemetry(
-                        "cernan.sinks.elasticsearch.error.reason.unknown",
-                        1.0,
-                    );
+                    ELASTIC_ERROR_ATTEMPTS.fetch_add(attempts as usize, Ordering::Release);
+                    ELASTIC_ERROR_UNKNOWN.fetch_add(1, Ordering::Release);
                     error!("Unable to write, unknown failure: {}", err);
                     attempts += 1;
                     time::delay(attempts);

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -1,14 +1,27 @@
+//! InfluxDB is a telemetry database.
 use hyper::Client;
 use hyper::header;
 use metric::{LogLine, TagMap, Telemetry};
 use quantiles::histogram::Bound;
 use sink::{Sink, Valve};
-use source::report_telemetry;
 use std::cmp;
 use std::string;
 use std::sync;
 use time;
 use url::Url;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+lazy_static! {
+    /// total delivery attempts made by this sink 
+    pub static ref INFLUX_DELIVERY_ATTEMPTS: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    /// total successful delivery attempts made by this sink 
+    pub static ref INFLUX_SUCCESS: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    /// total failed delivery attempts because of client error
+    pub static ref INFLUX_FAILURE_CLIENT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    /// total failed delivery attempts because of server error
+    pub static ref INFLUX_FAILURE_SERVER: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+}
 
 /// The `InfluxDB` structure
 ///
@@ -227,10 +240,7 @@ impl Sink for InfluxDB {
             // delivery_attempts_0 waits. The idea is that a failure that
             // happens to succeed may succeed against a degraded system; we
             // should not assume full health.
-            report_telemetry(
-                "cernan.sinks.influxdb.delivery_attempts",
-                self.delivery_attempts as f64,
-            );
+            INFLUX_DELIVERY_ATTEMPTS.fetch_add(self.delivery_attempts as usize, Ordering::Release);
             time::delay(self.delivery_attempts);
 
             match self.client
@@ -244,7 +254,7 @@ impl Sink for InfluxDB {
                     // https://docs.influxdata.com/influxdb/v1.
                     // 2/guides/writing_data/#http-response-summary
                     if resp.status.is_success() {
-                        report_telemetry("cernan.sinks.influxdb.success", 1.0);
+                        INFLUX_SUCCESS.fetch_add(1, Ordering::Release);
                         buffer.clear();
                         self.delivery_attempts =
                             self.delivery_attempts.saturating_sub(1);
@@ -252,17 +262,11 @@ impl Sink for InfluxDB {
                     } else if resp.status.is_client_error() {
                         self.delivery_attempts =
                             self.delivery_attempts.saturating_add(1);
-                        report_telemetry(
-                            "cernan.sinks.influxdb.failure.client_error",
-                            1.0,
-                        );
+                        INFLUX_FAILURE_CLIENT.fetch_add(1, Ordering::Release);
                     } else if resp.status.is_server_error() {
                         self.delivery_attempts =
                             self.delivery_attempts.saturating_add(1);
-                        report_telemetry(
-                            "cernan.sinks.influxdb.failure.server_error",
-                            1.0,
-                        );
+                        INFLUX_FAILURE_SERVER.fetch_add(1, Ordering::Release);
                     }
                 }
             }

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -563,8 +563,10 @@ impl Sink for Wavefront {
 
     fn valve_state(&self) -> Valve {
         if self.aggrs.len() > 10_000 {
+            report_telemetry("cernan.sink.wavefront.valve.closed", 1.0);
             Valve::Closed
         } else {
+            report_telemetry("cernan.sink.wavefront.valve.open", 1.0);
             Valve::Open
         }
     }

--- a/src/source/graphite.rs
+++ b/src/source/graphite.rs
@@ -76,7 +76,7 @@ fn handle_tcp(
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || for stream in listner.incoming() {
         if let Ok(stream) = stream {
-            GRAPHITE_NEW_PEER.fetch_add(1, Ordering::Release);
+            GRAPHITE_NEW_PEER.fetch_add(1, Ordering::Relaxed);
             debug!(
                 "new peer at {:?} | local addr for peer {:?}",
                 stream.peer_addr(),
@@ -106,14 +106,14 @@ fn handle_stream(
             if len > 0 {
                 if parse_graphite(&line, &mut res, basic_metric.clone()) {
                     assert!(!res.is_empty());
-                    GRAPHITE_GOOD_PACKET.fetch_add(1, Ordering::Release);
-                    GRAPHITE_TELEM.fetch_add(res.len(), Ordering::Release);
+                    GRAPHITE_GOOD_PACKET.fetch_add(1, Ordering::Relaxed);
+                    GRAPHITE_TELEM.fetch_add(1, Ordering::Relaxed);
                     for m in res.drain(..) {
                         send(&mut chans, metric::Event::Telemetry(Arc::new(Some(m))));
                     }
                     line.clear();
                 } else {
-                    GRAPHITE_BAD_PACKET.fetch_add(1, Ordering::Release);
+                    GRAPHITE_BAD_PACKET.fetch_add(1, Ordering::Relaxed);
                     error!("bad packet: {:?}", line);
                     line.clear();
                 }

--- a/src/source/graphite.rs
+++ b/src/source/graphite.rs
@@ -1,16 +1,22 @@
 use super::Source;
 use metric;
 use protocols::graphite::parse_graphite;
-use source::internal::report_telemetry;
 use std::io::BufReader;
 use std::io::prelude::*;
 use std::net::{TcpListener, TcpStream};
 use std::net::ToSocketAddrs;
 use std::str;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 use util;
 use util::send;
+
+lazy_static! {
+    pub static ref GRAPHITE_NEW_PEER: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    pub static ref GRAPHITE_GOOD_PACKET: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    pub static ref GRAPHITE_BAD_PACKET: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+}
 
 /// Graphite protocol source
 ///
@@ -69,7 +75,7 @@ fn handle_tcp(
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || for stream in listner.incoming() {
         if let Ok(stream) = stream {
-            report_telemetry("cernan.graphite.new_peer", 1.0);
+            GRAPHITE_NEW_PEER.fetch_add(1, Ordering::Release);
             debug!(
                 "new peer at {:?} | local addr for peer {:?}",
                 stream.peer_addr(),
@@ -98,13 +104,13 @@ fn handle_stream(
         while let Some(len) = line_reader.read_line(&mut line).ok() {
             if len > 0 {
                 if parse_graphite(&line, &mut res, basic_metric.clone()) {
-                    report_telemetry("cernan.graphite.packet", 1.0);
+                    GRAPHITE_GOOD_PACKET.fetch_add(1, Ordering::Release);
                     for m in res.drain(..) {
                         send(&mut chans, metric::Event::Telemetry(Arc::new(Some(m))));
                     }
                     line.clear();
                 } else {
-                    report_telemetry("cernan.graphite.bad_packet", 1.0);
+                    GRAPHITE_BAD_PACKET.fetch_add(1, Ordering::Release);
                     error!("bad packet: {:?}", line);
                     line.clear();
                 }

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -2,6 +2,7 @@ use coco::Stack;
 use metric;
 use metric::{AggregationMethod, Telemetry};
 use source;
+use filter;
 use sink;
 use source::Source;
 use std;
@@ -119,6 +120,12 @@ impl Source for Internal {
                 atom_non_zero_telem!(
                     "cernan.graphite.packet",
                     source::graphite::GRAPHITE_GOOD_PACKET,
+                    self.tags,
+                    self.chans
+                );
+                atom_non_zero_telem!(
+                    "cernan.graphite.telemetry.received",
+                    source::graphite::GRAPHITE_TELEM,
                     self.tags,
                     self.chans
                 );
@@ -268,6 +275,31 @@ impl Source for Internal {
                 atom_non_zero_telem!(
                     "cernan.sinks.influxdb.failure.server_error",
                     sink::influxdb::INFLUX_FAILURE_SERVER,
+                    self.tags,
+                    self.chans
+                );
+                // filter::delay_filter
+                atom_non_zero_telem!(
+                    "cernan.filters.delay.telemetry.accept",
+                    filter::delay_filter::DELAY_TELEM_ACCEPT,
+                    self.tags,
+                    self.chans
+                );
+                atom_non_zero_telem!(
+                    "cernan.filters.delay.telemetry.reject",
+                    filter::delay_filter::DELAY_TELEM_REJECT,
+                    self.tags,
+                    self.chans
+                );
+                atom_non_zero_telem!(
+                    "cernan.filters.delay.log.reject",
+                    filter::delay_filter::DELAY_LOG_REJECT,
+                    self.tags,
+                    self.chans
+                );
+                atom_non_zero_telem!(
+                    "cernan.filters.delay.log.accept",
+                    filter::delay_filter::DELAY_LOG_ACCEPT,
                     self.tags,
                     self.chans
                 );

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -13,8 +13,7 @@ mod statsd;
 pub use self::file::{FileServer, FileServerConfig};
 pub use self::flush::FlushTimer;
 pub use self::graphite::{Graphite, GraphiteConfig};
-pub use self::internal::{report_full_telemetry, Internal,
-                         InternalConfig};
+pub use self::internal::{report_full_telemetry, Internal, InternalConfig};
 pub use self::native::{NativeServer, NativeServerConfig};
 pub use self::statsd::{Statsd, StatsdConfig};
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -13,7 +13,7 @@ mod statsd;
 pub use self::file::{FileServer, FileServerConfig};
 pub use self::flush::FlushTimer;
 pub use self::graphite::{Graphite, GraphiteConfig};
-pub use self::internal::{report_full_telemetry, report_telemetry, Internal,
+pub use self::internal::{report_full_telemetry, Internal,
                          InternalConfig};
 pub use self::native::{NativeServer, NativeServerConfig};
 pub use self::statsd::{Statsd, StatsdConfig};

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -4,11 +4,11 @@ use source::Source;
 use std::net::{ToSocketAddrs, UdpSocket};
 use std::str;
 use std::sync;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 use util;
 use util::send;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 lazy_static! {
     pub static ref STATSD_GOOD_PACKET: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
@@ -86,9 +86,9 @@ fn handle_udp(
                 for m in metrics.drain(..) {
                     send(&mut chans, metric::Event::new_telemetry(m));
                 }
-                STATSD_GOOD_PACKET.fetch_add(1, Ordering::Release);
+                STATSD_GOOD_PACKET.fetch_add(1, Ordering::Relaxed);
             } else {
-                STATSD_BAD_PACKET.fetch_add(1, Ordering::Release);
+                STATSD_BAD_PACKET.fetch_add(1, Ordering::Relaxed);
                 error!("BAD PACKET: {:?}", val);
             },
             Err(e) => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,3 +18,19 @@ pub fn send(chans: &mut Channel, event: metric::Event) {
         chans[0].send(event);
     }
 }
+
+/// Determine the state of a buffering queue, whether open or closed.
+///
+/// Cernan is architected to be a push-based system. It copes with demand rushes
+/// by buffering to disk -- via the hopper queues -- and rejecting memory-based
+/// storage with overload signals. This signal, in particular, limits the amount
+/// of information delivered to a filter / sink by declaring that said filter /
+/// sink's input 'valve' is closed. Exactly how and why a filter / sink declares
+/// its valve state is left to the implementation.
+pub enum Valve {
+    /// In the `Open` state a filter / sink will accept new inputs
+    Open,
+    /// In the `Closed` state a filter / sink will reject new inputs, backing
+    /// them up in the communication queue.
+    Closed,
+}


### PR DESCRIPTION
This sequence of commits corrects a freeze-up issue observed in development cernan. Namely it:

* removes a great deal of allocated Telemetry for internal metrics
* corrects an issue with bucket iteration 
* reduces contention on allocated Telemetry for internal metrics 
* introduces more self-telemetry 

Please see individual commits for details. 