### PR TITLE
RFC: systemd-journald source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "systemd 0.2.0",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -312,6 +313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cstr-argument"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -708,6 +718,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsystemd-sys"
+version = "0.1.0"
+dependencies = [
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "log"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,8 +746,26 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "mbox"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "memchr"
 version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1384,6 +1420,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1445,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "systemd"
+version = "0.2.0"
+dependencies = [
+ "cstr-argument 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsystemd-sys 0.1.0",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mbox 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-cstr 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1621,6 +1674,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-cstr"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "utf8-ranges"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1780,7 @@ dependencies = [
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crc 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64d4a687c40efbc7d376958117b34d5f1cece11709110a742405bf58e7a34f00"
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
+"checksum cstr-argument 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "514570a4b719329df37f93448a70df2baac553020d0eb43a8dfa9c1f5ba7b658"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
@@ -1768,7 +1827,9 @@ dependencies = [
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum lua 0.0.11 (git+https://github.com/blt/rust-lua53.git)" = "<none>"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
+"checksum mbox 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7ee02677a39af06f5b494d9d7ca6a430db198065169b26aaf214e13240513b3"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
+"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e00e17be181010a91dbfefb01660b17311059dc8c7f48b9017677721e732bd"
@@ -1842,6 +1903,7 @@ dependencies = [
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
 "checksum smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f8266519bc1d17d0b5b16f6c21295625d562841c708f6376f49028a43e9c11e"
 "checksum spade 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22bd542364c0c964e90ddc146d7b44a4035b618dc347033918994c431cb69d76"
+"checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
@@ -1871,6 +1933,7 @@ dependencies = [
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"
 "checksum url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa35e768d4daf1d85733418a49fb42e10d7f633e394fccab4ab7aba897053fe2"
+"checksum utf8-cstr 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ seahash = "3.0"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-systemd = { path = "../rust-systemd" }
+systemd = { url = "https://github.com/ibotty/rust-systemd", branch = "await-new-records" }
 toml = "0.4"
 url = "1.6"
 uuid = {version = "0.5", features = ["v4"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Brian L. Troutwine <blt@postmates.com>",
            "Tom Santero <tom.santero@postmates.com>"]
 description = "A telemetry and logging aggregation server."
-keywords = ["statsd", "graphite", "telemetry", "logging", "metrics"]
+keywords = ["statsd", "graphite", "telemetry", "logging", "metrics", "systemd"]
 license = "MIT"
 name = "cernan"
 readme = "README.md"
@@ -39,6 +39,7 @@ seahash = "3.0"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"
+systemd = { path = "../rust-systemd" }
 toml = "0.4"
 url = "1.6"
 uuid = {version = "0.5", features = ["v4"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ seahash = "3.0"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-systemd = { url = "https://github.com/ibotty/rust-systemd", branch = "await-new-records" }
+systemd = { git = "https://github.com/ibotty/rust-systemd", branch = "await-new-records" }
 toml = "0.4"
 url = "1.6"
 uuid = {version = "0.5", features = ["v4"]}

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@
 use clap::{App, Arg};
 use metric::TagMap;
 use rusoto_core::Region;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
@@ -142,7 +143,7 @@ impl Default for Args {
             native_server_config: None,
             files: None,
             internal: InternalConfig::default(),
-            journalds: None
+            journalds: None,
         }
     }
 }
@@ -1009,6 +1010,14 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                         .unwrap_or(&toml::Value::Boolean(true))
                         .as_bool()
                         .expect("must be a bool");
+
+                    res.matches = tbl.get("matches")
+                        .map(|m| {
+                             m.clone()
+                                 .try_into()
+                                 .expect("matches must be a table with only strings values")
+                        })
+                        .unwrap_or_else(|| BTreeMap::new());
 
                     res.forwards = tbl.get("forwards")
                         .map(|fwd| {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1002,7 +1002,7 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                         }).unwrap_or(JournalFiles::System);
 
                     res.runtime_only = tbl.get("runtime_only")
-                        .unwrap_or(&toml::Value::Boolean(true))
+                        .unwrap_or(&toml::Value::Boolean(false))
                         .as_bool()
                         .expect("must be a bool");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ extern crate rusoto_firehose;
 extern crate seahash;
 #[macro_use]
 extern crate serde_json;
+extern crate systemd;
 extern crate toml;
 extern crate url;
 extern crate uuid;

--- a/src/source/journald.rs
+++ b/src/source/journald.rs
@@ -31,7 +31,7 @@ impl Default for JournaldConfig {
     fn default() -> JournaldConfig {
         JournaldConfig {
             journal_files: JournalFiles::System,
-            runtime_only: true,
+            runtime_only: false,
             local_only: true,
             matches: BTreeMap::new(),
             tags: TagMap::default(),

--- a/src/source/journald.rs
+++ b/src/source/journald.rs
@@ -3,7 +3,7 @@ use source::Source;
 use std::collections::BTreeMap;
 use std::io::Result;
 use std::sync::Arc;
-use systemd::journal::{Journal, JournalFiles, JournalRecord};
+use systemd::journal::{Journal, JournalFiles, JournalRecord, JournalSeek};
 use util::Channel;
 use util::send;
 
@@ -80,6 +80,9 @@ impl Source for Journald {
             journal.match_add(key, val.as_bytes())
                 .expect("Unable to add match to journal");
         }
+
+        // seek to end of journal
+        journal.seek(JournalSeek::Tail).expect("Unable to seek to tail of journal");
 
         let tags = Arc::clone(&self.tags);
         let gen_log = |mut rec: JournalRecord| -> Result<Event> {

--- a/src/source/journald.rs
+++ b/src/source/journald.rs
@@ -1,0 +1,136 @@
+use metric::{Event, LogLine, TagMap};
+use source::Source;
+use std::io::Result;
+use std::sync::Arc;
+use systemd::journal::{Journal, JournalFiles, JournalRecord};
+use util::Channel;
+use util::send;
+
+/// Configuration for `Journald`.
+#[derive(Debug, Clone)]
+pub struct JournaldConfig {
+    /// The journal files to read from. Defaults to using only the system log.
+    pub journal_files: JournalFiles,
+    /// Whether to only use runtime journal data.
+    pub runtime_only: bool,
+    /// Whether to also consider journals from other machines.
+    pub local_only: bool,
+
+    /// The tagmap that journald will apply to all of its created log lines.
+    pub tags: TagMap,
+    /// The forwards that statsd will send its telemetry on to.
+    pub forwards: Vec<String>,
+    /// The unique name for the source in the routing topology.
+    pub config_path: Option<String>,
+}
+
+impl Default for JournaldConfig {
+    fn default() -> JournaldConfig {
+        JournaldConfig {
+            journal_files: JournalFiles::System,
+            runtime_only: true,
+            local_only: true,
+            tags: TagMap::default(),
+            forwards: Vec::new(),
+            config_path: None,
+        }
+    }
+}
+
+/// The Journald `Source`.
+///
+/// Journald is systemd's service to collect and store logging data.
+pub struct Journald {
+    chans: Channel,
+    tags: Arc<TagMap>,
+
+    journal_files: JournalFiles,
+    runtime_only: bool,
+    local_only: bool,
+}
+
+impl Journald {
+    /// Create a new `Journald` source
+    pub fn new(chans: Channel, config: JournaldConfig) -> Journald {
+        Journald {
+            chans: chans,
+            tags: Arc::new(config.tags),
+            journal_files: config.journal_files,
+            runtime_only: config.runtime_only,
+            local_only: config.local_only,
+        }
+    }
+}
+
+
+impl Source for Journald {
+    fn run(&mut self) {
+        let mut journal = Journal::open(self.journal_files.clone(),
+                              self.runtime_only.clone(),
+                              self.local_only.clone())
+            .expect("Unable to open journal");
+        let tags = Arc::clone(&self.tags);
+        let gen_log = |mut rec: JournalRecord| -> Result<Event> {
+            let path = rec.remove("_SYSTEMD_UNIT")
+                .or_else(|| rec.remove("_SYSTEMD_USER_UNIT"))
+                .map_or_else(|| {
+                    info!("could not get either _SYSTEMD_UNIT nor _SYSTEMD_USER_UNIT");
+                    String::from("unknown_unit")
+               },
+               |s| s.clone() );
+
+            let value = rec.remove("MESSAGE")
+                .map_or_else(|| String::from(""), |s| s.clone());
+
+            let mut l = LogLine::new(path.as_ref(), value.as_ref());
+
+            // Copy timestamp from CLOCK_REALTIME
+            l = match rec.get("_SOURCE_REALTIME_TIMESTAMP").map(|s| s.parse()) {
+                Some(Ok(t)) => l.time(t),
+                _ => {
+                    info!("Unable to get SOURCE_REALTIME_TIMESTAMP from journald record.");
+                    l
+                }
+            };
+
+            // Copy JournalRecord's fields into the LogLine.
+            for (k, v) in rec {
+                l = l.insert_field(k, v);
+            }
+
+            // Copy tags into LogLine's fields.
+            l = l.overlay_tags_from_map(&tags);
+
+            Ok(Event::new_log(l))
+        };
+
+        loop {
+            let mut chans = self.chans.clone();
+            let process_records = |rec: JournalRecord| {
+                match gen_log(rec) {
+                    Ok(logline) => send(&mut chans, logline),
+                    Err(err) => {
+                        warn!("cannot generate log: {}", err);
+                        return Ok(());
+                    }
+                }
+                Ok(())
+            };
+
+            match journal.watch_all_elements(process_records) {
+                Err(err) => {
+                    // Error code 74 is BADMSG
+                    // Skip invalid records (due to corrupt journal)
+                    if err.raw_os_error() == Some(74) {
+                        info!("encountered record with error BADMSG: {}", err);
+                        continue;
+                    } else {
+                        error!("got error from journald: {}", err);
+                        return;
+                    }
+                }
+                Ok(()) => continue,
+            }
+        }
+    }
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -9,6 +9,7 @@ mod graphite;
 mod internal;
 mod native;
 mod statsd;
+mod journald;
 
 pub use self::file::{FileServer, FileServerConfig};
 pub use self::flush::FlushTimer;
@@ -16,6 +17,7 @@ pub use self::graphite::{Graphite, GraphiteConfig};
 pub use self::internal::{report_full_telemetry, Internal, InternalConfig};
 pub use self::native::{NativeServer, NativeServerConfig};
 pub use self::statsd::{Statsd, StatsdConfig, StatsdParseConfig};
+pub use self::journald::{Journald, JournaldConfig};
 
 /// cernan Source, the originator of all `metric::Event`.
 ///


### PR DESCRIPTION
This is getting closer to working. There are (at least) the following tasks still to do (disregarding code review requests).

- [ ]  Documentation,
- [ ]  Matching DSL in config file (selecting which messages to ingest),
- [ ]  Upstreaming rust-systemd pull-request (jmesmon/rust-systemd#35),
- [ ]  `cfg-config` it out on platforms that don't support/run systemd,
- [ ]  properly setting the timestamp,
- [ ]  tests,
- [ ]  fixing travis-ci, so it tests (at least building) this source.

Original message below.
---
This is an untested journald source.

It depends on an (still unreviewed) pull request to the systemd crate: jmesmon/rust-systemd#35

There are a few things missing. It cannot
 * filter yet what messages to ingest (by unit, or anything else);
 * ingest historical messages.

It also does not contain any documentation. Where should I put it?

I am still not sure what configuration API is best to describe matching the log records to get (systemd-journald can AND and OR matches. See `sd_journal_add_match(3)`). Or whether that is even desirable. What is easily possible and should be done before merging is simple filtering by one field.

ref #232 