### PR TITLE
Remove ES loglines when they've signaled as OK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cernan"
-version = "0.8.2"
+version = "0.8.3-pre"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chan-signal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.8.2"
+version = "0.8.3-pre"
 
 [[bin]]
 name = "cernan"

--- a/src/config.rs
+++ b/src/config.rs
@@ -568,6 +568,14 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
             let mut res = ElasticsearchConfig::default();
             res.config_path = Some("sinks.elasticsearch".to_string());
 
+            res.delivery_attempt_limit = snk.get("delivery_attempt_limit")
+                .map(|p| {
+                    p.as_integer()
+                        .expect("could not parse sinks.elasticsearch.delivery_attempt_limit")
+                        as u8
+                })
+                .unwrap_or(res.delivery_attempt_limit);
+
             res.port = snk.get("port")
                 .map(|p| {
                     p.as_integer()
@@ -1083,6 +1091,7 @@ scripts-directory = "/foo/bar"
   index-prefix = "prefix-"
   secure = true
   flush_interval = 2020
+  delivery_attempt_limit = 33
 "#;
 
         let args = parse_config_file(config, 4);
@@ -1095,6 +1104,7 @@ scripts-directory = "/foo/bar"
         assert_eq!(es.index_prefix, Some("prefix-".into()));
         assert_eq!(es.secure, true);
         assert_eq!(es.flush_interval, 2020);
+        assert_eq!(es.delivery_attempt_limit, 33);
     }
 
     #[test]

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -157,6 +157,12 @@ impl Source for Internal {
                     self.chans
                 );
                 atom_non_zero_telem!(
+                    "cernan.sinks.elasticsearch.internal.buffer_len",
+                    sink::elasticsearch::ELASTIC_INTERNAL_BUFFER_LEN,
+                    self.tags,
+                    self.chans
+                );
+                atom_non_zero_telem!(
                     "cernan.sinks.elasticsearch.records.total_delivered",
                     sink::elasticsearch::ELASTIC_RECORDS_TOTAL_DELIVERED,
                     self.tags,


### PR DESCRIPTION
It's possible for a bulk request to roll through but then for an
individual item in the request to still fail. We now store a UUID
in the ES buffer and use that UUID -- fed through to ES -- to remove
a newly stored bulk item from our buffer.

This resolves #348

Signed-off-by: Brian L. Troutwine <blt@postmates.com>