### PR TITLE
Resolve Prometheus backup issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cernan"
-version = "0.7.10"
+version = "0.7.11-pre"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.7.10"
+version = "0.7.11-pre"
 
 [[bin]]
 name = "cernan"

--- a/src/filter/delay_filter.rs
+++ b/src/filter/delay_filter.rs
@@ -10,7 +10,6 @@ use metric;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use time;
-use util;
 
 lazy_static! {
     /// Total number of telemetry rejected for age
@@ -54,10 +53,6 @@ impl DelayFilter {
 }
 
 impl filter::Filter for DelayFilter {
-    fn valve_state(&self) -> util::Valve {
-        util::Valve::Open
-    }
-
     fn process(
         &mut self,
         event: metric::Event,

--- a/src/filter/flush_boundary_filter.rs
+++ b/src/filter/flush_boundary_filter.rs
@@ -1,7 +1,6 @@
 use filter;
 use metric;
 use std::mem;
-use util;
 
 /// Buffer events for a set period of flushes
 ///
@@ -55,10 +54,6 @@ impl FlushBoundaryFilter {
 }
 
 impl filter::Filter for FlushBoundaryFilter {
-    fn valve_state(&self) -> util::Valve {
-        util::Valve::Open
-    }
-
     fn process(
         &mut self,
         event: metric::Event,

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -6,7 +6,6 @@ use lua::ffi::lua_State;
 use metric;
 use std::path::PathBuf;
 use std::sync;
-use util;
 
 struct Payload<'a> {
     metrics: Vec<Box<metric::Telemetry>>,
@@ -506,10 +505,6 @@ impl ProgrammableFilter {
 }
 
 impl filter::Filter for ProgrammableFilter {
-    fn valve_state(&self) -> util::Valve {
-        util::Valve::Open
-    }
-
     fn process(
         &mut self,
         event: metric::Event,

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -32,6 +32,9 @@ pub use self::wavefront::{Wavefront, WavefrontConfig};
 pub trait Sink {
     /// Lookup the `Sink`'s specific flush interval. This determines how often a
     /// sink will obey the periodic flush pulse.
+    ///
+    /// If the value is `None` this is a signal that the sink will NEVER flush
+    /// EXCEPT in the case where the sink's valve_state is Closed.
     fn flush_interval(&self) -> Option<u64>;
     /// Perform the `Sink` specific flush. The rate at which this occurs is
     /// determined by the global `flush_interval` or the sink specific flush
@@ -54,33 +57,55 @@ pub trait Sink {
         let mut attempts = 0;
         let mut recv = recv.into_iter();
         let mut last_flush_idx = 0;
+        // The run-loop of a sink is two nested loops. The outer loop pulls a
+        // value from the hopper queue. If that value is Some the inner loop
+        // tries to do something with it, only discarding it at such time as
+        // it's been delivered to the Source.
         loop {
             time::delay(attempts);
-            match recv.next() {
-                None => {
-                    attempts += 1;
-                    if let Valve::Closed = self.valve_state() {
-                        self.flush();
-                    }
-                }
-                Some(event) => match self.valve_state() {
+            let nxt = recv.next();
+            if nxt.is_none() {
+                attempts += 1;
+                continue;
+            }
+            let event = nxt.unwrap();
+            loop {
+                // We have to be careful here not to dump a value until it's
+                // already been delivered _and_ be sure we at least attempt to
+                // make progress on delivery. There are two conditions we have
+                // to look out for most carefully:
+                //
+                //  1. Is the valve_state closed?
+                //  2. Does the flush_interval match our flush index?
+                //
+                // If the valve state is closed we attempt to flush the sink to
+                // clear the valve, hold on to the value and loop around again
+                // after a delay. If the flush_interval is Some and DOES match
+                // then we flush. If the flush_interval is Some and DOES NOT
+                // match then we do not flush. If the flush_interval is NONE
+                // then we never flush.
+                match self.valve_state() {
                     Valve::Open => match event {
-                        Event::TimerFlush(idx) => if idx > last_flush_idx {
-                            if let Some(flush_interval) = self.flush_interval() {
-                                if idx % flush_interval == 0 {
-                                    self.flush();
+                        Event::TimerFlush(idx) => {
+                            if idx > last_flush_idx {
+                                if let Some(flush_interval) = self.flush_interval() {
+                                    if idx % flush_interval == 0 {
+                                        self.flush();
+                                    }
                                 }
+                                last_flush_idx = idx;
                             }
-                            last_flush_idx = idx;
-                        },
+                            break;
+                        }
                         Event::Telemetry(metric) => {
                             attempts = attempts.saturating_sub(1);
                             self.deliver(metric);
+                            break;
                         }
-
                         Event::Log(line) => {
                             attempts = attempts.saturating_sub(1);
                             self.deliver_line(line);
+                            break;
                         }
                     },
                     Valve::Closed => {
@@ -88,7 +113,7 @@ pub trait Sink {
                         self.flush();
                         continue;
                     }
-                },
+                }
             }
         }
     }

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -60,7 +60,7 @@ pub trait Sink {
         // The run-loop of a sink is two nested loops. The outer loop pulls a
         // value from the hopper queue. If that value is Some the inner loop
         // tries to do something with it, only discarding it at such time as
-        // it's been delivered to the Source.
+        // it's been delivered to the Sink.
         loop {
             time::delay(attempts);
             let nxt = recv.next();

--- a/src/sink/null.rs
+++ b/src/sink/null.rs
@@ -45,7 +45,7 @@ impl Sink for Null {
     }
 
     fn flush_interval(&self) -> Option<u64> {
-        None
+        Some(1)
     }
 
 

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -303,6 +303,18 @@ impl Source for Internal {
                 );
                 // sink::prometheus
                 atom_non_zero_telem!(
+                    "cernan.sinks.prometheus.aggregation.inside_baseball.windowed.total",
+                    sink::prometheus::PROMETHEUS_AGGR_WINDOWED_LEN,
+                    self.tags,
+                    self.chans
+                );
+                atom_non_zero_telem!(
+                    "cernan.sinks.prometheus.aggregation.inside_baseball.perpetual.total",
+                    sink::prometheus::PROMETHEUS_AGGR_PERPETUAL_LEN,
+                    self.tags,
+                    self.chans
+                );
+                atom_non_zero_telem!(
                     "cernan.sinks.prometheus.aggregation.reportable",
                     sink::prometheus::PROMETHEUS_AGGR_REPORTABLE,
                     self.tags,


### PR DESCRIPTION
In high cardinality situations we observed that the prometheus sink
could back up into its queue. This was a result of the valve_state
being in place for a sink for which it is not appropriate. Sink
telemetry was misleading as the self-telemetry is only updated
during an insertion, which could not happen once valve was locked
shut. The valve state would never clear because prometheus does
not drop timeseries.

This sink also resolves a drop issue with the sink run loop in
some cases and removes the valve state concept from the filter as
that is only complicated and has no real value.

Cernan should now be more robust to high-cardinality timeseries
but the prometheus sink is susceptible to memory attacks if
random names are pumped through.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>