### PR TITLE
Spruce up the cernan release build

### DIFF
--- a/build-container.sh
+++ b/build-container.sh
@@ -17,15 +17,10 @@ fi
 cargo clean
 
 VERSION="${1}"
-confd_version=0.11.0
-confd_url="https://github.com/kelseyhightower/confd/releases/download/v${confd_version}/confd-${confd_version}-linux-amd64"
-mkdir -p target/bindir/
-[ -f target/bindir/confd-bin ] || curl -L "$confd_url" > target/bindir/confd-bin
-chmod +x target/bindir/confd-bin
 
 docker build -t cernan-build -f docker/build/Dockerfile .
 docker run -v $(pwd):/source -w /source -it cernan-build cargo build --release
-cp target/release/cernan target/bindir/
+cp target/x86_64-unknown-linux-musl/release/cernan target/bindir/
 docker build -t quay.io/postmates/cernan:latest -t "quay.io/postmates/cernan:$VERSION" -f docker/release/Dockerfile .
 docker push "quay.io/postmates/cernan:$VERSION"
 docker push "quay.io/postmates/cernan:latest"

--- a/build-container.sh
+++ b/build-container.sh
@@ -18,9 +18,9 @@ cargo clean
 
 VERSION="${1}"
 
+mkdir -p target/bindir
 docker build -t cernan-build -f docker/build/Dockerfile .
 docker run -v $(pwd):/source -w /source -it cernan-build cargo build --release
-cp target/x86_64-unknown-linux-musl/release/cernan target/bindir/
 docker build -t quay.io/postmates/cernan:latest -t "quay.io/postmates/cernan:$VERSION" -f docker/release/Dockerfile .
 docker push "quay.io/postmates/cernan:$VERSION"
 docker push "quay.io/postmates/cernan:latest"

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:edge
+FROM ekidd/rust-musl-builder
 
-RUN apk add --no-cache --update \
-  git \
-  alpine-sdk \
-  perl \
-  openssl-dev \
-  cargo \
-  rust
+RUN VERS=1.2.11 && \
+    cd /home/rust/libs && \
+    curl -LO http://zlib.net/zlib-$VERS.tar.gz && \
+    tar xzf zlib-$VERS.tar.gz && cd zlib-$VERS && \
+    CC=musl-gcc ./configure --static --prefix=/usr/local/musl && \
+    make && sudo make install && \
+    cd .. && rm -rf zlib-$VERS.tar.gz zlib-$VERS

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -7,14 +7,14 @@ RUN apk update \
 
 RUN apk add --no-cache --update \
   ca-certificates \
-  llvm-libunwind@testing \ 
+  llvm-libunwind@testing \
   openssl && \
   update-ca-certificates && \
   rm -rf /var/cache/apk/* && \
   mkdir -p /etc/cernan/scripts
 
 COPY docker/release/entrypoint.sh /entrypoint.sh
-COPY target/release/cernan /usr/bin/cernan
+COPY target/x86_64-unknown-linux-musl/release/cernan /usr/bin/cernan
 COPY examples/configs/quickstart.toml /etc/cernan/cernan.toml
 
 ENV STATSD_PORT 8125


### PR DESCRIPTION
We used to build releases inside Alpine Linux. This worked out okay for
a while but the rust version there has gotten very out of date as of
this writing. We're using ekidd/rust-musl-builder now, a Debian base
that'll crank out musl binaries. We're still targeting Alpine as the
deployment image.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>