### PR TITLE
Copy prometheus aggr into HTTP land

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.8.0"
+version = "0.8.1-pre"
 
 [[bin]]
 name = "cernan"

--- a/src/source/file/mod.rs
+++ b/src/source/file/mod.rs
@@ -50,8 +50,7 @@ mod test {
             let dir = tempdir::TempDir::new("file_watcher_qc").unwrap();
             let path = dir.path().join("a_file.log");
             let mut fp = fs::File::create(&path).expect("could not create");
-            let mut fw =
-                FileWatcher::new(&path).expect("must be able to create");
+            let mut fw = FileWatcher::new(&path).expect("must be able to create");
 
             let mut expected_read = Vec::new();
 


### PR DESCRIPTION
The prometheus sink can be made to back up if the prometheus server
holds on to the far-side because we lock the aggregation between
the ingestor and the http server. That means, we have lock contention
that freezes up the ingestion. What we do is copy the ingestion
aggregation every flush interval _when the lock is not held_.
This will mean that some updates will fail to get all the newly
ingested points but we don't hang like dopes waiting for prometheus
server to let go of the request.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>