### PR TITLE
Allow hopper maximum index size to be configured

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cernan"
-version = "0.7.6"
+version = "0.7.7-pre"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.7.6"
+version = "0.7.7-pre"
 
 [[bin]]
 name = "cernan"

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -107,7 +107,7 @@ fn main() {
     // SINKS
     if let Some(ref config) = args.null {
         let (send, recv) =
-            hopper::channel(&config.config_path, &args.data_directory).unwrap();
+            hopper::channel_with_max_bytes(&config.config_path, &args.data_directory, args.max_hopper_queue_bytes).unwrap();
         senders.insert(config.config_path.clone(), send);
         receivers.insert(config.config_path.clone(), recv);
         config_topology.insert(config.config_path.clone(), Default::default());
@@ -115,7 +115,7 @@ fn main() {
     if let Some(ref config) = args.console {
         let config_path = cfg_conf!(config);
         let (send, recv) =
-            hopper::channel(&config_path, &args.data_directory).unwrap();
+            hopper::channel_with_max_bytes(&config_path, &args.data_directory, args.max_hopper_queue_bytes).unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
         config_topology.insert(config_path.clone(), Default::default());
@@ -123,7 +123,7 @@ fn main() {
     if let Some(ref config) = args.wavefront {
         let config_path = cfg_conf!(config);
         let (send, recv) =
-            hopper::channel(&config_path, &args.data_directory).unwrap();
+            hopper::channel_with_max_bytes(&config_path, &args.data_directory, args.max_hopper_queue_bytes).unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
         config_topology.insert(config_path.clone(), Default::default());
@@ -131,7 +131,7 @@ fn main() {
     if let Some(ref config) = args.prometheus {
         let config_path = cfg_conf!(config);
         let (send, recv) =
-            hopper::channel(&config_path, &args.data_directory).unwrap();
+            hopper::channel_with_max_bytes(&config_path, &args.data_directory, args.max_hopper_queue_bytes).unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
         config_topology.insert(config_path.clone(), Default::default());
@@ -139,7 +139,7 @@ fn main() {
     if let Some(ref config) = args.influxdb {
         let config_path = cfg_conf!(config);
         let (send, recv) =
-            hopper::channel(&config_path, &args.data_directory).unwrap();
+            hopper::channel_with_max_bytes(&config_path, &args.data_directory, args.max_hopper_queue_bytes).unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
         config_topology.insert(config_path.clone(), Default::default());
@@ -147,7 +147,7 @@ fn main() {
     if let Some(ref config) = args.native_sink_config {
         let config_path = cfg_conf!(config);
         let (send, recv) =
-            hopper::channel(&config_path, &args.data_directory).unwrap();
+            hopper::channel_with_max_bytes(&config_path, &args.data_directory, args.max_hopper_queue_bytes).unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
         config_topology.insert(config_path.clone(), Default::default());
@@ -155,7 +155,7 @@ fn main() {
     if let Some(ref config) = args.elasticsearch {
         let config_path = cfg_conf!(config);
         let (send, recv) =
-            hopper::channel(&config_path, &args.data_directory).unwrap();
+            hopper::channel_with_max_bytes(&config_path, &args.data_directory, args.max_hopper_queue_bytes).unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
         config_topology.insert(config_path.clone(), Default::default());
@@ -164,7 +164,7 @@ fn main() {
         for config in configs {
             let config_path = cfg_conf!(config);
             let (send, recv) =
-                hopper::channel(&config_path, &args.data_directory).unwrap();
+                hopper::channel_with_max_bytes(&config_path, &args.data_directory, args.max_hopper_queue_bytes).unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), Default::default());
@@ -174,7 +174,7 @@ fn main() {
     if let Some(ref configs) = args.programmable_filters {
         for (config_path, config) in configs {
             let (send, recv) =
-                hopper::channel(config_path, &args.data_directory).unwrap();
+                hopper::channel_with_max_bytes(config_path, &args.data_directory, args.max_hopper_queue_bytes).unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), config.forwards.clone());
@@ -183,7 +183,7 @@ fn main() {
     if let Some(ref configs) = args.delay_filters {
         for (config_path, config) in configs {
             let (send, recv) =
-                hopper::channel(config_path, &args.data_directory).unwrap();
+                hopper::channel_with_max_bytes(config_path, &args.data_directory, args.max_hopper_queue_bytes).unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), config.forwards.clone());
@@ -192,7 +192,7 @@ fn main() {
     if let Some(ref configs) = args.flush_boundary_filters {
         for (config_path, config) in configs {
             let (send, recv) =
-                hopper::channel(config_path, &args.data_directory).unwrap();
+                hopper::channel_with_max_bytes(config_path, &args.data_directory, args.max_hopper_queue_bytes).unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), config.forwards.clone());


### PR DESCRIPTION
This commit adds the `max-hopper-queue-bytes` configuration option
to cernan. This allows end-users to control the size of hopper's
index files, addressing issues on small-disk systems where active
index files fill up remaining disk space.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>