### PR TITLE
Allow histograms to be flipped on for statsd metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "protobuf 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quantiles 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_firehose 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ lua = { git = "https://github.com/blt/rust-lua53.git", branch = "master" }
 openssl-probe = "0.1"
 protobuf = "1.2"
 quantiles = { version = "0.6", features = ["serde_support"] }
+regex = "0.2"
 rusoto_core = {version = "0.25.0"}
 rusoto_firehose = {version = "0.25.0"}
 seahash = "3.0"

--- a/benches/metrics.rs
+++ b/benches/metrics.rs
@@ -7,6 +7,7 @@ use self::test::Bencher;
 use cernan::metric::{TagMap, Telemetry};
 use cernan::protocols::graphite::parse_graphite;
 use cernan::protocols::statsd::parse_statsd;
+use cernan::source::StatsdParseConfig;
 use std::sync;
 
 #[bench]
@@ -32,7 +33,8 @@ fn bench_statsd_incr_gauge_no_sample(b: &mut Bencher) {
     b.iter(|| {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let mut res = Vec::new();
-        parse_statsd("a.b:+12.1|g\n", &mut res, metric);
+        let config = sync::Arc::new(StatsdParseConfig::default());
+        parse_statsd("a.b:+12.1|g\n", &mut res, metric, config);
     });
 }
 
@@ -41,7 +43,8 @@ fn bench_statsd_incr_gauge_with_sample(b: &mut Bencher) {
     b.iter(|| {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let mut res = Vec::new();
-        parse_statsd("a.b:+12.1|g@2.2\n", &mut res, metric);
+        let config = sync::Arc::new(StatsdParseConfig::default());
+        parse_statsd("a.b:+12.1|g@2.2\n", &mut res, metric, config);
     });
 }
 
@@ -50,7 +53,8 @@ fn bench_statsd_gauge_no_sample(b: &mut Bencher) {
     b.iter(|| {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let mut res = Vec::new();
-        parse_statsd("a.b:12.1|g\n", &mut res, metric);
+        let config = sync::Arc::new(StatsdParseConfig::default());
+        parse_statsd("a.b:12.1|g\n", &mut res, metric, config);
     });
 }
 
@@ -59,7 +63,8 @@ fn bench_statsd_gauge_mit_sample(b: &mut Bencher) {
     b.iter(|| {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let mut res = Vec::new();
-        parse_statsd("a.b:12.1|g@0.22\n", &mut res, metric);
+        let config = sync::Arc::new(StatsdParseConfig::default());
+        parse_statsd("a.b:12.1|g@0.22\n", &mut res, metric, config);
     });
 }
 
@@ -68,7 +73,8 @@ fn bench_statsd_counter_no_sample(b: &mut Bencher) {
     b.iter(|| {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let mut res = Vec::new();
-        parse_statsd("a.b:12.1|c\n", &mut res, metric);
+        let config = sync::Arc::new(StatsdParseConfig::default());
+        parse_statsd("a.b:12.1|c\n", &mut res, metric, config);
     });
 }
 
@@ -77,7 +83,8 @@ fn bench_statsd_counter_with_sample(b: &mut Bencher) {
     b.iter(|| {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let mut res = Vec::new();
-        parse_statsd("a.b:12.1|c@1.0\n", &mut res, metric);
+        let config = sync::Arc::new(StatsdParseConfig::default());
+        parse_statsd("a.b:12.1|c@1.0\n", &mut res, metric, config);
     });
 }
 
@@ -86,7 +93,8 @@ fn bench_statsd_timer(b: &mut Bencher) {
     b.iter(|| {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let mut res = Vec::new();
-        parse_statsd("a.b:12.1|ms\n", &mut res, metric);
+        let config = sync::Arc::new(StatsdParseConfig::default());
+        parse_statsd("a.b:12.1|ms\n", &mut res, metric, config);
     });
 }
 
