### PR TITLE
Avoid catastrophic failure when an ES request times out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cernan"
-version = "0.8.4"
+version = "0.8.5-pre"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chan-signal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.8.4"
+version = "0.8.5-pre"
 
 [[bin]]
 name = "cernan"


### PR DESCRIPTION
As of 0.20.6 ES it's possible for a bulk request to time out,
which we unwrapped on like goofs. This commit removes that
unwrap and fails the flush in the event of a timeout bubbling up.

This resolves #353 and elastic-rs/elastic#286.

Related to #355.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>