### PR TITLE
Deallocate unused structures in cernan startup

### DIFF
--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -381,7 +381,7 @@ fn main() {
         },
     );
 
-    let internal_config = args.internal;
+    let internal_config = mem::replace(&mut args.internal, Default::default());
     let mut internal_send = Vec::new();
     populate_forwards(
         &mut internal_send,
@@ -456,10 +456,17 @@ fn main() {
                 }
             }
         }
+        drop(flush_sends);
+        drop(senders);
         cernan::source::FlushTimer::new(flush_channels).run();
     }));
 
     joins.push(thread::spawn(move || { cernan::time::update_time(); }));
+
+    drop(args);
+    drop(config_topology);
+    drop(level);
+    drop(receivers);
 
     for jh in joins {
         // TODO Having sub-threads panic will not cause a bubble-up if that


### PR DESCRIPTION
This commit deallocates the unused structures that are created as
a part of the cernan startup routine. This is especially important
with regard to the hopper Senders present in 'senders' and 'flush_sends'
as these contain file descriptors which will NOT be closed until
such time as the Sender's original thread lets go of it.

This is related to the work being done as a part of #244.

This commit has the benefit is slightly reducing cernan's memory draw.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>