@@ -95,7 +103,8 @@ fn bench_statsd_histogram(b: &mut Bencher) {
     b.iter(|| {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let mut res = Vec::new();
-        parse_statsd("a.b:12.1|h\n", &mut res, metric);
+        let config = sync::Arc::new(StatsdParseConfig::default());
+        parse_statsd("a.b:12.1|h\n", &mut res, metric, config);
     });
 }
 
@@ -104,6 +113,7 @@ fn bench_graphite(b: &mut Bencher) {
     b.iter(|| {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let mut res = Vec::new();
-        parse_graphite("fst 1 101\n", &mut res, metric);
+        let config = sync::Arc::new(StatsdParseConfig::default());
+        parse_graphite("fst 1 101\n", &mut res, metric, config);
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ extern crate libc;
 extern crate lua;
 extern crate protobuf;
 extern crate quantiles;
+extern crate regex;
 extern crate rusoto_core;
 extern crate rusoto_firehose;
 extern crate seahash;

--- a/src/protocols/statsd.rs
+++ b/src/protocols/statsd.rs
@@ -4,6 +4,7 @@
 
 use metric;
 use metric::AggregationMethod;
+use source::StatsdParseConfig;
 use std::str::FromStr;
 use std::sync;
 use time;
@@ -22,6 +23,7 @@ pub fn parse_statsd(
     source: &str,
     res: &mut Vec<metric::Telemetry>,
     metric: sync::Arc<Option<metric::Telemetry>>,
+    config: sync::Arc<StatsdParseConfig>,
 ) -> bool {
     for src in source.lines() {
         let mut offset = 0;
@@ -95,9 +97,15 @@ pub fn parse_statsd(
                                             Ok(f) => f,
                                             Err(_) => return false,
                                         };
+                                        metric = metric.persist(false);
                                         metric = metric
-                                            .kind(AggregationMethod::Summarize)
-                                            .persist(false);
+                                            .kind(AggregationMethod::Summarize);
+                                        for &(ref mask_re, ref bounds) in config.histogram_masks.iter() {
+                                            if mask_re.is_match(name) {
+                                                metric = metric.kind(AggregationMethod::Histogram).bounds(bounds.clone());
+                                                break;
+                                            }
+                                        }
                                         metric.value(val * (1.0 / sample))
                                     }
                                     _ => return false,
@@ -112,9 +120,18 @@ pub fn parse_statsd(
                                         metric.kind(AggregationMethod::Set)
                                     }
                                 }
-                                "ms" | "h" => metric
-                                    .kind(AggregationMethod::Summarize)
-                                    .persist(false),
+                                "ms" | "h" => {
+                                    metric = metric.persist(false);
+                                    metric = metric
+                                        .kind(AggregationMethod::Summarize);
+                                    for &(ref mask_re, ref bounds) in config.histogram_masks.iter() {
+                                        if mask_re.is_match(name) {
+                                            metric = metric.kind(AggregationMethod::Histogram).bounds(bounds.clone());
+                                            break;
+                                        }
+                                    }
+                                    metric
+                                }, 
                                 "c" => {
                                     metric.kind(AggregationMethod::Sum).persist(false)
                                 }
@@ -279,7 +296,9 @@ mod tests {
             let metric = sync::Arc::new(Some(Telemetry::default()));
             let mut res = Vec::new();
 
-            if parse_statsd(&lines, &mut res, metric) {
+            let config = sync::Arc::new(StatsdParseConfig::default());
+
+            if parse_statsd(&lines, &mut res, metric, config) {
                 assert_eq!(res.len(), pyld.lines.len());
                 for (sline, telem) in pyld.lines.iter().zip(res.iter()) {
                     assert_eq!(sline.name, telem.name);
@@ -325,11 +344,13 @@ mod tests {
     #[test]
     fn test_counter() {
         let metric = sync::Arc::new(Some(Telemetry::default()));
+        let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
         assert!(parse_statsd(
             "a.b:3.1|c\na-b:4|c|@0.1\na-b:5.2|c@0.2\n",
             &mut res,
-            metric
+            metric,
+                config, 
         ));
         assert_eq!(res[0].kind(), AggregationMethod::Sum);
         assert_eq!(res[0].name, "a.b");
@@ -348,8 +369,9 @@ mod tests {
     #[test]
     fn test_parse_negative_timer() {
         let metric = sync::Arc::new(Some(Telemetry::default()));
+        let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd("fst:-1.1|ms\n", &mut res, metric));
+        assert!(parse_statsd("fst:-1.1|ms\n", &mut res, metric, config));
 
         assert_eq!(res[0].kind(), AggregationMethod::Summarize);
         assert_eq!(res[0].name, "fst");
@@ -360,8 +382,9 @@ mod tests {
     #[test]
     fn test_metric_equal_in_name() {
         let metric = sync::Arc::new(Some(Telemetry::default()));
+        let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd("A=:1|ms\n", &mut res, metric));
+        assert!(parse_statsd("A=:1|ms\n", &mut res, metric, config));
 
         assert_eq!(res[0].kind(), AggregationMethod::Summarize);
         assert_eq!(res[0].name, "A=");
@@ -372,8 +395,9 @@ mod tests {
     #[test]
     fn test_metric_slash_in_name() {
         let metric = sync::Arc::new(Some(Telemetry::default()));
+        let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd("A/:1|ms\n", &mut res, metric));
+        assert!(parse_statsd("A/:1|ms\n", &mut res, metric, config));
 
         assert_eq!(res[0].kind(), AggregationMethod::Summarize);
         assert_eq!(res[0].name, "A/");
@@ -384,11 +408,13 @@ mod tests {
     #[test]
     fn test_metric_sample_gauge() {
         let metric = sync::Arc::new(Some(Telemetry::default()));
+        let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
         assert!(parse_statsd(
             "foo:1|g|@+0.22\nbar:101|g|@2\nbaz:2|g@0.2\nqux:4|g@0.1",
             &mut res,
-            metric
+            metric,
+            config
         ));
         //                              0         A     F
         assert_eq!(res[0].kind(), AggregationMethod::Set);
@@ -415,23 +441,26 @@ mod tests {
     #[test]
     fn test_metric_parse_invalid_no_name() {
         let metric = sync::Arc::new(Some(Telemetry::default()));
+        let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(!parse_statsd("", &mut res, metric));
+        assert!(!parse_statsd("", &mut res, metric, config));
     }
 
 
     #[test]
     fn test_metric_parse_invalid_no_value() {
         let metric = sync::Arc::new(Some(Telemetry::default()));
+        let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(!parse_statsd("foo:", &mut res, metric));
+        assert!(!parse_statsd("foo:", &mut res, metric, config));
     }
 
     #[test]
     fn test_metric_multiple() {
         let metric = sync::Arc::new(Some(Telemetry::default()));
+        let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd("a.b:12.1|g\nb_c:13.2|c\n", &mut res, metric));
+        assert!(parse_statsd("a.b:12.1|g\nb_c:13.2|c\n", &mut res, metric, config));
         assert_eq!(2, res.len());
 
         assert_eq!(res[0].kind(), AggregationMethod::Set);
@@ -448,8 +477,9 @@ mod tests {
     #[test]
     fn test_metric_optional_final_newline() {
         let metric = sync::Arc::new(Some(Telemetry::default()));
+        let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd("a.b:12.1|g\nb_c:13.2|c", &mut res, metric));
+        assert!(parse_statsd("a.b:12.1|g\nb_c:13.2|c", &mut res, metric, config));
         assert_eq!(2, res.len());
 
         assert_eq!(res[0].kind(), AggregationMethod::Set);
@@ -467,8 +497,9 @@ mod tests {
     fn test_solo_negative_gauge_as_ephemeral_set() {
         let pyld = "zrth:-1|g\n";
         let metric = sync::Arc::new(Some(Telemetry::default()));
+        let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd(pyld, &mut res, metric));
+        assert!(parse_statsd(pyld, &mut res, metric, config));
 
         assert_eq!(res[0].kind(), AggregationMethod::Sum);
         assert_eq!(res[0].name, "zrth");
@@ -480,8 +511,9 @@ mod tests {
     fn test_multi_gauge_as_persist_sum() {
         let pyld = "zrth:0|g\nzrth:-1|g\n";
         let metric = sync::Arc::new(Some(Telemetry::default()));
+        let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd(pyld, &mut res, metric));
+        assert!(parse_statsd(pyld, &mut res, metric, config));
 
         assert_eq!(res[0].kind(), AggregationMethod::Set);
         assert_eq!(res[0].name, "zrth");
@@ -506,8 +538,9 @@ mod tests {
             ":1.0|c",
         ];
         let metric = sync::Arc::new(Some(Telemetry::default()));
+        let config = sync::Arc::new(StatsdParseConfig::default());
         for input in invalid.iter() {
-            assert!(!parse_statsd(*input, &mut Vec::new(), metric.clone()));
+            assert!(!parse_statsd(*input, &mut Vec::new(), metric.clone(), config.clone()));
         }
     }
 
@@ -516,8 +549,9 @@ mod tests {
         let pyld = "zrth:0|g\nfst:-1.1|ms\nsnd:+2.2|g\nthd:3.3|h\nfth:4|c\nfvth:5.5|c|@0.1\nsxth:\
                     -6.6|g\nsvth:+7.77|g\n";
         let metric = sync::Arc::new(Some(Telemetry::default()));
+        let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd(pyld, &mut res, metric));
+        assert!(parse_statsd(pyld, &mut res, metric, config));
 
         assert_eq!(res[0].kind(), AggregationMethod::Set);
         assert_eq!(res[0].name, "zrth");

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -15,7 +15,7 @@ pub use self::flush::FlushTimer;
 pub use self::graphite::{Graphite, GraphiteConfig};
 pub use self::internal::{report_full_telemetry, Internal, InternalConfig};
 pub use self::native::{NativeServer, NativeServerConfig};
-pub use self::statsd::{Statsd, StatsdConfig};
+pub use self::statsd::{Statsd, StatsdConfig, StatsdParseConfig};
 
 /// cernan Source, the originator of all `metric::Event`.
 ///

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -35,13 +35,13 @@ pub type Mask = Regex;
 /// The bound type for metrics in `StatsdParseConfig`.
 pub type Bounds = Vec<f64>;
 
-/// Configuratoin for the statsd parser
+/// Configuration for the statsd parser
 #[derive(Debug, Clone)]
 pub struct StatsdParseConfig {
     /// Set specific bin masks for timeseries according to their name. The name
-    /// may be a globbing match, such like 'foo.*'. In this case all metrics
-    /// prefixed by 'foo.' which are timer or histogram will be interpreted as a
-    /// histogram.
+    /// may be a [regex](https://crates.io/crates/regex) match, such like
+    /// 'foo.*'. In this case all metrics prefixed by 'foo.' which are timer or
+    /// histogram will be interpreted as a histogram.
     pub histogram_masks: Vec<(Mask, Bounds)>,
 }
 


### PR DESCRIPTION
This commit adds a 'mapping' capability for statsd source. It looks
like so:

    [sources]
      [sources.statsd.primary]
      enabled = true
      host = "localhost"
      port = 1024
      forwards = ["sinks.console", "sinks.null"]

      [sources.statsd.primary.mapping]
      [sources.statsd.primary.mapping.foo]
      mask = "foo.*"
      bounds = [0.0, 1.0, 10.0]

      [sources.statsd.primary.mapping.bar]
      mask = "bar.*"
      bounds = [0.0, 2.0, 20.0]

      [sources.statsd.primary.mapping.default]
      mask = ".*"
      bounds = [0.0, 0.1, 10.0, 100.0]

In this example three mappings are created: 'foo', 'bar' and 'default'.
The 'foo' mapping will match those metrics whose names are 'foo.*' where
the glob is greedy, 'bar' matches 'bar.*' and default catches all that
remain. In this configuration no statsd timers or histograms will not
be an AggregationMethod::Histogram. If two mappings should overlap in
their masks the one which appears first in the configuration will be
the preferred mapping.

Resolves #307

Signed-off-by: Brian L. Troutwine <blt@postmates.com>