### PR TITLE
Add HISTOGRAM support to the wavefront sink

### DIFF
--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -242,7 +242,7 @@ impl Source for Internal {
                     self.chans
                 );
                 atom_non_zero_telem!(
-                    "cernan.sinks.wavefront.value.open",
+                    "cernan.sinks.wavefront.valve.open",
                     sink::wavefront::WAVEFRONT_VALVE_OPEN,
                     self.tags,
                     self.chans


### PR DESCRIPTION
This commit adds emission of the histogram summarization to the
wavefront sink. The name of the metric is smushed together with
the bin boundary and the count / timestamp happen where you'd
expect.

The bin is separated by '_' rather than a dot to avoid confusion
with bins that have a decimal value.

Resolves #308. Related to #307.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>