### PR TITLE
Integrate openssl_probe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
   - nightly
 
 script:
-  - cargo build
+  - cargo clean
   - cargo test
 
 matrix:
@@ -30,7 +30,7 @@ addons:
       - binutils-dev
 
 after_success: |
-  wget https://github.com/SimonKagstrom/kcov/archive/v33.tar.gz && 
+  wget https://github.com/SimonKagstrom/kcov/archive/v33.tar.gz &&
   tar xzf v33.tar.gz &&
   cd kcov-33 &&
   mkdir build &&

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cernan"
-version = "0.7.7"
+version = "0.7.8-pre"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -17,6 +17,7 @@ dependencies = [
  "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lua 0.0.11 (git+https://github.com/blt/rust-lua53.git)",
+ "openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quantiles 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -695,6 +696,11 @@ dependencies = [
  "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
@@ -1434,6 +1440,7 @@ dependencies = [
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
 "checksum openssl 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)" = "085aaedcc89a2fac1eb2bc19cd66f29d4ea99fec60f82a5f3a88a6be7dbd90b5"
+"checksum openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d98df0270d404ccd3c050a41d579c52d1db15375168bb3471e04ec0f5f378daf"
 "checksum openssl-sys 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7e3a9845a4c9fdb321931868aae5549e96bb7b979bf9af7de03603d74691b5f3"
 "checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.7.7"
+version = "0.7.8-pre"
 
 [[bin]]
 name = "cernan"
@@ -18,9 +18,9 @@ byteorder = "1.0"
 chrono = "0.4"
 clap = "2.20.5"
 coco = "0.2.0"
-fern = "0.4"
 elastic = "0.13"
 elastic_types = "0.19"
+fern = "0.4"
 glob = "0.2.11"
 hopper = "0.3.2"
 hyper = "0.10"
@@ -29,8 +29,11 @@ lazy_static = "0.2.1"
 libc = "0.2"
 log = "0.3.6"
 lua = { git = "https://github.com/blt/rust-lua53.git", branch = "master" }
+openssl-probe = "0.1"
 protobuf = "1.2"
 quantiles = { version = "0.6", features = ["serde_support"] }
+rusoto_core = {version = "0.25.0"}
+rusoto_firehose = {version = "0.25.0"}
 seahash = "3.0"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
@@ -38,8 +41,6 @@ serde_json = "1.0"
 toml = "0.4"
 url = "1.4.0"
 uuid = {version = "0.5", features = ["v4"]}
-rusoto_core = {version = "0.25.0"}
-rusoto_firehose = {version = "0.25.0"}
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -6,6 +6,7 @@ extern crate fern;
 extern crate hopper;
 #[macro_use]
 extern crate log;
+extern crate openssl_probe;
 
 use cernan::filter::{DelayFilterConfig, Filter, FlushBoundaryFilterConfig,
                      ProgrammableFilterConfig};
@@ -56,6 +57,8 @@ macro_rules! cfg_conf {
 
 #[allow(cyclomatic_complexity)]
 fn main() {
+    openssl_probe::init_ssl_cert_env_vars();
+
     let mut args = cernan::config::parse_args();
 
     let level = match args.verbose {


### PR DESCRIPTION
We now build off alpine from emk/rust-musl-builder. We've had
reports since this switch of problems with Firehose OpenSSL.
This commit follows the instructions found here:

https://github.com/emk/rust-musl-builder#making-openssl-work

Hopefully this will repair the situation.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>