### PR TITLE
Introduce Telemetry override for 'count' and 'sample_sum'

### DIFF
--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -112,13 +112,15 @@ impl Accumulator {
     }
 
     #[cfg(test)]
-    pub fn total_samples(&self) -> usize {
+    pub fn total_stored_samples(&self) -> usize {
         match *self {
             Accumulator::Perpetual(_) => 1,
             Accumulator::Windowed {
                 cap: _,
-                samples: ref s,
-            } => s.len(),
+                ref samples,
+                sum: _,
+                count: _,
+            } => samples.len(),
         }
     }
 
@@ -220,7 +222,7 @@ impl PrometheusAggr {
                 let accum = self.values.index(hsh_idx).clone();
                 match accum {
                     Accumulator::Perpetual(t) => Some(t),
-                    Accumulator::Windowed { cap: _, samples } => {
+                    Accumulator::Windowed { cap: _, samples, sum: _, count: _ } => {
                         let mut start = samples[0].clone();
                         for t in &samples[1..] {
                             start += t.clone();
@@ -793,10 +795,13 @@ mod test {
                             metric::AggregationMethod::Summarize => {
                                 let mut samples =
                                     Vec::with_capacity(capacity_in_seconds);
+                                let val = telem.query(1.0).unwrap();
                                 samples.push(telem);
                                 Accumulator::Windowed {
                                     cap: capacity_in_seconds,
                                     samples: samples,
+                                    count: 1,
+                                    sum: val,
                                 }
                             }
                         };
@@ -818,6 +823,8 @@ mod test {
             let mut windowed = Accumulator::Windowed {
                 cap: cap,
                 samples: Vec::new(),
+                sum: 0.0,
+                count: 0,
             };
 
             for t in telems.into_iter() {
@@ -827,7 +834,7 @@ mod test {
                 windowed.insert(t);
             }
 
-            assert!(windowed.total_samples() <= cap);
+            assert!(windowed.total_stored_samples() <= cap);
 
             TestResult::passed()
         }


### PR DESCRIPTION
In some rare cases -- like in the prometheus sink -- it's necessary to fake the count and sample_sum of a telemetry. Say, if you're windowing a certain troublesome kind of aggregation. Well, that's what this commit does: it lets you fake those two things.