### PR TITLE
At Least Once Delivery on Graceful Shutdown

### DIFF
--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -360,7 +360,7 @@ fn main() {
     //
     if let Some(config) = mem::replace(&mut args.null, None) {
         let recv = receivers.remove(&config.config_path).unwrap();
-        let sources = adjacency_matrix.pop_keys(&config.config_path);
+        let sources = adjacency_matrix.pop_nodes(&config.config_path);
         sinks.insert(
             config.config_path.clone(),
             thread::spawn(move || {
@@ -372,7 +372,7 @@ fn main() {
         let recv = receivers
             .remove(&config.config_path.clone().unwrap())
             .unwrap();
-        let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
+        let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
             thread::spawn(move || {
@@ -384,7 +384,7 @@ fn main() {
         let recv = receivers
             .remove(&config.config_path.clone().unwrap())
             .unwrap();
-        let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
+        let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
             thread::spawn(move || match cernan::sink::Wavefront::new(config) {
@@ -402,7 +402,7 @@ fn main() {
         let recv = receivers
             .remove(&config.config_path.clone().unwrap())
             .unwrap();
-        let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
+        let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
             thread::spawn(move || {
@@ -414,7 +414,7 @@ fn main() {
         let recv = receivers
             .remove(&config.config_path.clone().unwrap())
             .unwrap();
-        let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
+        let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
             thread::spawn(move || {
@@ -426,7 +426,7 @@ fn main() {
         let recv = receivers
             .remove(&config.config_path.clone().unwrap())
             .unwrap();
-        let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
+        let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
             thread::spawn(move || {
@@ -438,7 +438,7 @@ fn main() {
         let recv = receivers
             .remove(&config.config_path.clone().unwrap())
             .unwrap();
-        let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
+        let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
             thread::spawn(move || {
@@ -452,7 +452,7 @@ fn main() {
                 .remove(&config.config_path.clone().unwrap())
                 .unwrap();
             let sources =
-                adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
+                adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
             sinks.insert(
                 config.config_path.clone().unwrap(),
                 thread::spawn(move || {
@@ -486,7 +486,7 @@ fn main() {
                 adjacency_matrix.filter_nodes(
                     &config.config_path.clone().unwrap(),
                     |&(ref _k, ref option_v)| option_v.is_none());
-            let downstream_sends = adjacency_matrix.pop_values(&config_path);
+            let downstream_sends = adjacency_matrix.pop_metadata(&config_path);
             filters.insert(
                 config.config_path.clone().unwrap(),
                 thread::spawn(move || {
@@ -523,7 +523,7 @@ fn main() {
                 adjacency_matrix.filter_nodes(
                     &config.config_path.clone().unwrap(),
                     |&(ref _k, ref option_v)| option_v.is_none());
-            let downstream_sends = adjacency_matrix.pop_values(&config_path);
+            let downstream_sends = adjacency_matrix.pop_metadata(&config_path);
             filters.insert(
                 config.config_path.clone().unwrap(),
                 thread::spawn(move || {
@@ -559,7 +559,7 @@ fn main() {
                 adjacency_matrix.filter_nodes(
                     &config.config_path.clone().unwrap(),
                     |&(ref _k, ref option_v)| option_v.is_none());
-            let downstream_sends = adjacency_matrix.pop_values(&config_path);
+            let downstream_sends = adjacency_matrix.pop_metadata(&config_path);
             filters.insert(
                 config.config_path.clone().unwrap(),
                 thread::spawn(move || {
@@ -587,7 +587,7 @@ fn main() {
                 &mut adjacency_matrix,
             );
 
-            let native_server_send = adjacency_matrix.pop_values(&config_path);
+            let native_server_send = adjacency_matrix.pop_metadata(&config_path);
             sources.insert(
                 config_path.clone(),
                 SourceWorker {
@@ -619,7 +619,7 @@ fn main() {
         &mut adjacency_matrix,
     );
 
-    let internal_send = adjacency_matrix.pop_values(&internal_config_path);
+    let internal_send = adjacency_matrix.pop_metadata(&internal_config_path);
     sources.insert(
         internal_config.config_path.clone().unwrap(),
         SourceWorker {
@@ -649,7 +649,7 @@ fn main() {
                 &mut adjacency_matrix,
             );
 
-            let statsd_sends = adjacency_matrix.pop_values(&config_path);
+            let statsd_sends = adjacency_matrix.pop_metadata(&config_path);
             sources.insert(
                 config_path.clone(),
                 SourceWorker {
@@ -680,7 +680,7 @@ fn main() {
                 &mut adjacency_matrix,
             );
 
-            let graphite_sends = adjacency_matrix.pop_values(&config_path);
+            let graphite_sends = adjacency_matrix.pop_metadata(&config_path);
             sources.insert(
                 config_path.clone(),
                 SourceWorker {
@@ -713,7 +713,7 @@ fn main() {
                 &mut adjacency_matrix,
             );
 
-            let fp_sends = adjacency_matrix.pop_values(&config_path);
+            let fp_sends = adjacency_matrix.pop_metadata(&config_path);
             sources.insert(
                 cfg_conf!(config).clone(),
                 SourceWorker {

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -45,6 +45,7 @@ fn populate_forwards(
 
         match available_sends.get(fwd) {
             Some(snd) => {
+                trace!("Populating sender from {:?} to {:?}", config_path, fwd);
                 adjacency_matrix.add_asymmetric_edge(
                     config_path,
                     &fwd.clone(),
@@ -469,8 +470,6 @@ fn main() {
             let recv = receivers
                 .remove(&config.config_path.clone().unwrap())
                 .unwrap();
-            let sources =
-                adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
             let config_path = config
                 .config_path
                 .clone()
@@ -483,6 +482,10 @@ fn main() {
                 &mut adjacency_matrix,
             );
 
+            let sources =
+                adjacency_matrix.filter_nodes(
+                    &config.config_path.clone().unwrap(),
+                    |&(ref _k, ref option_v)| option_v.is_none());
             let downstream_sends = adjacency_matrix.pop_values(&config_path);
             filters.insert(
                 config.config_path.clone().unwrap(),
@@ -503,8 +506,7 @@ fn main() {
             let recv = receivers
                 .remove(&config.config_path.clone().unwrap())
                 .unwrap();
-            let sources =
-                adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
+
             let config_path = config
                 .config_path
                 .clone()
@@ -517,6 +519,10 @@ fn main() {
                 &mut adjacency_matrix,
             );
 
+            let sources =
+                adjacency_matrix.filter_nodes(
+                    &config.config_path.clone().unwrap(),
+                    |&(ref _k, ref option_v)| option_v.is_none());
             let downstream_sends = adjacency_matrix.pop_values(&config_path);
             filters.insert(
                 config.config_path.clone().unwrap(),
@@ -537,8 +543,6 @@ fn main() {
             let recv = receivers
                 .remove(&config.config_path.clone().unwrap())
                 .unwrap();
-            let sources =
-                adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
             let config_path = config
                 .config_path
                 .clone()
@@ -551,6 +555,10 @@ fn main() {
                 &mut adjacency_matrix,
             );
 
+            let sources =
+                adjacency_matrix.filter_nodes(
+                    &config.config_path.clone().unwrap(),
+                    |&(ref _k, ref option_v)| option_v.is_none());
             let downstream_sends = adjacency_matrix.pop_values(&config_path);
             filters.insert(
                 config.config_path.clone().unwrap(),

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -288,20 +288,20 @@ fn main() {
     }
     if let Some(ref configs) = args.statsds {
         for (config_path, config) in configs {
-			config_topology.insert(config_path.clone(), config.forwards.clone());
+            config_topology.insert(config_path.clone(), config.forwards.clone());
             adjacency_matrix.add_edges(&config_path.clone(), config.forwards.clone(), None);
         }
     }
     if let Some(ref configs) = args.graphites {
         for (config_path, config) in configs {
-			config_topology.insert(config_path.clone(), config.forwards.clone());
+            config_topology.insert(config_path.clone(), config.forwards.clone());
             adjacency_matrix.add_edges(&config_path.clone(), config.forwards.clone(), None);
         }
     }
     if let Some(ref configs) = args.files {
         for config in configs {
             let config_path = cfg_conf!(config);
-			config_topology.insert(config_path.clone(), config.forwards.clone());
+	        config_topology.insert(config_path.clone(), config.forwards.clone());
             adjacency_matrix.add_edges(&config_path.clone(), config.forwards.clone(), None);
         }
     }
@@ -522,7 +522,6 @@ fn main() {
                 Some(&mut flush_sends),
                 &config.forwards,
                 &config_path,
-                //&cfg_conf!(config),
                 &senders,
                 &mut adjacency_matrix,
             );

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -47,7 +47,7 @@ fn populate_forwards(
         match available_sends.get(fwd) {
             Some(snd) => {
                 adjacency_matrix.add_asymmetric_edge(
-                    config_path.clone(),
+                    config_path,
                     &fwd.clone(),
                     Some(snd.clone()));
             }
@@ -244,7 +244,7 @@ fn main() {
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), config.forwards.clone());
-            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
+            adjacency_matrix.add_edges(&config_path.clone(), config.forwards.clone(), None);
         }
     }
     if let Some(ref configs) = args.delay_filters {
@@ -257,7 +257,7 @@ fn main() {
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), config.forwards.clone());
-            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
+            adjacency_matrix.add_edges(&config_path.clone(), config.forwards.clone(), None);
         }
     }
     if let Some(ref configs) = args.flush_boundary_filters {
@@ -270,39 +270,39 @@ fn main() {
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), config.forwards.clone());
-            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
+            adjacency_matrix.add_edges(&config_path.clone(), config.forwards.clone(), None);
         }
     }
     // SOURCES
     //
     if let Some(ref configs) = args.native_server_config {
         for (config_path, config) in configs {
-            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
+            adjacency_matrix.add_edges(&config_path.clone(), config.forwards.clone(), None);
         }
     }
     {
         let internal_config = &args.internal;
         config_topology
             .insert(cfg_conf!(internal_config), internal_config.forwards.clone());
-        adjacency_matrix.add_edges(cfg_conf!(internal_config), internal_config.forwards.clone(), None);
+        adjacency_matrix.add_edges(&cfg_conf!(internal_config), internal_config.forwards.clone(), None);
     }
     if let Some(ref configs) = args.statsds {
         for (config_path, config) in configs {
 			config_topology.insert(config_path.clone(), config.forwards.clone());
-            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
+            adjacency_matrix.add_edges(&config_path.clone(), config.forwards.clone(), None);
         }
     }
     if let Some(ref configs) = args.graphites {
         for (config_path, config) in configs {
 			config_topology.insert(config_path.clone(), config.forwards.clone());
-            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
+            adjacency_matrix.add_edges(&config_path.clone(), config.forwards.clone(), None);
         }
     }
     if let Some(ref configs) = args.files {
         for config in configs {
             let config_path = cfg_conf!(config);
 			config_topology.insert(config_path.clone(), config.forwards.clone());
-            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
+            adjacency_matrix.add_edges(&config_path.clone(), config.forwards.clone(), None);
         }
     }
 

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -12,12 +12,12 @@ extern crate log;
 extern crate openssl_probe;
 
 use cernan::constants;
+use cernan::matrix;
 use cernan::filter::{DelayFilterConfig, Filter, FlushBoundaryFilterConfig,
                      ProgrammableFilterConfig};
 use cernan::metric;
 use cernan::sink::Sink;
 use cernan::source::Source;
-use cernan::util;
 use chrono::Utc;
 use std::collections::{HashMap, HashSet};
 use std::mem;
@@ -31,26 +31,25 @@ struct SourceWorker {
     readiness: mio::SetReadiness,
 }
 
-#[derive(Debug)]
-struct SinkWorker {
-    thread: std::thread::JoinHandle<()>,
-    sender: hopper::Sender<metric::Event>,
-}
-
 fn populate_forwards(
-    sends: &mut util::Channel,
     mut top_level_forwards: Option<&mut HashSet<String>>,
     forwards: &[String],
     config_path: &str,
     available_sends: &HashMap<String, hopper::Sender<metric::Event>>,
+    adjacency_matrix: &mut matrix::Adjacency<hopper::Sender<metric::Event>>,
 ) {
     for fwd in forwards {
         if let Some(tlf) = top_level_forwards.as_mut() {
             let _ = (*tlf).insert(fwd.clone());
         }
+
+
         match available_sends.get(fwd) {
             Some(snd) => {
-                sends.push(snd.clone());
+                adjacency_matrix.add_asymmetric_edge(
+                    config_path.clone(),
+                    &fwd.clone(),
+                    Some(snd.clone()));
             }
             None => {
                 error!(
@@ -63,9 +62,9 @@ fn populate_forwards(
     }
 }
 
-fn join_all(workers: HashMap<String, SinkWorker>) {
+fn join_all(workers: HashMap<String, std::thread::JoinHandle<()>>) {
     for (_worker_id, worker) in workers {
-        worker.thread.join().expect("Failed to join worker");
+        worker.join().expect("Failed to join worker");
     }
 }
 
@@ -121,14 +120,15 @@ fn main() {
     //    events, once read it is safe for these workers to flush any pending writes
     //    and shutdown.
     let mut sources: HashMap<String, SourceWorker> = HashMap::new();
-    let mut sinks: HashMap<String, SinkWorker> = HashMap::new();
-    let mut filters: HashMap<String, SinkWorker> = HashMap::new();
+    let mut sinks: HashMap<String, std::thread::JoinHandle<()>> = HashMap::new();
+    let mut filters: HashMap<String, std::thread::JoinHandle<()>> = HashMap::new();
     let mut senders: HashMap<String, hopper::Sender<metric::Event>> = HashMap::new();
     let mut receivers: HashMap<String, hopper::Receiver<metric::Event>> =
         HashMap::new();
     let mut flush_sends = HashSet::new();
 
     let mut config_topology: HashMap<String, Vec<String>> = HashMap::new();
+    let mut adjacency_matrix = matrix::Adjacency::<hopper::Sender<metric::Event>>::new();
 
     // We have to build up the mapping from source / filter / sink to its
     // forwards. We do that here. Once completed we'll have populated:
@@ -244,6 +244,7 @@ fn main() {
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), config.forwards.clone());
+            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
         }
     }
     if let Some(ref configs) = args.delay_filters {
@@ -256,6 +257,7 @@ fn main() {
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), config.forwards.clone());
+            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
         }
     }
     if let Some(ref configs) = args.flush_boundary_filters {
@@ -268,34 +270,39 @@ fn main() {
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), config.forwards.clone());
+            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
         }
     }
     // SOURCES
     //
     if let Some(ref configs) = args.native_server_config {
         for (config_path, config) in configs {
-            config_topology.insert(config_path.clone(), config.forwards.clone());
+            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
         }
     }
     {
         let internal_config = &args.internal;
         config_topology
             .insert(cfg_conf!(internal_config), internal_config.forwards.clone());
+        adjacency_matrix.add_edges(cfg_conf!(internal_config), internal_config.forwards.clone(), None);
     }
     if let Some(ref configs) = args.statsds {
         for (config_path, config) in configs {
-            config_topology.insert(config_path.clone(), config.forwards.clone());
+			config_topology.insert(config_path.clone(), config.forwards.clone());
+            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
         }
     }
     if let Some(ref configs) = args.graphites {
         for (config_path, config) in configs {
-            config_topology.insert(config_path.clone(), config.forwards.clone());
+			config_topology.insert(config_path.clone(), config.forwards.clone());
+            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
         }
     }
     if let Some(ref configs) = args.files {
         for config in configs {
             let config_path = cfg_conf!(config);
-            config_topology.insert(config_path.clone(), config.forwards.clone());
+			config_topology.insert(config_path.clone(), config.forwards.clone());
+            adjacency_matrix.add_edges(config_path.clone(), config.forwards.clone(), None);
         }
     }
 
@@ -319,127 +326,92 @@ fn main() {
     //
     if let Some(config) = mem::replace(&mut args.null, None) {
         let recv = receivers.remove(&config.config_path).unwrap();
+        let sources = adjacency_matrix.pop_keys(&config.config_path);
         sinks.insert(
             config.config_path.clone(),
-            SinkWorker {
-                sender: senders
-                    .get(&config.config_path.clone())
-                    .expect("Oops")
-                    .clone(),
-                thread: thread::spawn(move || {
-                    cernan::sink::Null::new(&config).run(recv);
-                }),
-            },
+            thread::spawn(move || {
+                cernan::sink::Null::new(&config).run(recv, sources);
+            }),
         );
     }
     if let Some(config) = mem::replace(&mut args.console, None) {
         let recv = receivers
             .remove(&config.config_path.clone().unwrap())
             .unwrap();
+        let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            SinkWorker {
-                sender: senders
-                    .get(&config.config_path.clone().unwrap())
-                    .expect("Oops")
-                    .clone(),
-                thread: thread::spawn(move || {
-                    cernan::sink::Console::new(&config).run(recv);
-                }),
-            },
+            thread::spawn(move || {
+                cernan::sink::Console::new(&config).run(recv, sources);
+            }),
         );
     }
     if let Some(config) = mem::replace(&mut args.wavefront, None) {
         let recv = receivers
             .remove(&config.config_path.clone().unwrap())
             .unwrap();
+        let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            SinkWorker {
-                sender: senders
-                    .get(&config.config_path.clone().unwrap())
-                    .expect("Oops")
-                    .clone(),
-                thread: thread::spawn(move || {
-                    match cernan::sink::Wavefront::new(config) {
-                        Ok(mut w) => {
-                            w.run(recv);
-                        }
-                        Err(e) => {
-                            error!("Configuration error for Wavefront: {}", e);
-                            process::exit(1);
-                        }
+            thread::spawn(move || {
+                match cernan::sink::Wavefront::new(config) {
+                    Ok(mut w) => {
+                        w.run(recv, sources);
                     }
-                }),
-            },
+                    Err(e) => {
+                        error!("Configuration error for Wavefront: {}", e);
+                        process::exit(1);
+                    }
+                }
+            }),
         );
     }
     if let Some(config) = mem::replace(&mut args.prometheus, None) {
         let recv = receivers
             .remove(&config.config_path.clone().unwrap())
             .unwrap();
+        let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            SinkWorker {
-                sender: senders
-                    .get(&config.config_path.clone().unwrap())
-                    .expect("Oops")
-                    .clone(),
-                thread: thread::spawn(move || {
-                    cernan::sink::Prometheus::new(&config).run(recv);
-                }),
-            },
+            thread::spawn(move || {
+                cernan::sink::Prometheus::new(&config).run(recv, sources);
+            }),
         );
     }
     if let Some(config) = mem::replace(&mut args.influxdb, None) {
         let recv = receivers
             .remove(&config.config_path.clone().unwrap())
             .unwrap();
+        let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            SinkWorker {
-                sender: senders
-                    .get(&config.config_path.clone().unwrap())
-                    .expect("Oops")
-                    .clone(),
-                thread: thread::spawn(move || {
-                    cernan::sink::InfluxDB::new(&config).run(recv);
-                }),
-            },
+            thread::spawn(move || {
+                cernan::sink::InfluxDB::new(&config).run(recv, sources);
+            }),
         );
     }
     if let Some(config) = mem::replace(&mut args.native_sink_config, None) {
         let recv = receivers
             .remove(&config.config_path.clone().unwrap())
             .unwrap();
+        let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            SinkWorker {
-                sender: senders
-                    .get(&config.config_path.clone().unwrap())
-                    .expect("Oops")
-                    .clone(),
-                thread: thread::spawn(move || {
-                    cernan::sink::Native::new(config).run(recv);
-                }),
-            },
+            thread::spawn(move || {
+                cernan::sink::Native::new(config).run(recv, sources);
+            }),
         );
     }
     if let Some(config) = mem::replace(&mut args.elasticsearch, None) {
         let recv = receivers
             .remove(&config.config_path.clone().unwrap())
             .unwrap();
+        let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            SinkWorker {
-                sender: senders
-                    .get(&config.config_path.clone().unwrap())
-                    .expect("Oops")
-                    .clone(),
-                thread: thread::spawn(move || {
-                    cernan::sink::Elasticsearch::new(config).run(recv);
-                }),
-            },
+            thread::spawn(move || {
+                cernan::sink::Elasticsearch::new(config).run(recv, sources);
+            }),
         );
     }
     if let Some(cfgs) = mem::replace(&mut args.firehosen, None) {
@@ -447,17 +419,12 @@ fn main() {
             let recv = receivers
                 .remove(&config.config_path.clone().unwrap())
                 .unwrap();
+            let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
             sinks.insert(
                 config.config_path.clone().unwrap(),
-                SinkWorker {
-                    sender: senders
-                        .get(&config.config_path.clone().unwrap())
-                        .expect("Oops")
-                        .clone(),
-                    thread: thread::spawn(move || {
-                        cernan::sink::Firehose::new(config).run(recv);
-                    }),
-                },
+                thread::spawn(move || {
+                    cernan::sink::Firehose::new(config).run(recv, sources);
+                }),
             );
         }
     }
@@ -470,29 +437,23 @@ fn main() {
             let recv = receivers
                 .remove(&config.config_path.clone().unwrap())
                 .unwrap();
-            let mut downstream_sends = Vec::new();
+            let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
+            let config_path = config.config_path.clone().expect("[INTERNAL ERROR] no config_path");
             populate_forwards(
-                &mut downstream_sends,
                 None,
                 &config.forwards,
-                &config
-                    .config_path
-                    .clone()
-                    .expect("[INTERNAL ERROR] no config_path"),
+                &config_path,
                 &senders,
+                &mut adjacency_matrix,
             );
+
+            let downstream_sends = adjacency_matrix.pop_values(&config_path);
             filters.insert(
                 config.config_path.clone().unwrap(),
-                SinkWorker {
-                    sender: senders
-                        .get(&config.config_path.clone().unwrap())
-                        .expect("Oops")
-                        .clone(),
-                    thread: thread::spawn(move || {
-                        cernan::filter::ProgrammableFilter::new(c)
-                            .run(recv, downstream_sends);
-                    }),
-                },
+                thread::spawn(move || {
+                    cernan::filter::ProgrammableFilter::new(c)
+                        .run(recv, sources, downstream_sends);
+                }),
             );
         }
     });
@@ -503,29 +464,23 @@ fn main() {
             let recv = receivers
                 .remove(&config.config_path.clone().unwrap())
                 .unwrap();
-            let mut downstream_sends = Vec::new();
+            let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
+            let config_path = config.config_path.clone().expect("[INTERNAL ERROR] no config_path");
             populate_forwards(
-                &mut downstream_sends,
                 None,
                 &config.forwards,
-                &config
-                    .config_path
-                    .clone()
-                    .expect("[INTERNAL ERROR] no config_path"),
+                &config_path,
                 &senders,
+                &mut adjacency_matrix,
             );
+
+            let downstream_sends = adjacency_matrix.pop_values(&config_path);
             filters.insert(
                 config.config_path.clone().unwrap(),
-                SinkWorker {
-                    sender: senders
-                        .get(&config.config_path.clone().unwrap())
-                        .expect("Oops")
-                        .clone(),
-                    thread: thread::spawn(move || {
-                        cernan::filter::DelayFilter::new(&c)
-                            .run(recv, downstream_sends);
-                    }),
-                },
+                thread::spawn(move || {
+                    cernan::filter::DelayFilter::new(&c)
+                        .run(recv, sources, downstream_sends);
+                }),
             );
         }
     });
@@ -536,29 +491,23 @@ fn main() {
             let recv = receivers
                 .remove(&config.config_path.clone().unwrap())
                 .unwrap();
-            let mut downstream_sends = Vec::new();
+            let sources = adjacency_matrix.pop_keys(&config.config_path.clone().unwrap());
+            let config_path = config.config_path.clone().expect("[INTERNAL ERROR] no config_path");
             populate_forwards(
-                &mut downstream_sends,
                 None,
                 &config.forwards,
-                &config
-                    .config_path
-                    .clone()
-                    .expect("[INTERNAL ERROR] no config_path"),
+                &config_path,
                 &senders,
+                &mut adjacency_matrix,
             );
+
+            let downstream_sends = adjacency_matrix.pop_values(&config_path);
             filters.insert(
                 config.config_path.clone().unwrap(),
-                SinkWorker {
-                    sender: senders
-                        .get(&config.config_path.clone().unwrap())
-                        .expect("Oops")
-                        .clone(),
-                    thread: thread::spawn(move || {
-                        cernan::filter::FlushBoundaryFilter::new(&c)
-                            .run(recv, downstream_sends);
-                    }),
-                },
+                thread::spawn(move || {
+                    cernan::filter::FlushBoundaryFilter::new(&c)
+                        .run(recv, sources, downstream_sends);
+                }),
             );
         }
     });
@@ -567,16 +516,18 @@ fn main() {
     //
     mem::replace(&mut args.native_server_config, None).map(|cfg_map| {
         for (config_path, config) in cfg_map {
-            let mut native_server_send = Vec::new();
             let poll = mio::Poll::new().unwrap();
             let (registration, readiness) = mio::Registration::new2();
             populate_forwards(
-                &mut native_server_send,
                 Some(&mut flush_sends),
                 &config.forwards,
-                &cfg_conf!(config),
+                &config_path,
+                //&cfg_conf!(config),
                 &senders,
+                &mut adjacency_matrix,
             );
+
+            let native_server_send = adjacency_matrix.pop_values(&config_path);
             sources.insert(
                 config_path.clone(),
                 SourceWorker {
@@ -597,16 +548,18 @@ fn main() {
     });
 
     let internal_config = mem::replace(&mut args.internal, Default::default());
+    let internal_config_path = internal_config.config_path.clone().unwrap();
     let poll = mio::Poll::new().unwrap();
     let (registration, readiness) = mio::Registration::new2();
-    let mut internal_send = Vec::new();
     populate_forwards(
-        &mut internal_send,
         Some(&mut flush_sends),
         &internal_config.forwards,
-        &cfg_conf!(internal_config),
+        &internal_config_path,
         &senders,
+        &mut adjacency_matrix,
     );
+
+    let internal_send = adjacency_matrix.pop_values(&internal_config_path);
     sources.insert(
         internal_config.config_path.clone().unwrap(),
         SourceWorker {
@@ -626,16 +579,17 @@ fn main() {
 
     mem::replace(&mut args.statsds, None).map(|cfg_map| {
         for (config_path, config) in cfg_map {
-            let mut statsd_sends = Vec::new();
             let poll = mio::Poll::new().unwrap();
             let (registration, readiness) = mio::Registration::new2();
             populate_forwards(
-                &mut statsd_sends,
                 Some(&mut flush_sends),
                 &config.forwards,
-                &cfg_conf!(config),
+                &config_path,
                 &senders,
+                &mut adjacency_matrix,
             );
+
+            let statsd_sends = adjacency_matrix.pop_values(&config_path);
             sources.insert(
                 config_path.clone(),
                 SourceWorker {
@@ -656,16 +610,17 @@ fn main() {
 
     mem::replace(&mut args.graphites, None).map(|cfg_map| {
         for (config_path, config) in cfg_map {
-            let mut graphite_sends = Vec::new();
             let poll = mio::Poll::new().unwrap();
             let (registration, readiness) = mio::Registration::new2();
             populate_forwards(
-                &mut graphite_sends,
                 Some(&mut flush_sends),
                 &config.forwards,
-                &cfg_conf!(config),
+                &config_path,
                 &senders,
+                &mut adjacency_matrix,
             );
+
+            let graphite_sends = adjacency_matrix.pop_values(&config_path);
             sources.insert(
                 config_path.clone(),
                 SourceWorker {
@@ -687,16 +642,18 @@ fn main() {
 
     mem::replace(&mut args.files, None).map(|cfg| {
         for config in cfg {
-            let mut fp_sends = Vec::new();
+            let config_path = config.config_path.clone().unwrap();
             let poll = mio::Poll::new().unwrap();
             let (registration, readiness) = mio::Registration::new2();
             populate_forwards(
-                &mut fp_sends,
                 Some(&mut flush_sends),
                 &config.forwards,
-                &cfg_conf!(config),
+                &config_path,
                 &senders,
+                &mut adjacency_matrix,
             );
+
+            let fp_sends = adjacency_matrix.pop_values(&config_path);
             sources.insert(
                 cfg_conf!(config).clone(),
                 SourceWorker {

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -5,7 +5,6 @@
 //! stream members as they come through. Exact behaviour varies by filters. The
 //! filter receives on an input channel and outputs over its forwards.
 
-use std;
 use hopper;
 use metric;
 use time;
@@ -63,7 +62,7 @@ pub trait Filter {
     fn run(
         &mut self,
         recv: hopper::Receiver<metric::Event>,
-        sources: std::vec::Vec<std::string::String>,
+        sources: Vec<String>,
         mut chans: util::Channel,
     ) {
         let mut attempts = 0;

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -75,10 +75,10 @@ pub trait Filter {
                 None => attempts += 1,
                 Some(metric::Event::Shutdown) => {
                     util::send(&mut chans, metric::Event::Shutdown);
-                        
+
                     total_shutdowns += 1;
                     if total_shutdowns >= sources.len() {
-                            return;
+                        return;
                     }
                 }
                 Some(event) => {

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -75,9 +75,9 @@ pub trait Filter {
                 None => attempts += 1,
                 Some(metric::Event::Shutdown) => {
                     util::send(&mut chans, metric::Event::Shutdown);
-
                     total_shutdowns += 1;
                     if total_shutdowns >= sources.len() {
+                        trace!("Received shutdown from every configured source: {:?}", sources);
                         return;
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,3 +66,4 @@ pub mod constants;
 pub mod thread;
 pub mod protocols;
 pub mod http;
+pub mod matrix;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,43 +1,52 @@
-//! Collection of matrix implementations. 
+//! Collection of matrix implementations.
 
-use std::str::FromStr;
 use std;
+use std::str::FromStr;
 use util;
 
-type AdjacencyMap <T> = util::HashMap<String, Option<T>>;
+type AdjacencyMap<T> = util::HashMap<String, Option<T>>;
 
-type AdjacencyMatrix <T> = util::HashMap<String, AdjacencyMap<T>>;
+type AdjacencyMatrix<T> = util::HashMap<String, AdjacencyMap<T>>;
 
 /// Adjacency matrix struct.
 #[derive(Default)]
-pub struct Adjacency <M: Clone> {
-    edges : AdjacencyMatrix<M>,
+pub struct Adjacency<M: Clone> {
+    edges: AdjacencyMatrix<M>,
 }
 
 ///  Poor man's adjacency matrix biased towards incident edge queries.
 ///
 ///  Edges are not symmetric.  Two values are symmetrically adjacent when
 ///  edges originate from each value to the other value.
-impl <M: Clone> Adjacency <M> {
-
+impl<M: Clone> Adjacency<M> {
     /// Construct a new adjacency matrix.
     pub fn new() -> Self {
         Adjacency {
-            edges: Default::default(), 
+            edges: Default::default(),
         }
-    } 
+    }
 
     /// Adds an outbound edge from a node to another.
-    pub fn add_asymmetric_edge(&mut self, from_str: &str, to_str: &str, metadata: Option<M>) {
+    pub fn add_asymmetric_edge(
+        &mut self,
+        from_str: &str,
+        to_str: &str,
+        metadata: Option<M>,
+    ) {
         let to = String::from_str(to_str).unwrap();
         let from = String::from_str(from_str).unwrap();
- 
+
         let vec = self.edges.entry(from).or_insert_with(Default::default);
         vec.insert(to, metadata);
     }
 
     /// Adds symmetric edges between the given node and a set of other nodes.
-    pub fn add_edges(&mut self, from_str: &str, to_strs: Vec<String>, metadata: Option<M>) {
+    pub fn add_edges(
+        &mut self,
+        from_str: &str,
+        to_strs: Vec<String>,
+        metadata: Option<M>,
+    ) {
         for to_str in to_strs {
             self.add_asymmetric_edge(from_str, &to_str, metadata.clone());
             self.add_asymmetric_edge(&to_str, from_str, metadata.clone())
@@ -46,16 +55,12 @@ impl <M: Clone> Adjacency <M> {
         drop(metadata);
     }
 
-    /// Returns the number of incident edges to the given node. 
+    /// Returns the number of incident edges to the given node.
     pub fn num_edges(&mut self, id: &str) -> usize {
         match self.edges.get(id) {
-            Some(value) => {
-                value.keys().len()
-            }
+            Some(value) => value.keys().len(),
 
-            None => {
-                0
-            }
+            None => 0,
         }
     }
 
@@ -65,7 +70,7 @@ impl <M: Clone> Adjacency <M> {
     }
 
     /// Iterates over edge relations in the matrix.
-    pub fn iter(& self) -> std::collections::hash_map::Iter<String, AdjacencyMap<M>> {
+    pub fn iter(&self) -> std::collections::hash_map::Iter<String, AdjacencyMap<M>> {
         self.edges.iter()
     }
 
@@ -74,18 +79,13 @@ impl <M: Clone> Adjacency <M> {
         self.edges.remove(id)
     }
 
-    /// As pop, but returns a vec of node identifiers connected to the given node.
+    /// As pop, but returns a vec of node identifiers connected to the given
+    /// node.
     pub fn pop_keys(&mut self, id: &str) -> Vec<String> {
         match self.pop(id) {
-            Some(map) => {
-                map.into_iter()
-                   .map(|(k,_v)| {k})
-                   .collect()
-            }
+            Some(map) => map.into_iter().map(|(k, _v)| k).collect(),
 
-            None => {
-                Vec::new()
-            }
+            None => Vec::new(),
         }
     }
 
@@ -93,16 +93,12 @@ impl <M: Clone> Adjacency <M> {
     /// Option values will be unwrapped and None values filtered.
     pub fn pop_values(&mut self, id: &str) -> Vec<M> {
         match self.pop(id) {
-            Some(map) => {
-                map.into_iter()
-                   .filter(|&(ref _k, ref option_v)| option_v.is_some())
-                   .map(|(_, some_v)| some_v.unwrap())
-                   .collect()
-            }
+            Some(map) => map.into_iter()
+                .filter(|&(ref _k, ref option_v)| option_v.is_some())
+                .map(|(_, some_v)| some_v.unwrap())
+                .collect(),
 
-            None => {
-                Vec::new()
-            }
+            None => Vec::new(),
         }
     }
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 use std;
 use util;
 
-type AdjacencyMap <T> = util::HashMap<std::string::String, std::option::Option<T>>;
-type AdjacencyMatrix <T> = util::HashMap<std::string::String, AdjacencyMap<T>>;
+type AdjacencyMap <T> = util::HashMap<String, Option<T>>;
+type AdjacencyMatrix <T> = util::HashMap<String, AdjacencyMap<T>>;
 
 /// Adjacency matrix struct.
 pub struct Adjacency <M: Clone> {
@@ -26,16 +26,16 @@ impl <M: Clone> Adjacency <M> {
     } 
 
     /// Adds an outbound edge from a node to another.
-    pub fn add_asymmetric_edge(&mut self, from_str: &str, to_str: &str, metadata: std::option::Option<M>) {
-        let to = std::string::String::from_str(to_str).unwrap();
-        let from = std::string::String::from_str(from_str).unwrap();
+    pub fn add_asymmetric_edge(&mut self, from_str: &str, to_str: &str, metadata: Option<M>) {
+        let to = String::from_str(to_str).unwrap();
+        let from = String::from_str(from_str).unwrap();
  
         let vec = self.edges.entry(from).or_insert(Default::default());
         vec.insert(to, metadata);
     }
 
     /// Adds symmetric edges between the given node and a set of other nodes.
-    pub fn add_edges(&mut self, from_str: std::string::String, to_strs: std::vec::Vec<std::string::String>, metadata: std::option::Option<M>) {
+    pub fn add_edges(&mut self, from_str: String, to_strs: Vec<String>, metadata: Option<M>) {
         for to_str in to_strs {
             self.add_asymmetric_edge(&from_str, &to_str, metadata.clone());
             self.add_asymmetric_edge(&to_str, &from_str, metadata.clone())
@@ -61,17 +61,17 @@ impl <M: Clone> Adjacency <M> {
     }
 
     /// Iterates over edge relations in the matrix.
-    pub fn iter(& self) -> std::collections::hash_map::Iter<std::string::String, AdjacencyMap<M>> {
+    pub fn iter(& self) -> std::collections::hash_map::Iter<String, AdjacencyMap<M>> {
         self.edges.iter()
     }
 
     /// Pops adjacency metadata for the given node.
-    pub fn pop(&mut self, id: &str) -> std::option::Option<AdjacencyMap<M>> {
+    pub fn pop(&mut self, id: &str) -> Option<AdjacencyMap<M>> {
         self.edges.remove(id)
     }
 
     /// As pop, but returns a vec of node identifiers connected to the given node.
-    pub fn pop_keys(&mut self, id: &str) -> std::vec::Vec<std::string::String> {
+    pub fn pop_keys(&mut self, id: &str) -> Vec<String> {
         match self.pop(id) {
             Some(map) => {
                 map.into_iter()
@@ -80,14 +80,14 @@ impl <M: Clone> Adjacency <M> {
             }
 
             None => {
-                std::vec::Vec::new()
+                Vec::new()
             }
         }
     }
 
     /// As pop, but returns a vec of metadata.
     /// Option values will be unwrapped and None values filtered.
-    pub fn pop_values(&mut self, id: &str) -> std::vec::Vec<M> {
+    pub fn pop_values(&mut self, id: &str) -> Vec<M> {
         match self.pop(id) {
             Some(map) => {
                 map.into_iter()
@@ -97,7 +97,7 @@ impl <M: Clone> Adjacency <M> {
             }
 
             None => {
-                std::vec::Vec::new()
+                Vec::new()
             }
         }
     }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -5,9 +5,11 @@ use std;
 use util;
 
 type AdjacencyMap <T> = util::HashMap<String, Option<T>>;
+
 type AdjacencyMatrix <T> = util::HashMap<String, AdjacencyMap<T>>;
 
 /// Adjacency matrix struct.
+#[derive(Default)]
 pub struct Adjacency <M: Clone> {
     edges : AdjacencyMatrix<M>,
 }
@@ -30,15 +32,15 @@ impl <M: Clone> Adjacency <M> {
         let to = String::from_str(to_str).unwrap();
         let from = String::from_str(from_str).unwrap();
  
-        let vec = self.edges.entry(from).or_insert(Default::default());
+        let vec = self.edges.entry(from).or_insert_with(Default::default);
         vec.insert(to, metadata);
     }
 
     /// Adds symmetric edges between the given node and a set of other nodes.
-    pub fn add_edges(&mut self, from_str: String, to_strs: Vec<String>, metadata: Option<M>) {
+    pub fn add_edges(&mut self, from_str: &str, to_strs: Vec<String>, metadata: Option<M>) {
         for to_str in to_strs {
-            self.add_asymmetric_edge(&from_str, &to_str, metadata.clone());
-            self.add_asymmetric_edge(&to_str, &from_str, metadata.clone())
+            self.add_asymmetric_edge(from_str, &to_str, metadata.clone());
+            self.add_asymmetric_edge(&to_str, from_str, metadata.clone())
         }
     }
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -64,8 +64,8 @@ impl<M: Clone + Debug> Adjacency<M> {
         }
     }
 
-    /// Returns true iff relations exist for the given id.
-    pub fn contains_key(&self, id: &str) -> bool {
+    /// Returns true iff relations exist for the given node id.
+    pub fn contains_node(&self, id: &str) -> bool {
         self.edges.contains_key(id)
     }
 
@@ -89,7 +89,7 @@ impl<M: Clone + Debug> Adjacency<M> {
 
     /// As pop, but returns a vec of node identifiers connected to the given
     /// node.
-    pub fn pop_keys(&mut self, id: &str) -> Vec<String> {
+    pub fn pop_nodes(&mut self, id: &str) -> Vec<String> {
         match self.pop(id) {
             Some(map) => map.into_iter().map(|(k, _v)| k).collect(),
 
@@ -97,9 +97,9 @@ impl<M: Clone + Debug> Adjacency<M> {
         }
     }
 
-    /// As pop, but returns a vec of metadata.
+    /// As pop, but returns a vec of edge metadata.
     /// Option values will be unwrapped and None values filtered.
-    pub fn pop_values(&mut self, id: &str) -> Vec<M> {
+    pub fn pop_metadata(&mut self, id: &str) -> Vec<M> {
         match self.pop(id) {
             Some(map) => map.into_iter()
                 .filter(|&(ref _k, ref option_v)| option_v.is_some())

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,0 +1,104 @@
+//! Collection of matrix implementations. 
+
+use std::str::FromStr;
+use std;
+use util;
+
+type AdjacencyMap <T> = util::HashMap<std::string::String, std::option::Option<T>>;
+type AdjacencyMatrix <T> = util::HashMap<std::string::String, AdjacencyMap<T>>;
+
+/// Adjacency matrix struct.
+pub struct Adjacency <M: Clone> {
+    edges : AdjacencyMatrix<M>,
+}
+
+///  Poor man's adjacency matrix biased towards incident edge queries.
+///
+///  Edges are not symmetric.  Two values are symmetrically adjacent when
+///  edges originate from each value to the other value.
+impl <M: Clone> Adjacency <M> {
+
+    /// Construct a new adjacency matrix.
+    pub fn new() -> Self {
+        Adjacency {
+            edges: Default::default(), 
+        }
+    } 
+
+    /// Adds an outbound edge from a node to another.
+    pub fn add_asymmetric_edge(&mut self, from_str: &str, to_str: &str, metadata: std::option::Option<M>) {
+        let to = std::string::String::from_str(to_str).unwrap();
+        let from = std::string::String::from_str(from_str).unwrap();
+ 
+        let vec = self.edges.entry(from).or_insert(Default::default());
+        vec.insert(to, metadata);
+    }
+
+    /// Adds symmetric edges between the given node and a set of other nodes.
+    pub fn add_edges(&mut self, from_str: std::string::String, to_strs: std::vec::Vec<std::string::String>, metadata: std::option::Option<M>) {
+        for to_str in to_strs {
+            self.add_asymmetric_edge(&from_str, &to_str, metadata.clone());
+            self.add_asymmetric_edge(&to_str, &from_str, metadata.clone())
+        }
+    }
+
+    /// Returns the number of incident edges to the given node. 
+    pub fn num_edges(&mut self, id: &str) -> usize {
+        match self.edges.get(id) {
+            Some(value) => {
+                value.keys().len()
+            }
+
+            None => {
+                0
+            }
+        }
+    }
+
+    /// Returns true iff relations exist for the given id.
+    pub fn contains_key(&self, id: &str) -> bool {
+        self.edges.contains_key(id)
+    }
+
+    /// Iterates over edge relations in the matrix.
+    pub fn iter(& self) -> std::collections::hash_map::Iter<std::string::String, AdjacencyMap<M>> {
+        self.edges.iter()
+    }
+
+    /// Pops adjacency metadata for the given node.
+    pub fn pop(&mut self, id: &str) -> std::option::Option<AdjacencyMap<M>> {
+        self.edges.remove(id)
+    }
+
+    /// As pop, but returns a vec of node identifiers connected to the given node.
+    pub fn pop_keys(&mut self, id: &str) -> std::vec::Vec<std::string::String> {
+        match self.pop(id) {
+            Some(map) => {
+                map.into_iter()
+                   .map(|(k,_v)| {k})
+                   .collect()
+            }
+
+            None => {
+                std::vec::Vec::new()
+            }
+        }
+    }
+
+    /// As pop, but returns a vec of metadata.
+    /// Option values will be unwrapped and None values filtered.
+    pub fn pop_values(&mut self, id: &str) -> std::vec::Vec<M> {
+        match self.pop(id) {
+            Some(map) => {
+                map.into_iter()
+                   .filter(|&(ref _k, ref option_v)| option_v.is_some())
+                   .map(|(_, some_v)| some_v.unwrap())
+                   .collect()
+            }
+
+            None => {
+                std::vec::Vec::new()
+            }
+        }
+    }
+}

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -42,6 +42,8 @@ impl <M: Clone> Adjacency <M> {
             self.add_asymmetric_edge(from_str, &to_str, metadata.clone());
             self.add_asymmetric_edge(&to_str, from_str, metadata.clone())
         }
+
+        drop(metadata);
     }
 
     /// Returns the number of incident edges to the given node. 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,6 +1,7 @@
 //! Collection of matrix implementations.
 
 use std;
+use std::fmt::Debug;
 use std::str::FromStr;
 use util;
 
@@ -18,7 +19,7 @@ pub struct Adjacency<M: Clone> {
 ///
 ///  Edges are not symmetric.  Two values are symmetrically adjacent when
 ///  edges originate from each value to the other value.
-impl<M: Clone> Adjacency<M> {
+impl<M: Clone + Debug> Adjacency<M> {
     /// Construct a new adjacency matrix.
     pub fn new() -> Self {
         Adjacency {
@@ -35,7 +36,6 @@ impl<M: Clone> Adjacency<M> {
     ) {
         let to = String::from_str(to_str).unwrap();
         let from = String::from_str(from_str).unwrap();
-
         let vec = self.edges.entry(from).or_insert_with(Default::default);
         vec.insert(to, metadata);
     }
@@ -67,6 +67,14 @@ impl<M: Clone> Adjacency<M> {
     /// Returns true iff relations exist for the given id.
     pub fn contains_key(&self, id: &str) -> bool {
         self.edges.contains_key(id)
+    }
+
+    /// Filters and returns edges satisfying the given constraint.
+    pub fn filter_nodes<F>(&self, id: &str, f: F) -> Vec<String>
+    where
+        for<'r> F: FnMut(&'r (&String, &Option<M>)) -> bool
+    {
+        self.edges[id].iter().filter(f).map(|(k, _v)| k.clone()).collect()
     }
 
     /// Iterates over edge relations in the matrix.

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -132,8 +132,9 @@ pub trait Sink {
                             //    1) An upstream source injects a Shutdown event after
                             //    all of its events have been processed.
                             //
-                            //    2) Sources shutdown only after receiving Shutdown from
-                            //    each of its upstream sources/filters.
+                            // 2) Sources shutdown only after receiving Shutdown
+                            // from each of its
+                            // upstream sources/filters.
                             total_shutdowns += 1;
                             if total_shutdowns >= sources.len() {
                                 return;

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -6,6 +6,7 @@
 
 use hopper;
 use metric::{Event, LogLine, Telemetry};
+use std;
 use std::sync;
 use time;
 use util::Valve;
@@ -56,10 +57,11 @@ pub trait Sink {
     /// The run-loop of the `Sink`. It's expect that few sinks will ever need to
     /// provide their own implementation. Please take care to obey `Valve`
     /// states and `flush_interval` configurations.
-    fn run(&mut self, recv: hopper::Receiver<Event>) {
+    fn run(&mut self, recv: hopper::Receiver<Event>, sources: std::vec::Vec<std::string::String>) {
         let mut attempts = 0;
         let mut recv = recv.into_iter();
         let mut last_flush_idx = 0;
+        let mut total_shutdowns = 0;
         // The run-loop of a sink is two nested loops. The outer loop pulls a
         // value from the hopper queue. If that value is Some the inner loop
         // tries to do something with it, only discarding it at such time as
@@ -128,12 +130,15 @@ pub trait Sink {
                             // Invariant - In order to ensure at least once delivery
                             // at the sink level, the following properties must hold:
                             //
-                            //    1) Shutdown events only ever appear at the end
-                            //    of a queue.
+                            //    1) An upstream source injects a Shutdown event after
+                            //    all of its events have been processed.
                             //
-                            //    2) The given sink synchronously flushes any
-                            //    internal memory.
-                            return;
+                            //    2) Sources shutdown only after receiving Shutdown from
+                            //    each of its upstream sources/filters.
+                            total_shutdowns += 1;
+                            if total_shutdowns >= sources.len() {
+                                return;
+                            }
                         }
                     },
                     Valve::Closed => {

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -6,7 +6,6 @@
 
 use hopper;
 use metric::{Event, LogLine, Telemetry};
-use std;
 use std::sync;
 use time;
 use util::Valve;
@@ -57,7 +56,7 @@ pub trait Sink {
     /// The run-loop of the `Sink`. It's expect that few sinks will ever need to
     /// provide their own implementation. Please take care to obey `Valve`
     /// states and `flush_interval` configurations.
-    fn run(&mut self, recv: hopper::Receiver<Event>, sources: std::vec::Vec<std::string::String>) {
+    fn run(&mut self, recv: hopper::Receiver<Event>, sources: Vec<String>) {
         let mut attempts = 0;
         let mut recv = recv.into_iter();
         let mut last_flush_idx = 0;

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -137,6 +137,7 @@ pub trait Sink {
                             // upstream sources/filters.
                             total_shutdowns += 1;
                             if total_shutdowns >= sources.len() {
+                                trace!("Received shutdown from every configured source: {:?}", sources);
                                 return;
                             }
                         }

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -115,7 +115,7 @@ impl Sink for Native {
     fn run(
         &mut self,
         recv: hopper::Receiver<metric::Event>,
-        sources: std::vec::Vec<std::string::String>,
+        sources: std::vec::Vec<String>,
     ) {
         let mut attempts = 0;
         let mut recv = recv.into_iter();

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -112,7 +112,11 @@ impl Sink for Native {
         // discard point
     }
 
-    fn run(&mut self, recv: hopper::Receiver<metric::Event>, sources: std::vec::Vec<std::string::String>) {
+    fn run(
+        &mut self,
+        recv: hopper::Receiver<metric::Event>,
+        sources: std::vec::Vec<std::string::String>,
+    ) {
         let mut attempts = 0;
         let mut recv = recv.into_iter();
         let mut last_flush_idx = 0;

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -6,7 +6,6 @@ use protobuf::repeated::RepeatedField;
 use protobuf::stream::CodedOutputStream;
 use protocols::native::{AggregationMethod, LogLine, Payload, Telemetry};
 use sink::{Sink, Valve};
-use std;
 use std::collections::HashMap;
 use std::io::BufWriter;
 use std::mem::replace;
@@ -115,7 +114,7 @@ impl Sink for Native {
     fn run(
         &mut self,
         recv: hopper::Receiver<metric::Event>,
-        sources: std::vec::Vec<String>,
+        sources: Vec<String>,
     ) {
         let mut attempts = 0;
         let mut recv = recv.into_iter();

--- a/src/source/file/file_server.rs
+++ b/src/source/file/file_server.rs
@@ -170,13 +170,17 @@ impl Source for FileServer {
             let backoff = backoff_cap.saturating_sub(global_lines_read);
             let mut events = mio::Events::with_capacity(1024);
             match poller.poll(& mut events, Some(time::Duration::from_millis(backoff as u64))){
-                Err(e) =>
-                    panic!(format!("Failed during poll {:?}", e)),
-                Ok(_num_events) =>
+                Err(e) => {
+                    panic!(format!("Failed during poll {:?}", e))
+                }
+
+                Ok(_num_events) => {
                     // File server doesn't poll for anything other than SYSTEM events.
                     // As currently there are no system events other than SHUTDOWN,
                     // we immediately exit.
-                    return,
+                    send(&mut self.chans, metric::Event::Shutdown);
+                    return;
+                }
             }
         }
     }

--- a/src/source/file/file_server.rs
+++ b/src/source/file/file_server.rs
@@ -169,10 +169,11 @@ impl Source for FileServer {
             }
             let backoff = backoff_cap.saturating_sub(global_lines_read);
             let mut events = mio::Events::with_capacity(1024);
-            match poller.poll(& mut events, Some(time::Duration::from_millis(backoff as u64))){
-                Err(e) => {
-                    panic!(format!("Failed during poll {:?}", e))
-                }
+            match poller.poll(
+                &mut events,
+                Some(time::Duration::from_millis(backoff as u64)),
+            ) {
+                Err(e) => panic!(format!("Failed during poll {:?}", e)),
 
                 Ok(_num_events) => {
                     // File server doesn't poll for anything other than SYSTEM events.

--- a/src/source/file/file_server.rs
+++ b/src/source/file/file_server.rs
@@ -174,7 +174,7 @@ impl Source for FileServer {
                 Some(time::Duration::from_millis(backoff as u64)),
             ) {
                 Err(e) => panic!(format!("Failed during poll {:?}", e)),
-
+                Ok(0) => {}
                 Ok(_num_events) => {
                     // File server doesn't poll for anything other than SYSTEM events.
                     // As currently there are no system events other than SHUTDOWN,

--- a/src/source/graphite.rs
+++ b/src/source/graphite.rs
@@ -160,7 +160,7 @@ fn handle_stream(
 }
 
 fn handle_tcp(
-    chans: util::Channel,
+    mut chans: util::Channel,
     tags: &sync::Arc<metric::TagMap>,
     listeners: util::TokenSlab<mio::net::TcpListener>,
     poll: &mio::Poll,
@@ -177,6 +177,8 @@ fn handle_tcp(
                             for handler in stream_handlers {
                                 handler.shutdown();
                             }
+
+                            send(&mut chans, metric::Event::Shutdown);
                             return;
                         }
                         listener_token => {

--- a/src/source/graphite.rs
+++ b/src/source/graphite.rs
@@ -203,8 +203,7 @@ impl Source for Graphite {
         match addrs {
             Ok(ips) => {
                 let ips: Vec<_> = ips.collect();
-                let mut listeners =
-                    util::TokenSlab::<mio::net::TcpListener>::new();
+                let mut listeners = util::TokenSlab::<mio::net::TcpListener>::new();
                 for addr in ips {
                     let listener = mio::net::TcpListener::bind(&addr)
                         .expect("Unable to bind to TCP socket");

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -2,6 +2,7 @@ use coco::Stack;
 use filter;
 use metric;
 use metric::{AggregationMethod, Telemetry};
+use mio;
 use sink;
 use source;
 use source::Source;
@@ -10,7 +11,6 @@ use std::sync;
 use std::sync::atomic::Ordering;
 use time;
 use util;
-use mio;
 
 lazy_static! {
     static ref Q: Stack<metric::Telemetry> = Stack::new();

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -116,7 +116,12 @@ impl Source for Internal {
                 // Internal source doesn't register any external evented sources.
                 // Any event must be a system event which, at the time of this writing,
                 // can only be a shutdown event.
-                Ok(num_events) if num_events > 0 => return,
+                Ok(num_events) if num_events > 0 => {
+                    util::send(
+                        &mut self.chans,
+                        metric::Event::Shutdown);
+                    return;
+                }
                 Ok(_) => {
                     if !self.chans.is_empty() {
                         // source::graphite

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -19,7 +19,6 @@ pub use self::internal::{report_full_telemetry, Internal, InternalConfig};
 pub use self::native::{NativeServer, NativeServerConfig};
 pub use self::statsd::{Statsd, StatsdConfig, StatsdParseConfig};
 
-
 /// cernan Source, the originator of all `metric::Event`.
 ///
 /// A cernan Source creates all `metric::Event`, doing so by listening to

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -73,7 +73,7 @@ impl NativeServer {
 }
 
 fn handle_tcp(
-    chans: util::Channel,
+    mut chans: util::Channel,
     tags: &sync::Arc<metric::TagMap>,
     listeners: util::TokenSlab<mio::net::TcpListener>,
     poller: &mio::Poll,
@@ -89,6 +89,7 @@ fn handle_tcp(
                         for handler in stream_handlers {
                             handler.shutdown();
                         }
+                        util::send(&mut chans, metric::Event::Shutdown);
                         return;
                     }
                     listener_token => {

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -120,7 +120,11 @@ fn handle_udp(
         match poll.poll(&mut events, None) {
             Ok(_num_events) => for event in events {
                 match event.token() {
-                    constants::SYSTEM => return,
+                    constants::SYSTEM => {
+                        send(&mut chans, metric::Event::Shutdown);
+                        return;
+                    }
+
                     token => {
                         // Get the socket to receive from:
                         let socket = &conns[token];

--- a/src/util.rs
+++ b/src/util.rs
@@ -64,6 +64,12 @@ pub struct TokenSlab <E: mio::Evented> {
     tokens : slab::Slab<E>,
 }
 
+impl <E: mio::Evented> Default for TokenSlab<E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl <E: mio::Evented> Index<mio::Token> for TokenSlab <E> {
     type Output = E;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,13 +1,13 @@
 //! Utility module, a grab-bag of functionality
-use std::ops::Index;
-use mio;
-use slab;
+use constants;
 use hopper;
 use metric;
+use mio;
 use seahash::SeaHasher;
+use slab;
 use std::collections;
 use std::hash;
-use constants;
+use std::ops::Index;
 
 /// Cernan hashmap
 ///
@@ -60,17 +60,17 @@ fn token_to_idx(token: &mio::Token) -> usize {
 }
 
 /// Wrapper around Slab
-pub struct TokenSlab <E: mio::Evented> {
-    tokens : slab::Slab<E>,
+pub struct TokenSlab<E: mio::Evented> {
+    tokens: slab::Slab<E>,
 }
 
-impl <E: mio::Evented> Default for TokenSlab<E> {
+impl<E: mio::Evented> Default for TokenSlab<E> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl <E: mio::Evented> Index<mio::Token> for TokenSlab <E> {
+impl<E: mio::Evented> Index<mio::Token> for TokenSlab<E> {
     type Output = E;
 
     /// Returns Evented object corresponding to Token.
@@ -82,11 +82,10 @@ impl <E: mio::Evented> Index<mio::Token> for TokenSlab <E> {
 /// Interface wrapping a subset of Slab such
 /// that we can magically translate indices to
 /// `mio::token`.
-impl <E: mio::Evented> TokenSlab <E> {
-
+impl<E: mio::Evented> TokenSlab<E> {
     /// Constructs a new TokenSlab with a capacity derived from the value
     /// of constants::SYSTEM.
-    pub fn new () -> TokenSlab<E> {
+    pub fn new() -> TokenSlab<E> {
         TokenSlab {
             tokens: slab::Slab::with_capacity(token_to_idx(&constants::SYSTEM)),
         }
@@ -94,7 +93,7 @@ impl <E: mio::Evented> TokenSlab <E> {
 
     /// Inserts a new Evented into the slab, returning a mio::Token
     /// corresponding to the index of the newly inserted type.
-    pub fn insert(&mut self, thing : E) -> mio::Token {
+    pub fn insert(&mut self, thing: E) -> mio::Token {
         let idx = self.tokens.insert(thing);
         mio::Token::from(idx)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -81,7 +81,7 @@ impl <E: mio::Evented> Index<mio::Token> for TokenSlab <E> {
 
 /// Interface wrapping a subset of Slab such
 /// that we can magically translate indices to
-/// mio::tokens.
+/// `mio::token`.
 impl <E: mio::Evented> TokenSlab <E> {
 
     /// Constructs a new TokenSlab with a capacity derived from the value


### PR DESCRIPTION
The following implements at-least-once delivery semantics on graceful shutdown.

We achieve this by:

* Requiring sources / filters to inject Shutdown events into downstream hopper queues when they can ensure that no more events will be placed.

* Restricting source/filter shutdown such that each incident producer has emitted a Shutdown.  This ensures that all possible events have been consumed from each producer.