### PR TITLE
Allow users to set the index type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cernan"
-version = "0.7.9"
+version = "0.7.10-pre"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.7.9"
+version = "0.7.10-pre"
 
 [[bin]]
 name = "cernan"

--- a/src/config.rs
+++ b/src/config.rs
@@ -578,6 +578,14 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                 })
                 .unwrap_or(res.secure);
 
+            res.index_type = snk.get("index_type")
+                .map(|bw| {
+                    bw.as_str()
+                        .expect("could not parse sinks.elasticsearch.index_type")
+                        .to_string()
+                })
+                .unwrap_or(res.index_type);
+
             res.flush_interval = snk.get("flush_interval")
                 .map(|fi| {
                     fi.as_integer()

--- a/src/sink/elasticsearch.rs
+++ b/src/sink/elasticsearch.rs
@@ -64,6 +64,8 @@ pub struct ElasticsearchConfig {
     /// The Elasticsearch index prefix. This prefix will be added to the
     /// automatically created date-based index of this sink.
     pub index_prefix: Option<String>,
+    /// The _type of the Elasticsearch index
+    pub index_type: String,
     /// Determines whether to use HTTP or HTTPS when publishing to
     /// Elasticsearch.
     pub secure: bool, // whether http or https
@@ -82,6 +84,7 @@ impl Default for ElasticsearchConfig {
             secure: false,
             host: "127.0.0.1".to_string(),
             index_prefix: None,
+            index_type: "payload".to_string(),
             port: 9200,
             flush_interval: 1,
         }
@@ -97,6 +100,7 @@ pub struct Elasticsearch {
     host: String,
     port: usize,
     index_prefix: Option<String>,
+    index_type: String,
     flush_interval: u64,
 }
 
@@ -111,6 +115,7 @@ impl Elasticsearch {
             host: config.host,
             port: config.port,
             index_prefix: config.index_prefix,
+            index_type: config.index_type,
             flush_interval: config.flush_interval,
         }
     }
@@ -123,7 +128,7 @@ impl Elasticsearch {
             let header: Value = json!({
                 "index": {
                     "_index" : idx(&self.index_prefix, m.time),
-                    "_type" : "payload",
+                    "_type" : self.index_type.clone(),
                     "_id" : uuid.clone(),
                 }
             });


### PR DESCRIPTION
Previously cernan hard-coded the index type in the Elasticsearch
sink to be "payload". @blakebarnett needs the ability to set the
type as a matter of configuration so, well, that's what we've
made possible here.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>