### PR TITLE
Drain unbounded buffer in Internal source

### DIFF
--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -316,10 +316,10 @@ impl Source for Internal {
                     }
                 }
             } else {
-                // do nothing, intentionally
+                while let Some(_) = Q.pop() {
+                    // do nothing, intentionally
+                }
             }
-
-
         }
     }
 }

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -316,6 +316,9 @@ impl Source for Internal {
                     }
                 }
             } else {
+                // There are no chans available. In this case we want to drain
+                // and deallocate any internal telemetry that may have made it
+                // to Q.
                 while let Some(_) = Q.pop() {
                     // do nothing, intentionally
                 }


### PR DESCRIPTION
This commit drains the unbounded buffer in the Internal source in
the case where there's no channels to push Internal metrics into.
This resolves #260

Signed-off-by: Brian L. Troutwine <blt@postmates.com>