### PR TITLE
Avoid getting stuck on a closed sink valve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cernan"
-version = "0.7.6"
+version = "0.7.7-pre"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.7.6"
+version = "0.7.7-pre"
 
 [[bin]]
 name = "cernan"

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -57,7 +57,12 @@ pub trait Sink {
         loop {
             time::delay(attempts);
             match recv.next() {
-                None => attempts += 1,
+                None => {
+                    attempts += 1;
+                    if let Valve::Closed = self.valve_state() {
+                        self.flush();
+                    }
+                },
                 Some(event) => match self.valve_state() {
                     Valve::Open => match event {
                         Event::TimerFlush(idx) => if idx > last_flush_idx {
@@ -80,6 +85,7 @@ pub trait Sink {
                     },
                     Valve::Closed => {
                         attempts += 1;
+                        self.flush();
                         continue;
                     }
                 },


### PR DESCRIPTION
This commit corrects a condition where a sink can get stuck when
its valve state is closed. Consider the case where a flush is
required to clear a valve but no flush is possible because the valve
is closed. This is a deadlock.

This only affects bursty sinks with long flush times and low valve
thresholds, like the firehose sink.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>