### PR TITLE
Correct crash in statsd source

### DIFF
--- a/src/metric/telemetry.rs
+++ b/src/metric/telemetry.rs
@@ -313,6 +313,17 @@ impl SoftTelemetry {
         self
     }
 
+    /// Clear quantile error bounds
+    ///
+    /// When switching between types during the construction of a Telemetry it's
+    /// possible the error bound will have been previously set. This is a
+    /// problem when the SoftTelemetry is hardened. This method clears that
+    /// previous error bound.
+    pub fn clear_error(mut self) -> SoftTelemetry {
+        self.error = None;
+        self
+    }
+
     /// Set the bounds for histogram calculation
     ///
     /// This is only necessary if the kind has been set to
@@ -907,6 +918,20 @@ mod tests {
     use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
     use std::cmp;
     use std::sync::Arc;
+
+    #[test]
+    fn set_bounds_no_crash() {
+        let res = Telemetry::new()
+            .name("l6")
+            .value(0.7913855)
+            .error(0.01)
+            .kind(AggregationMethod::Histogram)
+            .clear_error()
+            .bounds(vec![0.01, 1.0, 2.0, 4.0])
+            .harden();
+
+        assert!(res.is_ok());
+    }
 
     #[test]
     fn partial_ord_equal() {

--- a/src/protocols/statsd.rs
+++ b/src/protocols/statsd.rs
@@ -108,6 +108,7 @@ pub fn parse_statsd(
                                             if mask_re.is_match(name) {
                                                 metric = metric
                                                     .kind(AggregationMethod::Histogram)
+                                                    .clear_error()
                                                     .bounds(bounds.clone());
                                                 break;
                                             }
@@ -137,6 +138,7 @@ pub fn parse_statsd(
                                         if mask_re.is_match(name) {
                                             metric = metric
                                                 .kind(AggregationMethod::Histogram)
+                                                .clear_error()
                                                 .bounds(bounds.clone());
                                             break;
                                         }


### PR DESCRIPTION
This commit corrects a crash in the statsd source when mapping
bounds are set. The issue was reported by @doubleyou in #371.
We now clear the error value out -- if it exists -- before
hardening.

This resolves #371

Signed-off-by: Brian L. Troutwine <blt@postmates.com>