### PR TITLE
Alters util::send to NoOp When Chans Is Empty

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -25,6 +25,11 @@ pub type Channel = Vec<hopper::Sender<metric::Event>>;
 
 /// Send a `metric::Event` into a `Channel`.
 pub fn send(chans: &mut Channel, event: metric::Event) {
+    if chans.is_empty() {
+        // Nothing to send to.
+        return
+    }
+
     let max: usize = chans.len().saturating_sub(1);
     if max == 0 {
         chans[0].send(event)


### PR DESCRIPTION
Supports use cases where sources have no configured forwards but attempt
to emit an event (such as Shutdown).