### PR TITLE
Remove windowing for Summarize in prometheus sink

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -521,14 +521,6 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
             let mut res = PrometheusConfig::default();
             res.config_path = Some("sinks.prometheus".to_string());
 
-            res.retain_limit = snk.get("retain_limit")
-                .map(|p| {
-                    p.as_integer()
-                        .expect("could not parse sinks.prometheus.retain_limit")
-                        as usize
-                })
-                .unwrap_or(res.retain_limit);
-
             res.port = snk.get("port")
                 .map(|p| {
                     p.as_integer().expect("could not parse sinks.prometheus.port")

--- a/src/protocols/graphite.rs
+++ b/src/protocols/graphite.rs
@@ -59,7 +59,7 @@ mod tests {
             "fst 1 101\nsnd -2.0 202\nthr 3 303\nfth@fth 4 404\nfv%fv 5 505\ns-th 6 606\n";
         let mut res = Vec::new();
         let metric = sync::Arc::new(Some(Telemetry::default()));
-        assert!(parse_graphite(pyld, &mut res, metric));
+        assert!(parse_graphite(pyld, &mut res, &metric));
 
         assert_eq!(res[0].kind(), AggregationMethod::Set);
         assert_eq!(res[0].name, "fst");

--- a/src/protocols/statsd.rs
+++ b/src/protocols/statsd.rs
@@ -305,7 +305,7 @@ mod tests {
 
             let config = sync::Arc::new(StatsdParseConfig::default());
 
-            if parse_statsd(&lines, &mut res, metric, config) {
+            if parse_statsd(&lines, &mut res, &metric, &config) {
                 assert_eq!(res.len(), pyld.lines.len());
                 for (sline, telem) in pyld.lines.iter().zip(res.iter()) {
                     assert_eq!(sline.name, telem.name);
@@ -356,8 +356,8 @@ mod tests {
         assert!(parse_statsd(
             "a.b:3.1|c\na-b:4|c|@0.1\na-b:5.2|c@0.2\n",
             &mut res,
-            metric,
-            config,
+            &metric,
+            &config,
         ));
         assert_eq!(res[0].kind(), AggregationMethod::Sum);
         assert_eq!(res[0].name, "a.b");
@@ -378,7 +378,7 @@ mod tests {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd("fst:-1.1|ms\n", &mut res, metric, config));
+        assert!(parse_statsd("fst:-1.1|ms\n", &mut res, &metric, &config));
 
         assert_eq!(res[0].kind(), AggregationMethod::Summarize);
         assert_eq!(res[0].name, "fst");
@@ -391,7 +391,7 @@ mod tests {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd("A=:1|ms\n", &mut res, metric, config));
+        assert!(parse_statsd("A=:1|ms\n", &mut res, &metric, &config));
 
         assert_eq!(res[0].kind(), AggregationMethod::Summarize);
         assert_eq!(res[0].name, "A=");
@@ -404,7 +404,7 @@ mod tests {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd("A/:1|ms\n", &mut res, metric, config));
+        assert!(parse_statsd("A/:1|ms\n", &mut res, &metric, &config));
 
         assert_eq!(res[0].kind(), AggregationMethod::Summarize);
         assert_eq!(res[0].name, "A/");
@@ -420,8 +420,8 @@ mod tests {
         assert!(parse_statsd(
             "foo:1|g|@+0.22\nbar:101|g|@2\nbaz:2|g@0.2\nqux:4|g@0.1",
             &mut res,
-            metric,
-            config
+            &metric,
+            &config
         ));
         //                              0         A     F
         assert_eq!(res[0].kind(), AggregationMethod::Set);
@@ -450,7 +450,7 @@ mod tests {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(!parse_statsd("", &mut res, metric, config));
+        assert!(!parse_statsd("", &mut res, &metric, &config));
     }
 
 
@@ -459,7 +459,7 @@ mod tests {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(!parse_statsd("foo:", &mut res, metric, config));
+        assert!(!parse_statsd("foo:", &mut res, &metric, &config));
     }
 
     #[test]
@@ -470,8 +470,8 @@ mod tests {
         assert!(parse_statsd(
             "a.b:12.1|g\nb_c:13.2|c\n",
             &mut res,
-            metric,
-            config
+            &metric,
+            &config
         ));
         assert_eq!(2, res.len());
 
@@ -494,8 +494,8 @@ mod tests {
         assert!(parse_statsd(
             "a.b:12.1|g\nb_c:13.2|c",
             &mut res,
-            metric,
-            config
+            &metric,
+            &config
         ));
         assert_eq!(2, res.len());
 
@@ -516,7 +516,7 @@ mod tests {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd(pyld, &mut res, metric, config));
+        assert!(parse_statsd(pyld, &mut res, &metric, &config));
 
         assert_eq!(res[0].kind(), AggregationMethod::Sum);
         assert_eq!(res[0].name, "zrth");
@@ -530,7 +530,7 @@ mod tests {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd(pyld, &mut res, metric, config));
+        assert!(parse_statsd(pyld, &mut res, &metric, &config));
 
         assert_eq!(res[0].kind(), AggregationMethod::Set);
         assert_eq!(res[0].name, "zrth");
@@ -560,8 +560,8 @@ mod tests {
             assert!(!parse_statsd(
                 *input,
                 &mut Vec::new(),
-                metric.clone(),
-                config.clone()
+                &metric.clone(),
+                &config.clone()
             ));
         }
     }
@@ -573,7 +573,7 @@ mod tests {
         let metric = sync::Arc::new(Some(Telemetry::default()));
         let config = sync::Arc::new(StatsdParseConfig::default());
         let mut res = Vec::new();
-        assert!(parse_statsd(pyld, &mut res, metric, config));
+        assert!(parse_statsd(pyld, &mut res, &metric, &config));
 
         assert_eq!(res[0].kind(), AggregationMethod::Set);
         assert_eq!(res[0].name, "zrth");

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -8,7 +8,7 @@
 //!   - QUANTILES -> summary
 //!   - HISTOGRAM -> histogram
 //!
-//! All points are retained indefinately in their aggregation.
+//! All points are retained indefinitely in their aggregation.
 
 use flate2::Compression;
 use flate2::write::GzEncoder;


### PR DESCRIPTION
Per @benley it doesn't make good sense for the prometheus sink to
hold everything perpetually save summarize in a retain_limit window.
The windowing is now removed and summarize will act as the other
aggregations do.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>