### PR TITLE
Padding control for wavefront sink

### DIFF
--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -825,7 +825,7 @@ mod test {
     fn same_names_in_and_out() {
         fn inner(ms: Vec<Telemetry>, loops: usize) -> TestResult {
             if loops == 0 {
-                return TestResult::discard()
+                return TestResult::discard();
             }
 
             let mut bucket = Buckets::new(1);
@@ -835,7 +835,7 @@ mod test {
                 expected_names.insert(m.name);
             }
             if expected_names.len() == 1 {
-                return TestResult::discard()
+                return TestResult::discard();
             }
 
             for _ in 0..loops {


### PR DESCRIPTION
This commit adds configuration knobs in the wavefront sink to turn zero-padding on and off by aggregation type. Padding was introduced in 0.7.0 but there's been concern with the results now that 0.7.1 is out and about. We now allow users to decide to pad or not.

By default this feature is OFF for all aggregations. Research by @pulltab suggests that neither etsy/statsd nor statsite have this feature.

This resolves #301

Signed-off-by: Brian L. Troutwine <blt@postmates.com>