### PR TITLE
Correct prometheus window summary truncation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cernan"
-version = "0.8.3"
+version = "0.8.4-pre"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chan-signal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.8.3"
+version = "0.8.4-pre"
 
 [[bin]]
 name = "cernan"

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -136,8 +136,9 @@ impl Accumulator {
                     }
                     Err(idx) => {
                         samples.insert(idx, telem);
-                        while samples.len() > cap {
-                            samples.remove(0);
+                        if samples.len() > cap {
+                            let top_idx = samples.len() - cap;
+                            samples.drain(0 .. top_idx);
                         }
                     }
                 }

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -136,8 +136,8 @@ impl Accumulator {
                     }
                     Err(idx) => {
                         samples.insert(idx, telem);
-                        if samples.len() > cap {
-                            samples.truncate(cap);
+                        while samples.len() > cap {
+                            samples.remove(0);
                         }
                     }
                 }


### PR DESCRIPTION
Turns out, we were truncating the wrong side of the window summary
aggregation. This is now resolved by removing the 0th index from the
summary until we hit our cap.

Resolves #351

Signed-off-by: Brian L. Troutwine <blt@postmates.com>