### PR TITLE
Allow end-users to configure statsd error bounds

### DIFF
--- a/src/protocols/statsd.rs
+++ b/src/protocols/statsd.rs
@@ -101,7 +101,7 @@ pub fn parse_statsd(
                                         metric = metric.persist(false);
                                         metric = metric
                                             .kind(AggregationMethod::Summarize)
-                                            .error(0.01);
+                                            .error(config.summarize_error_bound);
                                         for &(ref mask_re, ref bounds) in
                                             &config.histogram_masks
                                         {
@@ -130,7 +130,7 @@ pub fn parse_statsd(
                                     metric = metric.persist(false);
                                     metric = metric
                                         .kind(AggregationMethod::Summarize)
-                                        .error(0.01);
+                                        .error(config.summarize_error_bound);
                                     for &(ref mask_re, ref bounds) in
                                         &config.histogram_masks
                                     {

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -43,12 +43,18 @@ pub struct StatsdParseConfig {
     /// 'foo.*'. In this case all metrics prefixed by 'foo.' which are timer or
     /// histogram will be interpreted as a histogram.
     pub histogram_masks: Vec<(Mask, Bounds)>,
+    /// Configure the error bound for a statsd timer or histogram. Cernan does
+    /// not compute precise quantiles but approximations with a guaranteed upper
+    /// bound on the error of approximation. This allows the end-user to set
+    /// that.
+    pub summarize_error_bound: f64,
 }
 
 impl Default for StatsdParseConfig {
     fn default() -> StatsdParseConfig {
         StatsdParseConfig {
             histogram_masks: vec![],
+            summarize_error_bound: 0.01,
         }
     }
 }


### PR DESCRIPTION
Historically the error bounds on a statsd timer and histogram have been
hard-coded as 0.001. With this commit we now allow users to fiddle with
this knob themselves.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>