### PR TITLE
Allow the docker command args to be overridable

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -19,4 +19,5 @@ COPY examples/configs/quickstart.toml /etc/cernan/cernan.toml
 
 ENV STATSD_PORT 8125
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT /usr/bin/cernan
+CMD --config /etc/cernan/cernan.toml

--- a/docker/release/entrypoint.sh
+++ b/docker/release/entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-/usr/bin/cernan --config /etc/cernan/cernan.toml


### PR DESCRIPTION
 - Entrypoint of /usr/bin/cernan by default
 - Default args of `--config /etc/cernan/cernan.toml`