### PR TITLE
Allow wavefront sink to shed points

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cernan"
-version = "0.8.1"
+version = "0.8.2-pre"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chan-signal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.8.1"
+version = "0.8.2-pre"
 
 [[bin]]
 name = "cernan"

--- a/src/config.rs
+++ b/src/config.rs
@@ -452,6 +452,14 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                 })
                 .unwrap_or(res.port);
 
+            res.age_threshold = snk.get("age_threshold")
+                .map(|p| {
+                    Some(p.as_integer()
+                        .expect("could not parse sinks.wavefront.age_threshold")
+                        as u64)
+                })
+                .unwrap_or(res.age_threshold);
+
             res.host = snk.get("host")
                 .map(|p| {
                     p.as_str()
@@ -1376,6 +1384,7 @@ scripts-directory = "/foo/bar"
       host = "example.com"
       bin_width = 9
       flush_interval = 15
+      age_threshold = 43
     "#;
 
         let args = parse_config_file(config, 4);
@@ -1386,6 +1395,7 @@ scripts-directory = "/foo/bar"
         assert_eq!(wavefront.port, 3131);
         assert_eq!(wavefront.bin_width, 9);
         assert_eq!(wavefront.flush_interval, 15);
+        assert_eq!(wavefront.age_threshold, Some(43));
     }
 
     #[test]
@@ -1410,6 +1420,7 @@ scripts-directory = "/foo/bar"
         assert_eq!(wavefront.host, String::from("example.com"));
         assert_eq!(wavefront.port, 3131);
         assert_eq!(wavefront.bin_width, 9);
+        assert_eq!(wavefront.age_threshold, None);
 
         assert_eq!(wavefront.percentiles.len(), 3);
         assert_eq!(wavefront.percentiles[0], ("max".to_string(), 1.0));

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -99,7 +99,7 @@ pub struct WavefrontConfig {
     /// status
     pub pad_control: PadControl,
     /// Determine the age at which a Telemetry point will be ejected. If the
-    /// value is None no points will ever be rejected.
+    /// value is None no points will ever be rejected. Units are seconds.
     pub age_threshold: Option<u64>,
 }
 


### PR DESCRIPTION
We know that Wavefront doesn't take historical backfill data. It
is possible for the sink to back up into its buffer when the proxy
it reports to is unavailable, leading to reports that will have no
value. This option allows Ops to configure a time window to shed
points.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>