### PR TITLE
Introduces Baseline Avro Source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "rusoto_firehose 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-avro 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -524,6 +525,14 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "error-chain"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -799,6 +808,11 @@ dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
@@ -1386,8 +1400,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde-avro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snap 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_codegen_internals"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"
@@ -1415,6 +1470,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1463,6 +1529,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "smallvec"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "snap"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "spade"
@@ -1871,6 +1946,7 @@ dependencies = [
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e92ecf0a508c8e074c0e6fa8fe0fa38414848ad4dfc4db6f74c5e9753330b248"
 "checksum fern 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f0297637852905c7ce4cefd8d8a6719f6e3cfb22e2e9f0aa0650f4804a6f360"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -1903,6 +1979,7 @@ dependencies = [
 "checksum lazycell 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b585b7a6811fb03aa10e74b278a0f00f8dd9b45dc681f148bb29fa5cb61859b"
 "checksum libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "36fbc8a8929c632868295d0178dd8f63fc423fd7537ad0738372bd010b3ac9b0"
 "checksum libflate 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ae46bcdafa496981e996e57c5be82c0a7f130a071323764c6faa4803619f1e67"
+"checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum lua 0.0.11 (git+https://github.com/blt/rust-lua53.git)" = "<none>"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
@@ -1968,10 +2045,15 @@ dependencies = [
 "checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "1c57ab4ec5fa85d08aaf8ed9245899d9bbdd66768945b21113b84d5f595cb6a1"
+"checksum serde-avro 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f48903bf150937336f3ed7fcb17b0d2a997f168d81fbf15b8045c03373852a5c"
+"checksum serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc888bd283bd2420b16ad0d860e35ad8acb21941180a83a189bb2046f9d00400"
+"checksum serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "978fd866f4d4872084a81ccc35e275158351d3b9fe620074e7d7504b816b74ba"
 "checksum serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "02c92ea07b6e49b959c1481804ebc9bfd92d3c459f1274c9a9546829e42a66ce"
 "checksum serde_derive_internals 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37aee4e0da52d801acfbc0cc219eb1eda7142112339726e427926a6f6ee65d3a"
 "checksum serde_derive_internals 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75c6aac7b99801a16db5b40b7bf0d7e4ba16e76fbf231e32a4677f271cac0603"
+"checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"
 "checksum serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7cf5b0b5b4bd22eeecb7e01ac2e1225c7ef5e4272b79ee28a8392a8c8489c839"
 "checksum serde_urlencoded 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce0fd303af908732989354c6f02e05e2e6d597152870f2c6990efb0577137480"
 "checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
@@ -1979,6 +2061,7 @@ dependencies = [
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
 "checksum smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f8266519bc1d17d0b5b16f6c21295625d562841c708f6376f49028a43e9c11e"
+"checksum snap 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "24fa40616f5d477294edf132d681b6a6ef4efc9efd71f900fbf356ecdac4a140"
 "checksum spade 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22bd542364c0c964e90ddc146d7b44a4035b618dc347033918994c431cb69d76"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ uuid = {version = "0.5", features = ["v4"]}
 chan-signal = "0.3.1"
 mio = "0.6.11"
 tiny_http = "0.5.8"
+serde-avro = "0.5.0"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -594,7 +594,11 @@ fn main() {
             let native_tags = std::sync::Arc::new(config.tags.clone());
             sources.insert(
                 config_path.clone(),
-                cernan::source::NativeServer::new(native_server_send, native_tags, config.into()).run(),
+                cernan::source::NativeServer::new(
+                    native_server_send,
+                    native_tags,
+                    config.into(),
+                ).run(),
             );
         }
     });
@@ -649,7 +653,8 @@ fn main() {
             let tags = std::sync::Arc::new(config.tags.clone());
             sources.insert(
                 config_path.clone(),
-                cernan::source::Graphite::new(graphite_sends, tags, config.into()).run(),
+                cernan::source::Graphite::new(graphite_sends, tags, config.into())
+                    .run(),
             );
         }
     });
@@ -714,8 +719,11 @@ fn main() {
     drop(flush_sends);
     drop(senders);
     let flush_tags = std::sync::Arc::new(cernan::metric::TagMap::default());
-    cernan::source::FlushTimer::new(flush_channels, flush_tags, cernan::source::FlushTimerConfig)
-        .run();
+    cernan::source::FlushTimer::new(
+        flush_channels,
+        flush_tags,
+        cernan::source::FlushTimerConfig,
+    ).run();
 
     cernan::thread::spawn(move |_poll| {
         cernan::time::update_time();

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -591,9 +591,10 @@ fn main() {
             );
 
             let native_server_send = adjacency_matrix.pop_metadata(&config_path);
+            let native_tags = std::sync::Arc::new(config.tags.clone());
             sources.insert(
                 config_path.clone(),
-                cernan::source::NativeServer::new(native_server_send, config).run(),
+                cernan::source::NativeServer::new(native_server_send, native_tags, config.into()).run(),
             );
         }
     });
@@ -609,9 +610,10 @@ fn main() {
     );
 
     let internal_send = adjacency_matrix.pop_metadata(&internal_config_path);
+    let tags = std::sync::Arc::new(internal_config.tags.clone());
     sources.insert(
         internal_config.config_path.clone().unwrap(),
-        cernan::source::Internal::new(internal_send, internal_config).run(),
+        cernan::source::Internal::new(internal_send, tags, internal_config).run(),
     );
 
     mem::replace(&mut args.statsds, None).map(|cfg_map| {
@@ -625,9 +627,10 @@ fn main() {
             );
 
             let statsd_sends = adjacency_matrix.pop_metadata(&config_path);
+            let tags = std::sync::Arc::new(config.tags.clone());
             sources.insert(
                 config_path.clone(),
-                cernan::source::Statsd::new(statsd_sends, config).run(),
+                cernan::source::Statsd::new(statsd_sends, tags, config).run(),
             );
         }
     });
@@ -643,9 +646,10 @@ fn main() {
             );
 
             let graphite_sends = adjacency_matrix.pop_metadata(&config_path);
+            let tags = std::sync::Arc::new(config.tags.clone());
             sources.insert(
                 config_path.clone(),
-                cernan::source::Graphite::new(graphite_sends, config).run(),
+                cernan::source::Graphite::new(graphite_sends, tags, config.into()).run(),
             );
         }
     });
@@ -661,9 +665,10 @@ fn main() {
             );
 
             let avro_sends = adjacency_matrix.pop_metadata(&config_path);
+            let tags = std::sync::Arc::new(config.tags.clone());
             sources.insert(
                 config_path.clone(),
-                cernan::source::Avro::new(avro_sends, config).run(),
+                cernan::source::Avro::new(avro_sends, tags, config).run(),
             );
         }
     });
@@ -680,9 +685,10 @@ fn main() {
             );
 
             let fp_sends = adjacency_matrix.pop_metadata(&config_path);
+            let tags = std::sync::Arc::new(config.tags.clone());
             sources.insert(
                 cfg_conf!(config).clone(),
-                cernan::source::FileServer::new(fp_sends, config).run(),
+                cernan::source::FileServer::new(fp_sends, tags, config).run(),
             );
         }
     });
@@ -707,7 +713,8 @@ fn main() {
 
     drop(flush_sends);
     drop(senders);
-    cernan::source::FlushTimer::new(flush_channels, cernan::source::FlushTimerConfig)
+    let flush_tags = std::sync::Arc::new(cernan::metric::TagMap::default());
+    cernan::source::FlushTimer::new(flush_channels, flush_tags, cernan::source::FlushTimerConfig)
         .run();
 
     cernan::thread::spawn(move |_poll| {

--- a/src/config.rs
+++ b/src/config.rs
@@ -921,16 +921,13 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
 
                     res.port = tbl.get("port")
                         .map(|p| {
-                            p.as_integer().expect("could not parse avro port")
-                                as u16
+                            p.as_integer().expect("could not parse avro port") as u16
                         })
                         .unwrap_or(res.port);
 
                     res.host = tbl.get("host")
                         .map(|p| {
-                            p.as_str()
-                                .expect("could not parse avro host")
-                                .to_string()
+                            p.as_str().expect("could not parse avro host").to_string()
                         })
                         .unwrap_or(res.host);
 

--- a/src/filter/delay_filter.rs
+++ b/src/filter/delay_filter.rs
@@ -80,6 +80,9 @@ impl filter::Filter for DelayFilter {
             metric::Event::TimerFlush(f) => {
                 res.push(metric::Event::TimerFlush(f));
             }
+            metric::Event::Raw(encoding, bytes) => {
+                res.push(metric::Event::Raw(encoding, bytes));
+            }
             metric::Event::Shutdown => {
                 res.push(metric::Event::Shutdown);
             }

--- a/src/filter/delay_filter.rs
+++ b/src/filter/delay_filter.rs
@@ -80,8 +80,11 @@ impl filter::Filter for DelayFilter {
             metric::Event::TimerFlush(f) => {
                 res.push(metric::Event::TimerFlush(f));
             }
-            metric::Event::Raw{encoding, bytes} => {
-                res.push(metric::Event::Raw{encoding: encoding, bytes: bytes});
+            metric::Event::Raw { encoding, bytes } => {
+                res.push(metric::Event::Raw {
+                    encoding: encoding,
+                    bytes: bytes,
+                });
             }
             metric::Event::Shutdown => {
                 res.push(metric::Event::Shutdown);

--- a/src/filter/delay_filter.rs
+++ b/src/filter/delay_filter.rs
@@ -80,8 +80,8 @@ impl filter::Filter for DelayFilter {
             metric::Event::TimerFlush(f) => {
                 res.push(metric::Event::TimerFlush(f));
             }
-            metric::Event::Raw(encoding, bytes) => {
-                res.push(metric::Event::Raw(encoding, bytes));
+            metric::Event::Raw{encoding, bytes} => {
+                res.push(metric::Event::Raw{encoding: encoding, bytes: bytes});
             }
             metric::Event::Shutdown => {
                 res.push(metric::Event::Shutdown);

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -77,7 +77,10 @@ pub trait Filter {
                     util::send(&mut chans, metric::Event::Shutdown);
                     total_shutdowns += 1;
                     if total_shutdowns >= sources.len() {
-                        trace!("Received shutdown from every configured source: {:?}", sources);
+                        trace!(
+                            "Received shutdown from every configured source: {:?}",
+                            sources
+                        );
                         return;
                     }
                 }

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -638,8 +638,8 @@ impl filter::Filter for ProgrammableFilter {
                 }
                 Ok(())
             }
-            metric::Event::Raw(encoding, bytes) => {
-                res.push(metric::Event::Raw(encoding, bytes));
+            metric::Event::Raw{encoding, bytes} => {
+                res.push(metric::Event::Raw{encoding: encoding, bytes: bytes});
                 Ok(())
             }
             metric::Event::Shutdown => {

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -638,8 +638,11 @@ impl filter::Filter for ProgrammableFilter {
                 }
                 Ok(())
             }
-            metric::Event::Raw{encoding, bytes} => {
-                res.push(metric::Event::Raw{encoding: encoding, bytes: bytes});
+            metric::Event::Raw { encoding, bytes } => {
+                res.push(metric::Event::Raw {
+                    encoding: encoding,
+                    bytes: bytes,
+                });
                 Ok(())
             }
             metric::Event::Shutdown => {

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -638,6 +638,10 @@ impl filter::Filter for ProgrammableFilter {
                 }
                 Ok(())
             }
+            metric::Event::Raw(encoding, bytes) => {
+                res.push(metric::Event::Raw(encoding, bytes));
+                Ok(())
+            }
             metric::Event::Shutdown => {
                 res.push(metric::Event::Shutdown);
                 Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ extern crate regex;
 extern crate rusoto_core;
 extern crate rusoto_firehose;
 extern crate seahash;
+extern crate serde_avro;
 #[macro_use]
 extern crate serde_json;
 extern crate slab;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -72,9 +72,13 @@ impl<M: Clone + Debug> Adjacency<M> {
     /// Filters and returns edges satisfying the given constraint.
     pub fn filter_nodes<F>(&self, id: &str, f: F) -> Vec<String>
     where
-        for<'r> F: FnMut(&'r (&String, &Option<M>)) -> bool
+        for<'r> F: FnMut(&'r (&String, &Option<M>)) -> bool,
     {
-        self.edges[id].iter().filter(f).map(|(k, _v)| k.clone()).collect()
+        self.edges[id]
+            .iter()
+            .filter(f)
+            .map(|(k, _v)| k.clone())
+            .collect()
     }
 
     /// Iterates over edge relations in the matrix.

--- a/src/metric/event.rs
+++ b/src/metric/event.rs
@@ -32,12 +32,12 @@ pub enum Event {
     /// marker the given source will exit cleanly.
     Shutdown,
     /// Raw, encoded bytes.
-    Raw{
+    Raw {
         /// Encoding for the included bytes.
         encoding: Encoding,
         /// Encoded payload.
         bytes: Vec<u8>,
-    }
+    },
 }
 
 impl Event {
@@ -68,7 +68,7 @@ impl Event {
                     None => None,
                 }
             }
-            Event::TimerFlush(_) | Event::Shutdown | Event::Raw{..} => None,
+            Event::TimerFlush(_) | Event::Shutdown | Event::Raw { .. } => None,
         }
     }
 }

--- a/src/metric/event.rs
+++ b/src/metric/event.rs
@@ -1,6 +1,13 @@
 use metric::{LogLine, Telemetry};
 use std::sync;
 
+/// Supported event encodings.
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub enum Encoding {
+    /// Avro
+    Avro,
+}
+
 /// Event: the central cernan datastructure
 ///
 /// Event is the heart of cernan, the enumeration that cernan works on in all
@@ -22,6 +29,8 @@ pub enum Event {
     /// more events will appear.  It is expected that after receiving this
     /// marker the given source will exit cleanly.
     Shutdown,
+    /// Raw, encoded bytes.
+    Raw(Encoding, Vec<u8>),
 }
 
 impl Event {
@@ -52,7 +61,7 @@ impl Event {
                     None => None,
                 }
             }
-            Event::TimerFlush(_) | Event::Shutdown => None,
+            Event::TimerFlush(_) | Event::Shutdown | Event::Raw(_, _) => None,
         }
     }
 }

--- a/src/metric/event.rs
+++ b/src/metric/event.rs
@@ -5,7 +5,7 @@ use std::sync;
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub enum Encoding {
     /// Raw bytes, no encoding.
-    None,
+    Raw,
     /// Avro
     Avro,
 }

--- a/src/metric/event.rs
+++ b/src/metric/event.rs
@@ -4,6 +4,8 @@ use std::sync;
 /// Supported event encodings.
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub enum Encoding {
+    /// Raw bytes, no encoding.
+    None,
     /// Avro
     Avro,
 }
@@ -30,7 +32,12 @@ pub enum Event {
     /// marker the given source will exit cleanly.
     Shutdown,
     /// Raw, encoded bytes.
-    Raw(Encoding, Vec<u8>),
+    Raw{
+        /// Encoding for the included bytes.
+        encoding: Encoding,
+        /// Encoded payload.
+        bytes: Vec<u8>,
+    }
 }
 
 impl Event {
@@ -61,7 +68,7 @@ impl Event {
                     None => None,
                 }
             }
-            Event::TimerFlush(_) | Event::Shutdown | Event::Raw(_, _) => None,
+            Event::TimerFlush(_) | Event::Shutdown | Event::Raw{..} => None,
         }
     }
 }

--- a/src/metric/mod.rs
+++ b/src/metric/mod.rs
@@ -6,7 +6,7 @@ mod logline;
 mod event;
 mod telemetry;
 
-pub use self::event::Event;
+pub use self::event::{Encoding, Event};
 pub use self::logline::LogLine;
 pub use self::telemetry::{AggregationMethod, Telemetry};
 #[cfg(test)]

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -51,7 +51,7 @@ pub trait Sink {
     /// implementation.
     fn deliver_line(&mut self, line: sync::Arc<Option<LogLine>>) -> ();
     ///// Deliver a 'Raw' series of encoded bytes to the sink.
-    //fn deliver_raw(&mut self, encoding: Encoding, bytes: Vec<u8>);
+    // fn deliver_raw(&mut self, encoding: Encoding, bytes: Vec<u8>);
     /// Provide a hook to shutdown a sink. This is necessary for sinks which
     /// have their own long-running threads.
     fn shutdown(self) -> ();
@@ -128,7 +128,7 @@ pub trait Sink {
                             break;
                         }
                         Event::Raw(_encoding, _bytes) => {
-                            //self.deliver_raw(encoding, bytes);
+                            // self.deliver_raw(encoding, bytes);
                             break;
                         }
                         Event::Shutdown => {

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -127,7 +127,7 @@ pub trait Sink {
                             self.deliver_line(line);
                             break;
                         }
-                        Event::Raw(_encoding, _bytes) => {
+                        Event::Raw{..} => {
                             // self.deliver_raw(encoding, bytes);
                             break;
                         }

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -5,7 +5,7 @@
 //! different choices.
 
 use hopper;
-use metric::{Event, LogLine, Telemetry};
+use metric::{Encoding, Event, LogLine, Telemetry};
 use std::sync;
 use time;
 use util::Valve;
@@ -50,8 +50,11 @@ pub trait Sink {
     /// Deliver a `LogLine` to the `Sink`. Exact behaviour varies by
     /// implementation.
     fn deliver_line(&mut self, line: sync::Arc<Option<LogLine>>) -> ();
-    ///// Deliver a 'Raw' series of encoded bytes to the sink.
-    // fn deliver_raw(&mut self, encoding: Encoding, bytes: Vec<u8>);
+    /// Deliver a 'Raw' series of encoded bytes to the sink.
+    fn deliver_raw(&mut self, _encoding: Encoding, _bytes: Vec<u8>) -> () {
+        // Not all sinks accept raw events.  By default, we do nothing.
+        return;
+    }
     /// Provide a hook to shutdown a sink. This is necessary for sinks which
     /// have their own long-running threads.
     fn shutdown(self) -> ();
@@ -127,8 +130,8 @@ pub trait Sink {
                             self.deliver_line(line);
                             break;
                         }
-                        Event::Raw{..} => {
-                            // self.deliver_raw(encoding, bytes);
+                        Event::Raw{encoding, bytes} => {
+                            self.deliver_raw(encoding, bytes);
                             break;
                         }
                         Event::Shutdown => {

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -5,7 +5,7 @@
 //! different choices.
 
 use hopper;
-use metric::{Encoding, Event, LogLine, Telemetry};
+use metric::{Event, LogLine, Telemetry};
 use std::sync;
 use time;
 use util::Valve;

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -130,7 +130,7 @@ pub trait Sink {
                             self.deliver_line(line);
                             break;
                         }
-                        Event::Raw{encoding, bytes} => {
+                        Event::Raw { encoding, bytes } => {
                             self.deliver_raw(encoding, bytes);
                             break;
                         }

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -5,7 +5,7 @@
 //! different choices.
 
 use hopper;
-use metric::{Event, LogLine, Telemetry};
+use metric::{Encoding, Event, LogLine, Telemetry};
 use std::sync;
 use time;
 use util::Valve;
@@ -50,6 +50,8 @@ pub trait Sink {
     /// Deliver a `LogLine` to the `Sink`. Exact behaviour varies by
     /// implementation.
     fn deliver_line(&mut self, line: sync::Arc<Option<LogLine>>) -> ();
+    ///// Deliver a 'Raw' series of encoded bytes to the sink.
+    //fn deliver_raw(&mut self, encoding: Encoding, bytes: Vec<u8>);
     /// Provide a hook to shutdown a sink. This is necessary for sinks which
     /// have their own long-running threads.
     fn shutdown(self) -> ();
@@ -123,6 +125,10 @@ pub trait Sink {
                         }
                         Event::Log(line) => {
                             self.deliver_line(line);
+                            break;
+                        }
+                        Event::Raw(_encoding, _bytes) => {
+                            //self.deliver_raw(encoding, bytes);
                             break;
                         }
                         Event::Shutdown => {

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -111,11 +111,7 @@ impl Sink for Native {
         // discard point
     }
 
-    fn run(
-        &mut self,
-        recv: hopper::Receiver<metric::Event>,
-        sources: Vec<String>,
-    ) {
+    fn run(&mut self, recv: hopper::Receiver<metric::Event>, sources: Vec<String>) {
         let mut attempts = 0;
         let mut recv = recv.into_iter();
         let mut last_flush_idx = 0;

--- a/src/source/avro.rs
+++ b/src/source/avro.rs
@@ -71,7 +71,7 @@ fn handle_avro_payload(
     util::send(&mut chans, metric::Event::Raw{encoding:metric::Encoding::Avro, bytes: buf});
 }
 
-impl source::Source<Avro, source::TCPConfig> for Avro {
+impl source::Source<source::TCPConfig> for Avro {
     /// Creates and starts an Avro source witht the given config.
     fn new(chans: util::Channel, config: source::TCPConfig) -> Self {
         Avro {

--- a/src/source/avro.rs
+++ b/src/source/avro.rs
@@ -1,0 +1,93 @@
+use byteorder::{BigEndian, ReadBytesExt};
+use constants;
+use metric;
+use mio;
+use serde_avro;
+use source;
+use std::io::Read;
+use std::{io, sync};
+use thread;
+use util;
+
+/// Avro source state
+pub struct Avro {
+    server: source::TCP
+}
+
+/// Monitors for inbound system and TCP events.
+fn stream_handler(
+    chans: util::Channel,
+    tags: &sync::Arc<metric::TagMap>,
+    poller: &mio::Poll,
+    stream: mio::net::TcpStream) 
+{
+    let mut reader = io::BufReader::new(stream);
+    loop {
+        let mut events = mio::Events::with_capacity(1024);
+        match poller.poll(&mut events, None) {
+            Err(e) => panic!(format!("Failed during poll {:?}", e)),
+            Ok(_num_events) => for event in events {
+                match event.token() {
+                    constants::SYSTEM => return,
+                    _stream_token => {
+                        handle_avro_payload(chans.clone(), tags, &mut reader);
+                    }
+                }
+            }
+        };
+    }
+}
+
+
+/// Pulls length prefixed (4 bytes, BE), avro encoded
+/// binaries off the wire and populates them in the configured
+/// channel.
+fn handle_avro_payload(
+    mut chans: util::Channel,
+    tags: &sync::Arc<metric::TagMap>,
+    reader: &mut io::BufReader<mio::net::TcpStream>,
+) {
+    let mut buf = Vec::with_capacity(4000);
+    let payload_size_in_bytes = match reader.read_u32::<BigEndian>() {
+        Ok(i) => i as usize,
+        Err(_) => return,
+    };
+    buf.resize(payload_size_in_bytes, 0);
+    if reader.read_exact(&mut buf).is_err() {
+        return;
+    }
+
+    match serde_avro::de::Deserializer::from_container(&buf[..]) {
+        Ok(avro_de) => {
+            trace!("Successfully deserialized container.");
+            //TODO - Enforce configurable type naming requirements.
+        }
+
+        Err(e) => {
+            trace!("Failed to deserialize container: {:?}", e.description());
+            return;
+        }
+    }
+
+    util::send(&mut chans, metric::Event::Raw(metric::Encoding::Avro, buf));
+}
+
+impl thread::Stoppable for Avro {
+    fn join(self) {
+        self.server.join();
+    }
+
+    fn shutdown(self) {
+        self.server.shutdown();
+    }
+}
+
+impl Avro {
+
+    /// Creates and starts an Avro source witht the given config.
+    pub fn new (chans: util::Channel, config: source::TCPConfig) -> Self {
+        Avro {
+            server: source::TCP::new(chans, config, stream_handler)
+        }
+    }
+}

--- a/src/source/avro.rs
+++ b/src/source/avro.rs
@@ -68,7 +68,7 @@ fn handle_avro_payload(
         }
     }
 
-    util::send(&mut chans, metric::Event::Raw(metric::Encoding::Avro, buf));
+    util::send(&mut chans, metric::Event::Raw{encoding:metric::Encoding::Avro, bytes: buf});
 }
 
 impl source::Source<Avro, source::TCPConfig> for Avro {

--- a/src/source/avro.rs
+++ b/src/source/avro.rs
@@ -4,14 +4,14 @@ use metric;
 use mio;
 use serde_avro;
 use source;
-use std::io::Read;
 use std::{io, sync};
+use std::io::Read;
 use thread;
 use util;
 
 /// Avro source state
 pub struct Avro {
-    server: source::TCP
+    server: source::TCP,
 }
 
 /// Monitors for inbound system and TCP events.
@@ -19,8 +19,8 @@ fn stream_handler(
     chans: util::Channel,
     tags: &sync::Arc<metric::TagMap>,
     poller: &mio::Poll,
-    stream: mio::net::TcpStream) 
-{
+    stream: mio::net::TcpStream,
+) {
     let mut reader = io::BufReader::new(stream);
     loop {
         let mut events = mio::Events::with_capacity(1024);
@@ -33,11 +33,10 @@ fn stream_handler(
                         handle_avro_payload(chans.clone(), tags, &mut reader);
                     }
                 }
-            }
+            },
         };
     }
 }
-
 
 /// Pulls length prefixed (4 bytes, BE), avro encoded
 /// binaries off the wire and populates them in the configured
@@ -60,7 +59,7 @@ fn handle_avro_payload(
     match serde_avro::de::Deserializer::from_container(&buf[..]) {
         Ok(_avro_de) => {
             trace!("Successfully deserialized container.");
-            //TODO - Enforce configurable type naming requirements.
+            // TODO - Enforce configurable type naming requirements.
         }
 
         Err(e) => {
@@ -74,13 +73,13 @@ fn handle_avro_payload(
 
 impl source::Source<Avro, source::TCPConfig> for Avro {
     /// Creates and starts an Avro source witht the given config.
-    fn new (chans: util::Channel, config: source::TCPConfig) -> Self {
+    fn new(chans: util::Channel, config: source::TCPConfig) -> Self {
         Avro {
-            server: source::TCP::new(chans, config)
+            server: source::TCP::new(chans, config),
         }
     }
 
-	fn run(self) -> thread::ThreadHandle {
-		self.server.run(stream_handler)
-	}
+    fn run(self) -> thread::ThreadHandle {
+        self.server.run(stream_handler)
+    }
 }

--- a/src/source/avro.rs
+++ b/src/source/avro.rs
@@ -3,20 +3,25 @@ use constants;
 use metric;
 use mio;
 use serde_avro;
-use source::{TCP, TCPStreamHandler};
+use source::{TCPStreamHandler, TCP};
 use std::{io, sync};
 use std::io::Read;
 use util;
 
 #[derive(Default, Debug, Clone, Deserialize)]
-pub struct AvroStreamHandler ;
+pub struct AvroStreamHandler;
 
 impl TCPStreamHandler for AvroStreamHandler {
-
     /// Receives and buffers Avro events from the given stream.
     ///
     /// The stream handler exits gracefully whhen a shutdown event is received.
-    fn handle_stream(&mut self, chans: util::Channel, tags: &sync::Arc<metric::TagMap>, poller: &mio::Poll, stream: mio::net::TcpStream)-> () {
+    fn handle_stream(
+        &mut self,
+        chans: util::Channel,
+        tags: &sync::Arc<metric::TagMap>,
+        poller: &mio::Poll,
+        stream: mio::net::TcpStream,
+    ) -> () {
         let mut reader = io::BufReader::new(stream);
         loop {
             let mut events = mio::Events::with_capacity(1024);
@@ -36,7 +41,6 @@ impl TCPStreamHandler for AvroStreamHandler {
 }
 
 impl AvroStreamHandler {
-
     /// Pulls length prefixed (4 bytes, BE), avro encoded
     /// binaries off the wire and populates them in the configured
     /// channel.
@@ -68,7 +72,13 @@ impl AvroStreamHandler {
             }
         }
 
-        util::send(&mut chans, metric::Event::Raw{encoding:metric::Encoding::Avro, bytes: buf});
+        util::send(
+            &mut chans,
+            metric::Event::Raw {
+                encoding: metric::Encoding::Avro,
+                bytes: buf,
+            },
+        );
     }
 }
 

--- a/src/source/avro.rs
+++ b/src/source/avro.rs
@@ -46,12 +46,12 @@ fn handle_avro_payload(
     _tags: &sync::Arc<metric::TagMap>,
     reader: &mut io::BufReader<mio::net::TcpStream>,
 ) {
-    let mut buf = Vec::with_capacity(4000);
     let payload_size_in_bytes = match reader.read_u32::<BigEndian>() {
         Ok(i) => i as usize,
         Err(_) => return,
     };
-    buf.resize(payload_size_in_bytes, 0);
+
+    let mut buf = Vec::with_capacity(payload_size_in_bytes);
     if reader.read_exact(&mut buf).is_err() {
         return;
     }
@@ -72,13 +72,14 @@ fn handle_avro_payload(
 }
 
 impl source::Source<source::TCPConfig> for Avro {
-    /// Creates and starts an Avro source witht the given config.
+    /// Creates an Avro source with the given config.
     fn new(chans: util::Channel, config: source::TCPConfig) -> Self {
         Avro {
             server: source::TCP::new(chans, config),
         }
     }
 
+    /// Starts the given Avro source, consuming its state in the process.
     fn run(self) -> thread::ThreadHandle {
         self.server.run(stream_handler)
     }

--- a/src/source/avro.rs
+++ b/src/source/avro.rs
@@ -3,84 +3,74 @@ use constants;
 use metric;
 use mio;
 use serde_avro;
-use source;
+use source::{TCP, TCPStreamHandler};
 use std::{io, sync};
 use std::io::Read;
-use thread;
 use util;
 
-/// Avro source state
-pub struct Avro {
-    server: source::TCP,
-}
+#[derive(Default, Debug, Clone, Deserialize)]
+pub struct AvroStreamHandler ;
 
-/// Monitors for inbound system and TCP events.
-fn stream_handler(
-    chans: util::Channel,
-    tags: &sync::Arc<metric::TagMap>,
-    poller: &mio::Poll,
-    stream: mio::net::TcpStream,
-) {
-    let mut reader = io::BufReader::new(stream);
-    loop {
-        let mut events = mio::Events::with_capacity(1024);
-        match poller.poll(&mut events, None) {
-            Err(e) => panic!(format!("Failed during poll {:?}", e)),
-            Ok(_num_events) => for event in events {
-                match event.token() {
-                    constants::SYSTEM => return,
-                    _stream_token => {
-                        handle_avro_payload(chans.clone(), tags, &mut reader);
+impl TCPStreamHandler for AvroStreamHandler {
+
+    /// Receives and buffers Avro events from the given stream.
+    ///
+    /// The stream handler exits gracefully whhen a shutdown event is received.
+    fn handle_stream(&mut self, chans: util::Channel, tags: &sync::Arc<metric::TagMap>, poller: &mio::Poll, stream: mio::net::TcpStream)-> () {
+        let mut reader = io::BufReader::new(stream);
+        loop {
+            let mut events = mio::Events::with_capacity(1024);
+            match poller.poll(&mut events, None) {
+                Err(e) => panic!(format!("Failed during poll {:?}", e)),
+                Ok(_num_events) => for event in events {
+                    match event.token() {
+                        constants::SYSTEM => return,
+                        _stream_token => {
+                            self.handle_avro_payload(chans.clone(), tags, &mut reader);
+                        }
                     }
-                }
-            },
-        };
+                },
+            };
+        }
     }
 }
 
-/// Pulls length prefixed (4 bytes, BE), avro encoded
-/// binaries off the wire and populates them in the configured
-/// channel.
-fn handle_avro_payload(
-    mut chans: util::Channel,
-    _tags: &sync::Arc<metric::TagMap>,
-    reader: &mut io::BufReader<mio::net::TcpStream>,
-) {
-    let payload_size_in_bytes = match reader.read_u32::<BigEndian>() {
-        Ok(i) => i as usize,
-        Err(_) => return,
-    };
+impl AvroStreamHandler {
 
-    let mut buf = Vec::with_capacity(payload_size_in_bytes);
-    if reader.read_exact(&mut buf).is_err() {
-        return;
-    }
+    /// Pulls length prefixed (4 bytes, BE), avro encoded
+    /// binaries off the wire and populates them in the configured
+    /// channel.
+    fn handle_avro_payload(
+        &mut self,
+        mut chans: util::Channel,
+        _tags: &sync::Arc<metric::TagMap>,
+        reader: &mut io::BufReader<mio::net::TcpStream>,
+    ) {
+        let payload_size_in_bytes = match reader.read_u32::<BigEndian>() {
+            Ok(i) => i as usize,
+            Err(_) => return,
+        };
 
-    match serde_avro::de::Deserializer::from_container(&buf[..]) {
-        Ok(_avro_de) => {
-            trace!("Successfully deserialized container.");
-            // TODO - Enforce configurable type naming requirements.
-        }
-
-        Err(e) => {
-            trace!("Failed to deserialize container: {:?}", e.description());
+        let mut buf = Vec::with_capacity(payload_size_in_bytes);
+        if reader.read_exact(&mut buf).is_err() {
             return;
         }
-    }
 
-    util::send(&mut chans, metric::Event::Raw{encoding:metric::Encoding::Avro, bytes: buf});
-}
+        match serde_avro::de::Deserializer::from_container(&buf[..]) {
+            Ok(_avro_de) => {
+                trace!("Successfully deserialized container.");
+                // TODO - Enforce configurable type naming requirements.
+            }
 
-impl source::Source<source::TCPConfig> for Avro {
-    /// Creates an Avro source with the given config.
-    fn new(chans: util::Channel, config: source::TCPConfig) -> Self {
-        Avro {
-            server: source::TCP::new(chans, config),
+            Err(e) => {
+                trace!("Failed to deserialize container: {:?}", e.description());
+                return;
+            }
         }
-    }
 
-    /// Starts the given Avro source, consuming its state in the process.
-    fn run(self) -> thread::ThreadHandle {
-        self.server.run(stream_handler)
+        util::send(&mut chans, metric::Event::Raw{encoding:metric::Encoding::Avro, bytes: buf});
     }
 }
+
+/// Source for Avro events.
+pub type Avro = TCP<AvroStreamHandler>;

--- a/src/source/file/file_server.rs
+++ b/src/source/file/file_server.rs
@@ -183,10 +183,6 @@ impl source::Source<FileServer, FileServerConfig> for FileServer {
     }
 
     fn run(self) -> thread::ThreadHandle {
-        thread::spawn(
-            move |poll| {
-                file_server(self.chans, self.config, poll)
-            }
-        )
+        thread::spawn(move |poll| file_server(self.chans, self.config, poll))
     }
 }

--- a/src/source/file/file_server.rs
+++ b/src/source/file/file_server.rs
@@ -172,10 +172,10 @@ fn file_server(mut chans: util::Channel, config: FileServerConfig, poller: mio::
 ///
 /// Specific operating systems support evented interfaces that correct this
 /// problem but your intrepid authors know of no generic solution.
-impl source::Source<FileServer, FileServerConfig> for FileServer {
+impl source::Source<FileServerConfig> for FileServer {
     /// Make a FileServer
     ///
-    fn new(chans: util::Channel, config: FileServerConfig) -> FileServer {
+    fn new(chans: util::Channel, config: FileServerConfig) -> Self {
         FileServer {
             chans: chans,
             config: config,

--- a/src/source/file/file_server.rs
+++ b/src/source/file/file_server.rs
@@ -6,8 +6,8 @@ use source::file::file_watcher::FileWatcher;
 use source::internal::report_full_telemetry;
 use std::mem;
 use std::path::PathBuf;
-use std::sync;
 use std::str;
+use std::sync;
 use std::time;
 use util;
 use util::send;
@@ -80,7 +80,12 @@ impl source::Source<FileServerConfig> for FileServer {
         }
     }
 
-    fn run(self, mut chans: util::Channel, tags: &sync::Arc<metric::TagMap>, poller: mio::Poll) -> () {
+    fn run(
+        self,
+        mut chans: util::Channel,
+        tags: &sync::Arc<metric::TagMap>,
+        poller: mio::Poll,
+    ) -> () {
         let mut buffer = String::new();
 
         let mut fp_map: util::HashMap<PathBuf, FileWatcher> = Default::default();

--- a/src/source/file/file_server.rs
+++ b/src/source/file/file_server.rs
@@ -6,9 +6,9 @@ use source::file::file_watcher::FileWatcher;
 use source::internal::report_full_telemetry;
 use std::mem;
 use std::path::PathBuf;
+use std::sync;
 use std::str;
 use std::time;
-use thread;
 use util;
 use util::send;
 
@@ -22,12 +22,12 @@ use util::send;
 /// exist at cernan startup. `FileServer` will discover new files which match
 /// its path in at most 60 seconds.
 pub struct FileServer {
-    chans: util::Channel,
-    config: FileServerConfig,
+    pattern: PathBuf,
+    max_lines_read: usize,
 }
 
 /// The configuration struct for `FileServer`.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct FileServerConfig {
     /// The path that `FileServer` will watch. Globs are allowed and
     /// `FileServer` will watch multiple files.
@@ -35,7 +35,8 @@ pub struct FileServerConfig {
     /// The maximum number of lines to read from a file before switching to a
     /// new file.
     pub max_lines_read: usize,
-    /// The default tags to apply to each discovered LogLine.
+    /// The tags the Native source will associate with every Telemetry it
+    /// creates.
     pub tags: metric::TagMap,
     /// The forwards which `FileServer` will obey.
     pub forwards: Vec<String>,
@@ -51,110 +52,6 @@ impl Default for FileServerConfig {
             tags: metric::TagMap::default(),
             forwards: Vec::default(),
             config_path: None,
-        }
-    }
-}
-
-fn file_server(mut chans: util::Channel, config: FileServerConfig, poller: mio::Poll) {
-    let pattern = config.path.expect("must specify a 'path' for FileServer");
-    let mut buffer = String::new();
-
-    let mut fp_map: util::HashMap<PathBuf, FileWatcher> = Default::default();
-    let mut fp_map_alt: util::HashMap<PathBuf, FileWatcher> = Default::default();
-
-    let mut backoff_cap: usize = 1;
-    let mut lines = Vec::new();
-    // Alright friends, how does this work?
-    //
-    // We want to avoid burning up users' CPUs. To do this we sleep after
-    // reading lines out of files. But! We want to be responsive as well. We
-    // keep track of a 'backoff_cap' to decide how long we'll wait in any
-    // given loop. This cap grows each time we fail to read lines in an
-    // exponential fashion to some hard-coded cap.
-    loop {
-        let mut global_lines_read: usize = 0;
-        // glob poll
-        for entry in glob(pattern.to_str().expect("no ability to glob"))
-            .expect("Failed to read glob pattern")
-        {
-            if let Ok(path) = entry {
-                let entry = fp_map.entry(path.clone());
-                if let Ok(fw) = FileWatcher::new(&path) {
-                    entry.or_insert(fw);
-                };
-            }
-        }
-        // line polling
-        for (path, mut watcher) in fp_map.drain() {
-            let mut lines_read: usize = 0;
-            while let Ok(sz) = watcher.read_line(&mut buffer) {
-                if sz > 0 {
-                    lines_read += 1;
-                    lines.push(
-                        metric::LogLine::new(
-                            path.to_str().expect("not a valid path"),
-                            &buffer,
-                        ).overlay_tags_from_map(&config.tags),
-                    );
-                    buffer.clear();
-                } else {
-                    break;
-                }
-                if lines_read > config.max_lines_read {
-                    break;
-                }
-            }
-            report_full_telemetry(
-                "cernan.sources.file.lines_read",
-                lines_read as f64,
-                Some(vec![
-                    ("file_path", path.to_str().expect("not a valid path")),
-                ]),
-            );
-            // A FileWatcher is dead when the underlying file has
-            // disappeared. If the FileWatcher is dead we don't stick it in
-            // the fp_map_alt and deallocate it.
-            if !watcher.dead() {
-                fp_map_alt.insert(path, watcher);
-            }
-            global_lines_read = global_lines_read.saturating_add(lines_read);
-        }
-        for l in lines.drain(..) {
-            send(&mut chans, metric::Event::new_log(l));
-        }
-        // We've drained the live FileWatchers into fp_map_alt in the line
-        // polling loop. Now we swapped them back to fp_map so next time we
-        // loop through we'll read from the live FileWatchers.
-        mem::swap(&mut fp_map, &mut fp_map_alt);
-        // When no lines have been read we kick the backup_cap up by twice,
-        // limited by the hard-coded cap. Else, we set the backup_cap to its
-        // minimum on the assumption that next time through there will be
-        // more lines to read promptly.
-        if global_lines_read == 0 {
-            let lim = backoff_cap.saturating_mul(2);
-            if lim > 2_048 {
-                backoff_cap = 2_048;
-            } else {
-                backoff_cap = lim;
-            }
-        } else {
-            backoff_cap = 1;
-        }
-        let backoff = backoff_cap.saturating_sub(global_lines_read);
-        let mut events = mio::Events::with_capacity(1024);
-        match poller.poll(
-            &mut events,
-            Some(time::Duration::from_millis(backoff as u64)),
-        ) {
-            Err(e) => panic!(format!("Failed during poll {:?}", e)),
-            Ok(0) => {}
-            Ok(_num_events) => {
-                // File server doesn't poll for anything other than SYSTEM events.
-                // As currently there are no system events other than SHUTDOWN,
-                // we immediately exit.
-                send(&mut chans, metric::Event::Shutdown);
-                return;
-            }
         }
     }
 }
@@ -175,14 +72,114 @@ fn file_server(mut chans: util::Channel, config: FileServerConfig, poller: mio::
 impl source::Source<FileServerConfig> for FileServer {
     /// Make a FileServer
     ///
-    fn new(chans: util::Channel, config: FileServerConfig) -> Self {
+    fn init(config: FileServerConfig) -> Self {
+        let pattern = config.path.expect("must specify a 'path' for FileServer");
         FileServer {
-            chans: chans,
-            config: config,
+            pattern: pattern,
+            max_lines_read: config.max_lines_read,
         }
     }
 
-    fn run(self) -> thread::ThreadHandle {
-        thread::spawn(move |poll| file_server(self.chans, self.config, poll))
+    fn run(self, mut chans: util::Channel, tags: &sync::Arc<metric::TagMap>, poller: mio::Poll) -> () {
+        let mut buffer = String::new();
+
+        let mut fp_map: util::HashMap<PathBuf, FileWatcher> = Default::default();
+        let mut fp_map_alt: util::HashMap<PathBuf, FileWatcher> = Default::default();
+
+        let mut backoff_cap: usize = 1;
+        let mut lines = Vec::new();
+        // Alright friends, how does this work?
+        //
+        // We want to avoid burning up users' CPUs. To do this we sleep after
+        // reading lines out of files. But! We want to be responsive as well. We
+        // keep track of a 'backoff_cap' to decide how long we'll wait in any
+        // given loop. This cap grows each time we fail to read lines in an
+        // exponential fashion to some hard-coded cap.
+        loop {
+            let mut global_lines_read: usize = 0;
+            // glob poll
+            for entry in glob(self.pattern.to_str().expect("no ability to glob"))
+                .expect("Failed to read glob pattern")
+            {
+                if let Ok(path) = entry {
+                    let entry = fp_map.entry(path.clone());
+                    if let Ok(fw) = FileWatcher::new(&path) {
+                        entry.or_insert(fw);
+                    };
+                }
+            }
+            // line polling
+            for (path, mut watcher) in fp_map.drain() {
+                let mut lines_read: usize = 0;
+                while let Ok(sz) = watcher.read_line(&mut buffer) {
+                    if sz > 0 {
+                        lines_read += 1;
+                        lines.push(
+                            metric::LogLine::new(
+                                path.to_str().expect("not a valid path"),
+                                &buffer,
+                            ).overlay_tags_from_map(tags),
+                        );
+                        buffer.clear();
+                    } else {
+                        break;
+                    }
+                    if lines_read > self.max_lines_read {
+                        break;
+                    }
+                }
+                report_full_telemetry(
+                    "cernan.sources.file.lines_read",
+                    lines_read as f64,
+                    Some(vec![
+                        ("file_path", path.to_str().expect("not a valid path")),
+                    ]),
+                );
+                // A FileWatcher is dead when the underlying file has
+                // disappeared. If the FileWatcher is dead we don't stick it in
+                // the fp_map_alt and deallocate it.
+                if !watcher.dead() {
+                    fp_map_alt.insert(path, watcher);
+                }
+                global_lines_read = global_lines_read.saturating_add(lines_read);
+            }
+            for l in lines.drain(..) {
+                send(&mut chans, metric::Event::new_log(l));
+            }
+            // We've drained the live FileWatchers into fp_map_alt in the line
+            // polling loop. Now we swapped them back to fp_map so next time we
+            // loop through we'll read from the live FileWatchers.
+            mem::swap(&mut fp_map, &mut fp_map_alt);
+            // When no lines have been read we kick the backup_cap up by twice,
+            // limited by the hard-coded cap. Else, we set the backup_cap to its
+            // minimum on the assumption that next time through there will be
+            // more lines to read promptly.
+            if global_lines_read == 0 {
+                let lim = backoff_cap.saturating_mul(2);
+                if lim > 2_048 {
+                    backoff_cap = 2_048;
+                } else {
+                    backoff_cap = lim;
+                }
+            } else {
+                backoff_cap = 1;
+            }
+            let backoff = backoff_cap.saturating_sub(global_lines_read);
+            let mut events = mio::Events::with_capacity(1024);
+            match poller.poll(
+                &mut events,
+                Some(time::Duration::from_millis(backoff as u64)),
+            ) {
+                Err(e) => panic!(format!("Failed during poll {:?}", e)),
+                Ok(0) => {}
+                Ok(_num_events) => {
+                    // File server doesn't poll for anything other than SYSTEM events.
+                    // As currently there are no system events other than SHUTDOWN,
+                    // we immediately exit.
+                    send(&mut chans, metric::Event::Shutdown);
+                    return;
+                }
+            }
+        }
     }
 }

--- a/src/source/flush.rs
+++ b/src/source/flush.rs
@@ -40,16 +40,10 @@ impl source::Source<FlushTimer, FlushTimerConfig> for FlushTimer {
     /// Create a new FlushTimer. This will not produce a new thread, that must
     /// be managed by the end-user.
     fn new(chans: util::Channel, _config: FlushTimerConfig) -> FlushTimer {
-        FlushTimer {
-            chans: chans,
-        }
+        FlushTimer { chans: chans }
     }
 
     fn run(self) -> thread::ThreadHandle {
-        thread::spawn(
-            move |poll| {
-                tick_tock(self.chans, poll)
-            }
-        )
+        thread::spawn(move |poll| tick_tock(self.chans, poll))
     }
 }

--- a/src/source/flush.rs
+++ b/src/source/flush.rs
@@ -1,49 +1,44 @@
 use metric;
 use mio;
 use source;
+use std::sync;
 use std::thread::sleep;
 use std::time::Duration;
-use thread;
 use util;
 use util::send;
 
 /// The source of all flush pulses.
-pub struct FlushTimer {
-    chans: util::Channel,
-}
+pub struct FlushTimer;
 
 /// Nil config for FlushTimer.
+#[derive(Clone, Debug, Deserialize)]
 pub struct FlushTimerConfig;
-
-fn tick_tock(mut chans: util::Channel, _poll: mio::Poll) {
-    let one_second = Duration::new(1, 0);
-    // idx will _always_ increase. If it's kept at u64 or greater it will
-    // overflow long past the collapse of our industrial civilization only
-    // so long as the intervals we sleep are kept to once a second or so.
-    //
-    // Heh, even past the length of the universe, really.
-    //
-    // Point being, there's a theoretical overflow problem here but it's not
-    // going to be hit in practice.
-    let mut idx: u64 = 0;
-    loop {
-        // We start with TimerFlush(1) as receivers start with
-        // TimerFlush(0). This will update their last_flush_idx seen at
-        // system boot.
-        idx += 1;
-        sleep(one_second);
-        send(&mut chans, metric::Event::TimerFlush(idx));
-    }
-}
 
 impl source::Source<FlushTimerConfig> for FlushTimer {
     /// Create a new FlushTimer. This will not produce a new thread, that must
     /// be managed by the end-user.
-    fn new(chans: util::Channel, _config: FlushTimerConfig) -> Self {
-        FlushTimer { chans: chans }
+    fn init(_config: FlushTimerConfig) -> Self {
+        FlushTimer { }
     }
 
-    fn run(self) -> thread::ThreadHandle {
-        thread::spawn(move |poll| tick_tock(self.chans, poll))
+    fn run(self, mut chans: util::Channel, _tags: &sync::Arc<metric::TagMap>, _poller: mio::Poll) -> () {
+        let one_second = Duration::new(1, 0);
+        // idx will _always_ increase. If it's kept at u64 or greater it will
+        // overflow long past the collapse of our industrial civilization only
+        // so long as the intervals we sleep are kept to once a second or so.
+        //
+        // Heh, even past the length of the universe, really.
+        //
+        // Point being, there's a theoretical overflow problem here but it's not
+        // going to be hit in practice.
+        let mut idx: u64 = 0;
+        loop {
+            // We start with TimerFlush(1) as receivers start with
+            // TimerFlush(0). This will update their last_flush_idx seen at
+            // system boot.
+            idx += 1;
+            sleep(one_second);
+            send(&mut chans, metric::Event::TimerFlush(idx));
+        }
     }
 }

--- a/src/source/flush.rs
+++ b/src/source/flush.rs
@@ -18,10 +18,15 @@ impl source::Source<FlushTimerConfig> for FlushTimer {
     /// Create a new FlushTimer. This will not produce a new thread, that must
     /// be managed by the end-user.
     fn init(_config: FlushTimerConfig) -> Self {
-        FlushTimer { }
+        FlushTimer {}
     }
 
-    fn run(self, mut chans: util::Channel, _tags: &sync::Arc<metric::TagMap>, _poller: mio::Poll) -> () {
+    fn run(
+        self,
+        mut chans: util::Channel,
+        _tags: &sync::Arc<metric::TagMap>,
+        _poller: mio::Poll,
+    ) -> () {
         let one_second = Duration::new(1, 0);
         // idx will _always_ increase. If it's kept at u64 or greater it will
         // overflow long past the collapse of our industrial civilization only

--- a/src/source/flush.rs
+++ b/src/source/flush.rs
@@ -36,10 +36,10 @@ fn tick_tock(mut chans: util::Channel, _poll: mio::Poll) {
     }
 }
 
-impl source::Source<FlushTimer, FlushTimerConfig> for FlushTimer {
+impl source::Source<FlushTimerConfig> for FlushTimer {
     /// Create a new FlushTimer. This will not produce a new thread, that must
     /// be managed by the end-user.
-    fn new(chans: util::Channel, _config: FlushTimerConfig) -> FlushTimer {
+    fn new(chans: util::Channel, _config: FlushTimerConfig) -> Self {
         FlushTimer { chans: chans }
     }
 

--- a/src/source/flush.rs
+++ b/src/source/flush.rs
@@ -1,43 +1,55 @@
 use metric;
 use mio;
-use source::Source;
+use source;
 use std::thread::sleep;
 use std::time::Duration;
+use thread;
 use util;
 use util::send;
 
-/// The source of all flush pulses. See `FlushTimer::run` for more details.
+/// The source of all flush pulses.
 pub struct FlushTimer {
     chans: util::Channel,
 }
 
-impl FlushTimer {
-    /// Create a new FlushTimer. This will not produce a new thread, that must
-    /// be managed by the end-user.
-    pub fn new(chans: util::Channel) -> FlushTimer {
-        FlushTimer { chans: chans }
+/// Nil config for FlushTimer.
+pub struct FlushTimerConfig;
+
+fn tick_tock(mut chans: util::Channel, _poll: mio::Poll) {
+    let one_second = Duration::new(1, 0);
+    // idx will _always_ increase. If it's kept at u64 or greater it will
+    // overflow long past the collapse of our industrial civilization only
+    // so long as the intervals we sleep are kept to once a second or so.
+    //
+    // Heh, even past the length of the universe, really.
+    //
+    // Point being, there's a theoretical overflow problem here but it's not
+    // going to be hit in practice.
+    let mut idx: u64 = 0;
+    loop {
+        // We start with TimerFlush(1) as receivers start with
+        // TimerFlush(0). This will update their last_flush_idx seen at
+        // system boot.
+        idx += 1;
+        sleep(one_second);
+        send(&mut chans, metric::Event::TimerFlush(idx));
     }
 }
 
-impl Source for FlushTimer {
-    fn run(&mut self, _poll: mio::Poll) {
-        let one_second = Duration::new(1, 0);
-        // idx will _always_ increase. If it's kept at u64 or greater it will
-        // overflow long past the collapse of our industrial civilization only
-        // so long as the intervals we sleep are kept to once a second or so.
-        //
-        // Heh, even past the length of the universe, really.
-        //
-        // Point being, there's a theoretical overflow problem here but it's not
-        // going to be hit in practice.
-        let mut idx: u64 = 0;
-        loop {
-            // We start with TimerFlush(1) as receivers start with
-            // TimerFlush(0). This will update their last_flush_idx seen at
-            // system boot.
-            idx += 1;
-            sleep(one_second);
-            send(&mut self.chans, metric::Event::TimerFlush(idx));
+impl source::Source<FlushTimer, FlushTimerConfig> for FlushTimer {
+    /// Create a new FlushTimer. This will not produce a new thread, that must
+    /// be managed by the end-user.
+    fn new(chans: util::Channel, _config: FlushTimerConfig) -> FlushTimer {
+        FlushTimer {
+            chans: chans,
         }
+    }
+
+    fn run(self) -> thread::ThreadHandle {
+        thread::spawn(
+            move |poll| {
+                tick_tock(self.chans, poll)
+            }
+        )
     }
 }

--- a/src/source/graphite.rs
+++ b/src/source/graphite.rs
@@ -117,9 +117,9 @@ fn handle_stream(
     }
 }
 
-impl source::Source<Graphite, GraphiteConfig> for Graphite {
+impl source::Source<GraphiteConfig> for Graphite {
     /// Create a new Graphite
-    fn new(chans: util::Channel, config: GraphiteConfig) -> Graphite {
+    fn new(chans: util::Channel, config: GraphiteConfig) -> Self {
         Graphite {
             server: source::TCP::new(chans, config.into()),
         }

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -5,10 +5,9 @@ use metric::{AggregationMethod, Telemetry};
 use mio;
 use sink;
 use source;
-use source::Source;
 use std;
-use std::sync;
 use std::sync::atomic::Ordering;
+use thread;
 use time;
 use util;
 
@@ -22,7 +21,7 @@ lazy_static! {
 /// telemetry and makes it easier for modules to report on themeselves.
 pub struct Internal {
     chans: util::Channel,
-    tags: sync::Arc<metric::TagMap>,
+    config: InternalConfig,
 }
 
 /// The configuration struct for 'Internal'
@@ -43,16 +42,6 @@ impl Default for InternalConfig {
             tags: metric::TagMap::default(),
             forwards: Vec::new(),
             config_path: Some("sources.internal".to_string()),
-        }
-    }
-}
-
-impl Internal {
-    /// Create a new Internal
-    pub fn new(chans: util::Channel, config: InternalConfig) -> Internal {
-        Internal {
-            chans: chans,
-            tags: sync::Arc::new(config.tags),
         }
     }
 }
@@ -99,335 +88,350 @@ macro_rules! atom_non_zero_telem {
     }
 }
 
+fn handle_internal_metrics(mut chans: util::Channel, config: InternalConfig, poll: mio::Poll) {
+    let slp = std::time::Duration::from_millis(1_000);
+    loop {
+        let mut events = mio::Events::with_capacity(1024);
+        match poll.poll(&mut events, Some(slp)) {
+            Err(_) => error!("Failed to poll for system events"),
+            // Internal source doesn't register any external evented sources.
+            // Any event must be a system event which, at the time of this writing,
+            // can only be a shutdown event.
+            Ok(num_events) if num_events > 0 => {
+                util::send(
+                    &mut chans,
+                    metric::Event::Shutdown);
+                return;
+            }
+            Ok(_) => {
+                if !chans.is_empty() {
+                    // source::graphite
+                    atom_non_zero_telem!(
+                        "cernan.graphite.new_peer",
+                        source::graphite::GRAPHITE_NEW_PEER,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.graphite.packet",
+                        source::graphite::GRAPHITE_GOOD_PACKET,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.graphite.telemetry.received",
+                        source::graphite::GRAPHITE_TELEM,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.graphite.bad_packet",
+                        source::graphite::GRAPHITE_BAD_PACKET,
+                        config.tags,
+                        chans
+                    );
+                    // source::statsd
+                    atom_non_zero_telem!(
+                        "cernan.statsd.packet",
+                        source::statsd::STATSD_GOOD_PACKET,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.statsd.bad_packet",
+                        source::statsd::STATSD_BAD_PACKET,
+                        config.tags,
+                        chans
+                    );
+                    // sink::elasticsearch
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.records.delivery",
+                        sink::elasticsearch::ELASTIC_RECORDS_DELIVERY,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.internal.buffer_len",
+                        sink::elasticsearch::ELASTIC_INTERNAL_BUFFER_LEN,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.records.total_delivered",
+                        sink::elasticsearch::ELASTIC_RECORDS_TOTAL_DELIVERED,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.records.total_failed",
+                        sink::elasticsearch::ELASTIC_RECORDS_TOTAL_FAILED,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.error.unknown",
+                        sink::elasticsearch::ELASTIC_ERROR_UNKNOWN,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.error.bulk_action.index",
+                        sink::elasticsearch::ELASTIC_BULK_ACTION_INDEX_ERR,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.error.bulk_action.create",
+                        sink::elasticsearch::ELASTIC_BULK_ACTION_CREATE_ERR,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.error.bulk_action.update",
+                        sink::elasticsearch::ELASTIC_BULK_ACTION_UPDATE_ERR,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.error.bulk_action.delete",
+                        sink::elasticsearch::ELASTIC_BULK_ACTION_DELETE_ERR,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.error.api.index_not_found",
+                        sink::elasticsearch::ELASTIC_ERROR_API_INDEX_NOT_FOUND,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.error.api.parsing",
+                        sink::elasticsearch::ELASTIC_ERROR_API_PARSING,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.error.api.mapper_parsing",
+                        sink::elasticsearch::ELASTIC_ERROR_API_MAPPER_PARSING,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                       "cernan.sinks.elasticsearch.error.api.action_request_validation",
+                       sink::elasticsearch::ELASTIC_ERROR_API_ACTION_REQUEST_VALIDATION,
+                       config.tags,
+                       chans
+                   );
+                    atom_non_zero_telem!(
+                       "cernan.sinks.elasticsearch.error.api.action_document_missing",
+                       sink::elasticsearch::ELASTIC_ERROR_API_DOCUMENT_MISSING,
+                       config.tags,
+                       chans
+                   );
+                    atom_non_zero_telem!(
+                       "cernan.sinks.elasticsearch.error.api.index_already_exists",
+                       sink::elasticsearch::ELASTIC_ERROR_API_INDEX_ALREADY_EXISTS,
+                       config.tags,
+                       chans
+                   );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.error.api.unknown",
+                        sink::elasticsearch::ELASTIC_ERROR_API_UNKNOWN,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.elasticsearch.error.client",
+                        sink::elasticsearch::ELASTIC_ERROR_CLIENT,
+                        config.tags,
+                        chans
+                    );
+                    // sink::wavefront
+                    atom_non_zero_telem!(
+                        "cernan.sinks.wavefront.aggregation.histogram",
+                        sink::wavefront::WAVEFRONT_AGGR_HISTO,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.wavefront.aggregation.sum",
+                        sink::wavefront::WAVEFRONT_AGGR_SUM,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.wavefront.aggregation.set",
+                        sink::wavefront::WAVEFRONT_AGGR_SET,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.wavefront.aggregation.summarize",
+                        sink::wavefront::WAVEFRONT_AGGR_SUMMARIZE,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.wavefront.aggregation.summarize.total_percentiles",
+                        sink::wavefront::WAVEFRONT_AGGR_TOT_PERCENT,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.wavefront.delivery_attempts",
+                        sink::wavefront::WAVEFRONT_DELIVERY_ATTEMPTS,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.wavefront.value.closed",
+                        sink::wavefront::WAVEFRONT_VALVE_CLOSED,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.wavefront.valve.open",
+                        sink::wavefront::WAVEFRONT_VALVE_OPEN,
+                        config.tags,
+                        chans
+                    );
+                    // sink::prometheus
+                    atom_non_zero_telem!(
+                        "cernan.sinks.prometheus.aggregation.inside_baseball.windowed.total",
+                        sink::prometheus::PROMETHEUS_AGGR_WINDOWED_LEN,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.prometheus.exposition.inside_baseball.delay.sum",
+                        sink::prometheus::PROMETHEUS_RESPONSE_DELAY_SUM,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.prometheus.aggregation.inside_baseball.perpetual.total",
+                        sink::prometheus::PROMETHEUS_AGGR_PERPETUAL_LEN,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.prometheus.aggregation.reportable",
+                        sink::prometheus::PROMETHEUS_AGGR_REPORTABLE,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.prometheus.aggregation.remaining",
+                        sink::prometheus::PROMETHEUS_AGGR_REMAINING,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.prometheus.report.success",
+                        sink::prometheus::PROMETHEUS_REPORT_SUCCESS,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.prometheus.report.error",
+                        sink::prometheus::PROMETHEUS_REPORT_ERROR,
+                        config.tags,
+                        chans
+                    );
+                    // sink::influxdb
+                    atom_non_zero_telem!(
+                        "cernan.sinks.influxdb.delivery_attempts",
+                        sink::influxdb::INFLUX_DELIVERY_ATTEMPTS,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.influxdb.success",
+                        sink::influxdb::INFLUX_SUCCESS,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.influxdb.failure.client_error",
+                        sink::influxdb::INFLUX_FAILURE_CLIENT,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.sinks.influxdb.failure.server_error",
+                        sink::influxdb::INFLUX_FAILURE_SERVER,
+                        config.tags,
+                        chans
+                    );
+                    // filter::delay_filter
+                    atom_non_zero_telem!(
+                        "cernan.filters.delay.telemetry.accept",
+                        filter::delay_filter::DELAY_TELEM_ACCEPT,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.filters.delay.telemetry.reject",
+                        filter::delay_filter::DELAY_TELEM_REJECT,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.filters.delay.log.reject",
+                        filter::delay_filter::DELAY_LOG_REJECT,
+                        config.tags,
+                        chans
+                    );
+                    atom_non_zero_telem!(
+                        "cernan.filters.delay.log.accept",
+                        filter::delay_filter::DELAY_LOG_ACCEPT,
+                        config.tags,
+                        chans
+                    );
+                    while let Some(mut telem) = Q.pop() {
+                        if !chans.is_empty() {
+                            telem = telem.overlay_tags_from_map(&config.tags);
+                            util::send(
+                                &mut chans,
+                                metric::Event::new_telemetry(telem),
+                            );
+                        } else {
+                            // do nothing, intentionally
+                        }
+                    }
+                } else {
+                    // There are no chans available. In this case we want to drain
+                    // and deallocate any internal telemetry that may have made it
+                    // to Q.
+                    while let Some(_) = Q.pop() {
+                        // do nothing, intentionally
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Internal as Source
 ///
 /// The 'run' of Internal will pull Telemetry off the internal queue, apply
 /// Internal's configured tags and push said telemetry into operator configured
 /// channels. If no channels are configured we toss the Telemetry onto the
 /// floor.
-impl Source for Internal {
-    #[allow(cyclomatic_complexity)]
-    fn run(&mut self, poll: mio::Poll) {
-        let slp = std::time::Duration::from_millis(1_000);
-        loop {
-            let mut events = mio::Events::with_capacity(1024);
-            match poll.poll(&mut events, Some(slp)) {
-                Err(_) => error!("Failed to poll for system events"),
-                // Internal source doesn't register any external evented sources.
-                // Any event must be a system event which, at the time of this writing,
-                // can only be a shutdown event.
-                Ok(num_events) if num_events > 0 => {
-                    util::send(
-                        &mut self.chans,
-                        metric::Event::Shutdown);
-                    return;
-                }
-                Ok(_) => {
-                    if !self.chans.is_empty() {
-                        // source::graphite
-                        atom_non_zero_telem!(
-                            "cernan.graphite.new_peer",
-                            source::graphite::GRAPHITE_NEW_PEER,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.graphite.packet",
-                            source::graphite::GRAPHITE_GOOD_PACKET,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.graphite.telemetry.received",
-                            source::graphite::GRAPHITE_TELEM,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.graphite.bad_packet",
-                            source::graphite::GRAPHITE_BAD_PACKET,
-                            self.tags,
-                            self.chans
-                        );
-                        // source::statsd
-                        atom_non_zero_telem!(
-                            "cernan.statsd.packet",
-                            source::statsd::STATSD_GOOD_PACKET,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.statsd.bad_packet",
-                            source::statsd::STATSD_BAD_PACKET,
-                            self.tags,
-                            self.chans
-                        );
-                        // sink::elasticsearch
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.records.delivery",
-                            sink::elasticsearch::ELASTIC_RECORDS_DELIVERY,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.internal.buffer_len",
-                            sink::elasticsearch::ELASTIC_INTERNAL_BUFFER_LEN,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.records.total_delivered",
-                            sink::elasticsearch::ELASTIC_RECORDS_TOTAL_DELIVERED,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.records.total_failed",
-                            sink::elasticsearch::ELASTIC_RECORDS_TOTAL_FAILED,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.error.unknown",
-                            sink::elasticsearch::ELASTIC_ERROR_UNKNOWN,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.error.bulk_action.index",
-                            sink::elasticsearch::ELASTIC_BULK_ACTION_INDEX_ERR,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.error.bulk_action.create",
-                            sink::elasticsearch::ELASTIC_BULK_ACTION_CREATE_ERR,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.error.bulk_action.update",
-                            sink::elasticsearch::ELASTIC_BULK_ACTION_UPDATE_ERR,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.error.bulk_action.delete",
-                            sink::elasticsearch::ELASTIC_BULK_ACTION_DELETE_ERR,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.error.api.index_not_found",
-                            sink::elasticsearch::ELASTIC_ERROR_API_INDEX_NOT_FOUND,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.error.api.parsing",
-                            sink::elasticsearch::ELASTIC_ERROR_API_PARSING,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.error.api.mapper_parsing",
-                            sink::elasticsearch::ELASTIC_ERROR_API_MAPPER_PARSING,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                           "cernan.sinks.elasticsearch.error.api.action_request_validation",
-                           sink::elasticsearch::ELASTIC_ERROR_API_ACTION_REQUEST_VALIDATION,
-                           self.tags,
-                           self.chans
-                       );
-                        atom_non_zero_telem!(
-                           "cernan.sinks.elasticsearch.error.api.action_document_missing",
-                           sink::elasticsearch::ELASTIC_ERROR_API_DOCUMENT_MISSING,
-                           self.tags,
-                           self.chans
-                       );
-                        atom_non_zero_telem!(
-                           "cernan.sinks.elasticsearch.error.api.index_already_exists",
-                           sink::elasticsearch::ELASTIC_ERROR_API_INDEX_ALREADY_EXISTS,
-                           self.tags,
-                           self.chans
-                       );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.error.api.unknown",
-                            sink::elasticsearch::ELASTIC_ERROR_API_UNKNOWN,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.elasticsearch.error.client",
-                            sink::elasticsearch::ELASTIC_ERROR_CLIENT,
-                            self.tags,
-                            self.chans
-                        );
-                        // sink::wavefront
-                        atom_non_zero_telem!(
-                            "cernan.sinks.wavefront.aggregation.histogram",
-                            sink::wavefront::WAVEFRONT_AGGR_HISTO,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.wavefront.aggregation.sum",
-                            sink::wavefront::WAVEFRONT_AGGR_SUM,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.wavefront.aggregation.set",
-                            sink::wavefront::WAVEFRONT_AGGR_SET,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.wavefront.aggregation.summarize",
-                            sink::wavefront::WAVEFRONT_AGGR_SUMMARIZE,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.wavefront.aggregation.summarize.total_percentiles",
-                            sink::wavefront::WAVEFRONT_AGGR_TOT_PERCENT,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.wavefront.delivery_attempts",
-                            sink::wavefront::WAVEFRONT_DELIVERY_ATTEMPTS,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.wavefront.value.closed",
-                            sink::wavefront::WAVEFRONT_VALVE_CLOSED,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.wavefront.valve.open",
-                            sink::wavefront::WAVEFRONT_VALVE_OPEN,
-                            self.tags,
-                            self.chans
-                        );
-                        // sink::prometheus
-                        atom_non_zero_telem!(
-                            "cernan.sinks.prometheus.aggregation.inside_baseball.windowed.total",
-                            sink::prometheus::PROMETHEUS_AGGR_WINDOWED_LEN,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.prometheus.exposition.inside_baseball.delay.sum",
-                            sink::prometheus::PROMETHEUS_RESPONSE_DELAY_SUM,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.prometheus.aggregation.inside_baseball.perpetual.total",
-                            sink::prometheus::PROMETHEUS_AGGR_PERPETUAL_LEN,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.prometheus.aggregation.reportable",
-                            sink::prometheus::PROMETHEUS_AGGR_REPORTABLE,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.prometheus.aggregation.remaining",
-                            sink::prometheus::PROMETHEUS_AGGR_REMAINING,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.prometheus.report.success",
-                            sink::prometheus::PROMETHEUS_REPORT_SUCCESS,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.prometheus.report.error",
-                            sink::prometheus::PROMETHEUS_REPORT_ERROR,
-                            self.tags,
-                            self.chans
-                        );
-                        // sink::influxdb
-                        atom_non_zero_telem!(
-                            "cernan.sinks.influxdb.delivery_attempts",
-                            sink::influxdb::INFLUX_DELIVERY_ATTEMPTS,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.influxdb.success",
-                            sink::influxdb::INFLUX_SUCCESS,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.influxdb.failure.client_error",
-                            sink::influxdb::INFLUX_FAILURE_CLIENT,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.sinks.influxdb.failure.server_error",
-                            sink::influxdb::INFLUX_FAILURE_SERVER,
-                            self.tags,
-                            self.chans
-                        );
-                        // filter::delay_filter
-                        atom_non_zero_telem!(
-                            "cernan.filters.delay.telemetry.accept",
-                            filter::delay_filter::DELAY_TELEM_ACCEPT,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.filters.delay.telemetry.reject",
-                            filter::delay_filter::DELAY_TELEM_REJECT,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.filters.delay.log.reject",
-                            filter::delay_filter::DELAY_LOG_REJECT,
-                            self.tags,
-                            self.chans
-                        );
-                        atom_non_zero_telem!(
-                            "cernan.filters.delay.log.accept",
-                            filter::delay_filter::DELAY_LOG_ACCEPT,
-                            self.tags,
-                            self.chans
-                        );
-                        while let Some(mut telem) = Q.pop() {
-                            if !self.chans.is_empty() {
-                                telem = telem.overlay_tags_from_map(&self.tags);
-                                util::send(
-                                    &mut self.chans,
-                                    metric::Event::new_telemetry(telem),
-                                );
-                            } else {
-                                // do nothing, intentionally
-                            }
-                        }
-                    } else {
-                        // There are no chans available. In this case we want to drain
-                        // and deallocate any internal telemetry that may have made it
-                        // to Q.
-                        while let Some(_) = Q.pop() {
-                            // do nothing, intentionally
-                        }
-                    }
-                }
-            }
+impl source::Source<Internal, InternalConfig> for Internal {
+    /// Create a new Internal
+    fn new(chans: util::Channel, config: InternalConfig) -> Internal {
+        Internal {
+            chans: chans,
+            config: config,
         }
+    }
+
+    fn run(self) -> thread::ThreadHandle {
+        thread::spawn(
+            move |poll| {
+                handle_internal_metrics(self.chans, self.config, poll)
+            }
+        )
     }
 }

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -6,8 +6,8 @@ use mio;
 use sink;
 use source;
 use std;
+use std::sync;
 use std::sync::atomic::Ordering;
-use thread;
 use time;
 use util;
 
@@ -19,10 +19,7 @@ lazy_static! {
 /// self-telemeter. This is an improvement over past methods as an explicit
 /// Source gives operators the ability to define a filter topology for such
 /// telemetry and makes it easier for modules to report on themeselves.
-pub struct Internal {
-    chans: util::Channel,
-    config: InternalConfig,
-}
+pub struct Internal ;
 
 /// The configuration struct for 'Internal'
 #[derive(Debug, Deserialize, Clone)]
@@ -88,332 +85,6 @@ macro_rules! atom_non_zero_telem {
     }
 }
 
-fn handle_internal_metrics(
-    mut chans: util::Channel,
-    config: InternalConfig,
-    poll: mio::Poll,
-) {
-    let slp = std::time::Duration::from_millis(1_000);
-    loop {
-        let mut events = mio::Events::with_capacity(1024);
-        match poll.poll(&mut events, Some(slp)) {
-            Err(_) => error!("Failed to poll for system events"),
-            // Internal source doesn't register any external evented sources.
-            // Any event must be a system event which, at the time of this writing,
-            // can only be a shutdown event.
-            Ok(num_events) if num_events > 0 => {
-                util::send(&mut chans, metric::Event::Shutdown);
-                return;
-            }
-            Ok(_) => {
-                if !chans.is_empty() {
-                    // source::graphite
-                    atom_non_zero_telem!(
-                        "cernan.graphite.new_peer",
-                        source::graphite::GRAPHITE_NEW_PEER,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.graphite.packet",
-                        source::graphite::GRAPHITE_GOOD_PACKET,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.graphite.telemetry.received",
-                        source::graphite::GRAPHITE_TELEM,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.graphite.bad_packet",
-                        source::graphite::GRAPHITE_BAD_PACKET,
-                        config.tags,
-                        chans
-                    );
-                    // source::statsd
-                    atom_non_zero_telem!(
-                        "cernan.statsd.packet",
-                        source::statsd::STATSD_GOOD_PACKET,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.statsd.bad_packet",
-                        source::statsd::STATSD_BAD_PACKET,
-                        config.tags,
-                        chans
-                    );
-                    // sink::elasticsearch
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.records.delivery",
-                        sink::elasticsearch::ELASTIC_RECORDS_DELIVERY,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.internal.buffer_len",
-                        sink::elasticsearch::ELASTIC_INTERNAL_BUFFER_LEN,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.records.total_delivered",
-                        sink::elasticsearch::ELASTIC_RECORDS_TOTAL_DELIVERED,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.records.total_failed",
-                        sink::elasticsearch::ELASTIC_RECORDS_TOTAL_FAILED,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.error.unknown",
-                        sink::elasticsearch::ELASTIC_ERROR_UNKNOWN,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.error.bulk_action.index",
-                        sink::elasticsearch::ELASTIC_BULK_ACTION_INDEX_ERR,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.error.bulk_action.create",
-                        sink::elasticsearch::ELASTIC_BULK_ACTION_CREATE_ERR,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.error.bulk_action.update",
-                        sink::elasticsearch::ELASTIC_BULK_ACTION_UPDATE_ERR,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.error.bulk_action.delete",
-                        sink::elasticsearch::ELASTIC_BULK_ACTION_DELETE_ERR,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.error.api.index_not_found",
-                        sink::elasticsearch::ELASTIC_ERROR_API_INDEX_NOT_FOUND,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.error.api.parsing",
-                        sink::elasticsearch::ELASTIC_ERROR_API_PARSING,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.error.api.mapper_parsing",
-                        sink::elasticsearch::ELASTIC_ERROR_API_MAPPER_PARSING,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                       "cernan.sinks.elasticsearch.error.api.action_request_validation",
-                       sink::elasticsearch::ELASTIC_ERROR_API_ACTION_REQUEST_VALIDATION,
-                       config.tags,
-                       chans
-                   );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.error.api.action_document_missing",
-                        sink::elasticsearch::ELASTIC_ERROR_API_DOCUMENT_MISSING,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.error.api.index_already_exists",
-                        sink::elasticsearch::ELASTIC_ERROR_API_INDEX_ALREADY_EXISTS,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.error.api.unknown",
-                        sink::elasticsearch::ELASTIC_ERROR_API_UNKNOWN,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.elasticsearch.error.client",
-                        sink::elasticsearch::ELASTIC_ERROR_CLIENT,
-                        config.tags,
-                        chans
-                    );
-                    // sink::wavefront
-                    atom_non_zero_telem!(
-                        "cernan.sinks.wavefront.aggregation.histogram",
-                        sink::wavefront::WAVEFRONT_AGGR_HISTO,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.wavefront.aggregation.sum",
-                        sink::wavefront::WAVEFRONT_AGGR_SUM,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.wavefront.aggregation.set",
-                        sink::wavefront::WAVEFRONT_AGGR_SET,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.wavefront.aggregation.summarize",
-                        sink::wavefront::WAVEFRONT_AGGR_SUMMARIZE,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.wavefront.aggregation.summarize.total_percentiles",
-                        sink::wavefront::WAVEFRONT_AGGR_TOT_PERCENT,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.wavefront.delivery_attempts",
-                        sink::wavefront::WAVEFRONT_DELIVERY_ATTEMPTS,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.wavefront.value.closed",
-                        sink::wavefront::WAVEFRONT_VALVE_CLOSED,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.wavefront.valve.open",
-                        sink::wavefront::WAVEFRONT_VALVE_OPEN,
-                        config.tags,
-                        chans
-                    );
-                    // sink::prometheus
-                    atom_non_zero_telem!(
-                        "cernan.sinks.prometheus.aggregation.inside_baseball.windowed.total",
-                        sink::prometheus::PROMETHEUS_AGGR_WINDOWED_LEN,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.prometheus.exposition.inside_baseball.delay.sum",
-                        sink::prometheus::PROMETHEUS_RESPONSE_DELAY_SUM,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.prometheus.aggregation.inside_baseball.perpetual.total",
-                        sink::prometheus::PROMETHEUS_AGGR_PERPETUAL_LEN,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.prometheus.aggregation.reportable",
-                        sink::prometheus::PROMETHEUS_AGGR_REPORTABLE,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.prometheus.aggregation.remaining",
-                        sink::prometheus::PROMETHEUS_AGGR_REMAINING,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.prometheus.report.success",
-                        sink::prometheus::PROMETHEUS_REPORT_SUCCESS,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.prometheus.report.error",
-                        sink::prometheus::PROMETHEUS_REPORT_ERROR,
-                        config.tags,
-                        chans
-                    );
-                    // sink::influxdb
-                    atom_non_zero_telem!(
-                        "cernan.sinks.influxdb.delivery_attempts",
-                        sink::influxdb::INFLUX_DELIVERY_ATTEMPTS,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.influxdb.success",
-                        sink::influxdb::INFLUX_SUCCESS,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.influxdb.failure.client_error",
-                        sink::influxdb::INFLUX_FAILURE_CLIENT,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.sinks.influxdb.failure.server_error",
-                        sink::influxdb::INFLUX_FAILURE_SERVER,
-                        config.tags,
-                        chans
-                    );
-                    // filter::delay_filter
-                    atom_non_zero_telem!(
-                        "cernan.filters.delay.telemetry.accept",
-                        filter::delay_filter::DELAY_TELEM_ACCEPT,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.filters.delay.telemetry.reject",
-                        filter::delay_filter::DELAY_TELEM_REJECT,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.filters.delay.log.reject",
-                        filter::delay_filter::DELAY_LOG_REJECT,
-                        config.tags,
-                        chans
-                    );
-                    atom_non_zero_telem!(
-                        "cernan.filters.delay.log.accept",
-                        filter::delay_filter::DELAY_LOG_ACCEPT,
-                        config.tags,
-                        chans
-                    );
-                    while let Some(mut telem) = Q.pop() {
-                        if !chans.is_empty() {
-                            telem = telem.overlay_tags_from_map(&config.tags);
-                            util::send(
-                                &mut chans,
-                                metric::Event::new_telemetry(telem),
-                            );
-                        } else {
-                            // do nothing, intentionally
-                        }
-                    }
-                } else {
-                    // There are no chans available. In this case we want to drain
-                    // and deallocate any internal telemetry that may have made it
-                    // to Q.
-                    while let Some(_) = Q.pop() {
-                        // do nothing, intentionally
-                    }
-                }
-            }
-        }
-    }
-}
-
 /// Internal as Source
 ///
 /// The 'run' of Internal will pull Telemetry off the internal queue, apply
@@ -422,16 +93,330 @@ fn handle_internal_metrics(
 /// floor.
 impl source::Source<InternalConfig> for Internal {
     /// Create a new Internal
-    fn new(chans: util::Channel, config: InternalConfig) -> Self {
-        Internal {
-            chans: chans,
-            config: config,
-        }
+    fn init(_config: InternalConfig) -> Self {
+        Internal {}
     }
 
-    fn run(self) -> thread::ThreadHandle {
-        thread::spawn(move |poll| {
-            handle_internal_metrics(self.chans, self.config, poll)
-        })
+    fn run(self, mut chans: util::Channel, tags: &sync::Arc<metric::TagMap>, poller: mio::Poll) -> ()
+    {
+        let slp = std::time::Duration::from_millis(1_000);
+        loop {
+            let mut events = mio::Events::with_capacity(1024);
+            match poller.poll(&mut events, Some(slp)) {
+                Err(_) => error!("Failed to poll for system events"),
+                // Internal source doesn't register any external evented sources.
+                // Any event must be a system event which, at the time of this writing,
+                // can only be a shutdown event.
+                Ok(num_events) if num_events > 0 => {
+                    util::send(&mut chans, metric::Event::Shutdown);
+                    return;
+                }
+                Ok(_) => {
+                    if !chans.is_empty() {
+                        // source::graphite
+                        atom_non_zero_telem!(
+                            "cernan.graphite.new_peer",
+                            source::graphite::GRAPHITE_NEW_PEER,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.graphite.packet",
+                            source::graphite::GRAPHITE_GOOD_PACKET,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.graphite.telemetry.received",
+                            source::graphite::GRAPHITE_TELEM,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.graphite.bad_packet",
+                            source::graphite::GRAPHITE_BAD_PACKET,
+                            tags,
+                            chans
+                        );
+                        // source::statsd
+                        atom_non_zero_telem!(
+                            "cernan.statsd.packet",
+                            source::statsd::STATSD_GOOD_PACKET,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.statsd.bad_packet",
+                            source::statsd::STATSD_BAD_PACKET,
+                            tags,
+                            chans
+                        );
+                        // sink::elasticsearch
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.records.delivery",
+                            sink::elasticsearch::ELASTIC_RECORDS_DELIVERY,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.internal.buffer_len",
+                            sink::elasticsearch::ELASTIC_INTERNAL_BUFFER_LEN,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.records.total_delivered",
+                            sink::elasticsearch::ELASTIC_RECORDS_TOTAL_DELIVERED,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.records.total_failed",
+                            sink::elasticsearch::ELASTIC_RECORDS_TOTAL_FAILED,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.error.unknown",
+                            sink::elasticsearch::ELASTIC_ERROR_UNKNOWN,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.error.bulk_action.index",
+                            sink::elasticsearch::ELASTIC_BULK_ACTION_INDEX_ERR,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.error.bulk_action.create",
+                            sink::elasticsearch::ELASTIC_BULK_ACTION_CREATE_ERR,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.error.bulk_action.update",
+                            sink::elasticsearch::ELASTIC_BULK_ACTION_UPDATE_ERR,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.error.bulk_action.delete",
+                            sink::elasticsearch::ELASTIC_BULK_ACTION_DELETE_ERR,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.error.api.index_not_found",
+                            sink::elasticsearch::ELASTIC_ERROR_API_INDEX_NOT_FOUND,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.error.api.parsing",
+                            sink::elasticsearch::ELASTIC_ERROR_API_PARSING,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.error.api.mapper_parsing",
+                            sink::elasticsearch::ELASTIC_ERROR_API_MAPPER_PARSING,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                           "cernan.sinks.elasticsearch.error.api.action_request_validation",
+                           sink::elasticsearch::ELASTIC_ERROR_API_ACTION_REQUEST_VALIDATION,
+                           tags,
+                           chans
+                       );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.error.api.action_document_missing",
+                            sink::elasticsearch::ELASTIC_ERROR_API_DOCUMENT_MISSING,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.error.api.index_already_exists",
+                            sink::elasticsearch::ELASTIC_ERROR_API_INDEX_ALREADY_EXISTS,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.error.api.unknown",
+                            sink::elasticsearch::ELASTIC_ERROR_API_UNKNOWN,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.elasticsearch.error.client",
+                            sink::elasticsearch::ELASTIC_ERROR_CLIENT,
+                            tags,
+                            chans
+                        );
+                        // sink::wavefront
+                        atom_non_zero_telem!(
+                            "cernan.sinks.wavefront.aggregation.histogram",
+                            sink::wavefront::WAVEFRONT_AGGR_HISTO,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.wavefront.aggregation.sum",
+                            sink::wavefront::WAVEFRONT_AGGR_SUM,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.wavefront.aggregation.set",
+                            sink::wavefront::WAVEFRONT_AGGR_SET,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.wavefront.aggregation.summarize",
+                            sink::wavefront::WAVEFRONT_AGGR_SUMMARIZE,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.wavefront.aggregation.summarize.total_percentiles",
+                            sink::wavefront::WAVEFRONT_AGGR_TOT_PERCENT,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.wavefront.delivery_attempts",
+                            sink::wavefront::WAVEFRONT_DELIVERY_ATTEMPTS,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.wavefront.value.closed",
+                            sink::wavefront::WAVEFRONT_VALVE_CLOSED,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.wavefront.valve.open",
+                            sink::wavefront::WAVEFRONT_VALVE_OPEN,
+                            tags,
+                            chans
+                        );
+                        // sink::prometheus
+                        atom_non_zero_telem!(
+                            "cernan.sinks.prometheus.aggregation.inside_baseball.windowed.total",
+                            sink::prometheus::PROMETHEUS_AGGR_WINDOWED_LEN,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.prometheus.exposition.inside_baseball.delay.sum",
+                            sink::prometheus::PROMETHEUS_RESPONSE_DELAY_SUM,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.prometheus.aggregation.inside_baseball.perpetual.total",
+                            sink::prometheus::PROMETHEUS_AGGR_PERPETUAL_LEN,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.prometheus.aggregation.reportable",
+                            sink::prometheus::PROMETHEUS_AGGR_REPORTABLE,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.prometheus.aggregation.remaining",
+                            sink::prometheus::PROMETHEUS_AGGR_REMAINING,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.prometheus.report.success",
+                            sink::prometheus::PROMETHEUS_REPORT_SUCCESS,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.prometheus.report.error",
+                            sink::prometheus::PROMETHEUS_REPORT_ERROR,
+                            tags,
+                            chans
+                        );
+                        // sink::influxdb
+                        atom_non_zero_telem!(
+                            "cernan.sinks.influxdb.delivery_attempts",
+                            sink::influxdb::INFLUX_DELIVERY_ATTEMPTS,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.influxdb.success",
+                            sink::influxdb::INFLUX_SUCCESS,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.influxdb.failure.client_error",
+                            sink::influxdb::INFLUX_FAILURE_CLIENT,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.influxdb.failure.server_error",
+                            sink::influxdb::INFLUX_FAILURE_SERVER,
+                            tags,
+                            chans
+                        );
+                        // filter::delay_filter
+                        atom_non_zero_telem!(
+                            "cernan.filters.delay.telemetry.accept",
+                            filter::delay_filter::DELAY_TELEM_ACCEPT,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.filters.delay.telemetry.reject",
+                            filter::delay_filter::DELAY_TELEM_REJECT,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.filters.delay.log.reject",
+                            filter::delay_filter::DELAY_LOG_REJECT,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.filters.delay.log.accept",
+                            filter::delay_filter::DELAY_LOG_ACCEPT,
+                            tags,
+                            chans
+                        );
+                        while let Some(mut telem) = Q.pop() {
+                            if !chans.is_empty() {
+                                telem = telem.overlay_tags_from_map(&tags);
+                                util::send(
+                                    &mut chans,
+                                    metric::Event::new_telemetry(telem),
+                                );
+                            } else {
+                                // do nothing, intentionally
+                            }
+                        }
+                    } else {
+                        // There are no chans available. In this case we want to drain
+                        // and deallocate any internal telemetry that may have made it
+                        // to Q.
+                        while let Some(_) = Q.pop() {
+                            // do nothing, intentionally
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -19,7 +19,7 @@ lazy_static! {
 /// self-telemeter. This is an improvement over past methods as an explicit
 /// Source gives operators the ability to define a filter topology for such
 /// telemetry and makes it easier for modules to report on themeselves.
-pub struct Internal ;
+pub struct Internal;
 
 /// The configuration struct for 'Internal'
 #[derive(Debug, Deserialize, Clone)]
@@ -97,8 +97,12 @@ impl source::Source<InternalConfig> for Internal {
         Internal {}
     }
 
-    fn run(self, mut chans: util::Channel, tags: &sync::Arc<metric::TagMap>, poller: mio::Poll) -> ()
-    {
+    fn run(
+        self,
+        mut chans: util::Channel,
+        tags: &sync::Arc<metric::TagMap>,
+        poller: mio::Poll,
+    ) -> () {
         let slp = std::time::Duration::from_millis(1_000);
         loop {
             let mut events = mio::Events::with_capacity(1024);

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -420,9 +420,9 @@ fn handle_internal_metrics(
 /// Internal's configured tags and push said telemetry into operator configured
 /// channels. If no channels are configured we toss the Telemetry onto the
 /// floor.
-impl source::Source<Internal, InternalConfig> for Internal {
+impl source::Source<InternalConfig> for Internal {
     /// Create a new Internal
-    fn new(chans: util::Channel, config: InternalConfig) -> Internal {
+    fn new(chans: util::Channel, config: InternalConfig) -> Self {
         Internal {
             chans: chans,
             config: config,

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -88,7 +88,11 @@ macro_rules! atom_non_zero_telem {
     }
 }
 
-fn handle_internal_metrics(mut chans: util::Channel, config: InternalConfig, poll: mio::Poll) {
+fn handle_internal_metrics(
+    mut chans: util::Channel,
+    config: InternalConfig,
+    poll: mio::Poll,
+) {
     let slp = std::time::Duration::from_millis(1_000);
     loop {
         let mut events = mio::Events::with_capacity(1024);
@@ -98,9 +102,7 @@ fn handle_internal_metrics(mut chans: util::Channel, config: InternalConfig, pol
             // Any event must be a system event which, at the time of this writing,
             // can only be a shutdown event.
             Ok(num_events) if num_events > 0 => {
-                util::send(
-                    &mut chans,
-                    metric::Event::Shutdown);
+                util::send(&mut chans, metric::Event::Shutdown);
                 return;
             }
             Ok(_) => {
@@ -223,17 +225,17 @@ fn handle_internal_metrics(mut chans: util::Channel, config: InternalConfig, pol
                        chans
                    );
                     atom_non_zero_telem!(
-                       "cernan.sinks.elasticsearch.error.api.action_document_missing",
-                       sink::elasticsearch::ELASTIC_ERROR_API_DOCUMENT_MISSING,
-                       config.tags,
-                       chans
-                   );
+                        "cernan.sinks.elasticsearch.error.api.action_document_missing",
+                        sink::elasticsearch::ELASTIC_ERROR_API_DOCUMENT_MISSING,
+                        config.tags,
+                        chans
+                    );
                     atom_non_zero_telem!(
-                       "cernan.sinks.elasticsearch.error.api.index_already_exists",
-                       sink::elasticsearch::ELASTIC_ERROR_API_INDEX_ALREADY_EXISTS,
-                       config.tags,
-                       chans
-                   );
+                        "cernan.sinks.elasticsearch.error.api.index_already_exists",
+                        sink::elasticsearch::ELASTIC_ERROR_API_INDEX_ALREADY_EXISTS,
+                        config.tags,
+                        chans
+                    );
                     atom_non_zero_telem!(
                         "cernan.sinks.elasticsearch.error.api.unknown",
                         sink::elasticsearch::ELASTIC_ERROR_API_UNKNOWN,
@@ -428,10 +430,8 @@ impl source::Source<Internal, InternalConfig> for Internal {
     }
 
     fn run(self) -> thread::ThreadHandle {
-        thread::spawn(
-            move |poll| {
-                handle_internal_metrics(self.chans, self.config, poll)
-            }
-        )
+        thread::spawn(move |poll| {
+            handle_internal_metrics(self.chans, self.config, poll)
+        })
     }
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -5,19 +5,23 @@
 //! that creates `Telemetry`, `FileServer` is a source that creates `LogLine`s.
 use mio;
 
+mod avro;
 mod file;
 mod flush;
 mod graphite;
 mod internal;
 mod native;
 mod statsd;
+mod tcp;
 
+pub use self::avro::Avro;
 pub use self::file::{FileServer, FileServerConfig};
 pub use self::flush::FlushTimer;
 pub use self::graphite::{Graphite, GraphiteConfig};
 pub use self::internal::{report_full_telemetry, Internal, InternalConfig};
 pub use self::native::{NativeServer, NativeServerConfig};
 pub use self::statsd::{Statsd, StatsdConfig, StatsdParseConfig};
+pub use self::tcp::{TCP, TCPConfig};
 
 /// cernan Source, the originator of all `metric::Event`.
 ///

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -3,7 +3,6 @@
 //! In cernan a `Source` is a place where all `metric::Event` come from, feeding
 //! down into the source's forwards for further processing. Statsd is a source
 //! that creates `Telemetry`, `FileServer` is a source that creates `LogLine`s.
-use mio;
 use thread;
 use util;
 
@@ -23,15 +22,14 @@ pub use self::graphite::{Graphite, GraphiteConfig};
 pub use self::internal::{report_full_telemetry, Internal, InternalConfig};
 pub use self::native::{NativeServer, NativeServerConfig};
 pub use self::statsd::{Statsd, StatsdConfig, StatsdParseConfig};
-pub use self::tcp::{TCP, TCPConfig};
+pub use self::tcp::{TCPConfig, TCP};
 
 /// cernan Source, the originator of all `metric::Event`.
 ///
 /// A cernan Source creates all `metric::Event`, doing so by listening to
 /// network IO, reading from files, etc etc. All sources push into the routing
 /// topology.
-pub trait Source <T, TConfig> {
-
+pub trait Source<T, TConfig> {
     /// Constructs initial state for the given source.
     fn new(chans: util::Channel, config: TConfig) -> T;
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -29,9 +29,9 @@ pub use self::tcp::{TCPConfig, TCP};
 /// A cernan Source creates all `metric::Event`, doing so by listening to
 /// network IO, reading from files, etc etc. All sources push into the routing
 /// topology.
-pub trait Source<T, TConfig> {
+pub trait Source<TConfig> {
     /// Constructs initial state for the given source.
-    fn new(chans: util::Channel, config: TConfig) -> T;
+    fn new(chans: util::Channel, config: TConfig) -> Self;
 
     /// Run the Source, consuming initial state and returning a
     /// handle to the running thread.

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -4,7 +4,7 @@ use metric;
 use mio;
 use protobuf;
 use protocols::native::{AggregationMethod, Payload};
-use source::{TCPStreamHandler, TCPConfig, TCP};
+use source::{TCPConfig, TCPStreamHandler, TCP};
 use std::io;
 use std::io::Read;
 use std::str;
@@ -60,11 +60,16 @@ impl From<NativeServerConfig> for TCPConfig {
 }
 
 #[derive(Default, Debug, Clone, Deserialize)]
-pub struct NativeStreamHandler ;
+pub struct NativeStreamHandler;
 
 impl TCPStreamHandler for NativeStreamHandler {
-
-    fn handle_stream(&mut self, chans: util::Channel, tags: &sync::Arc<metric::TagMap>, poller: &mio::Poll, stream: mio::net::TcpStream)-> () {
+    fn handle_stream(
+        &mut self,
+        chans: util::Channel,
+        tags: &sync::Arc<metric::TagMap>,
+        poller: &mio::Poll,
+        stream: mio::net::TcpStream,
+    ) -> () {
         let mut reader = io::BufReader::new(stream);
         loop {
             let mut events = mio::Events::with_capacity(1024);
@@ -82,11 +87,9 @@ impl TCPStreamHandler for NativeStreamHandler {
             }
         }
     }
-
 }
 
 impl NativeStreamHandler {
-
     fn handle_stream_payload(
         &mut self,
         mut chans: util::Channel,

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -8,7 +8,6 @@ use protocols::native::{AggregationMethod, Payload};
 use source;
 use std::io;
 use std::io::Read;
-use std::net::ToSocketAddrs;
 use std::str;
 use std::sync;
 use thread;

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -1,16 +1,14 @@
 use byteorder::{BigEndian, ReadBytesExt};
 use constants;
-use hopper;
 use metric;
 use mio;
 use protobuf;
 use protocols::native::{AggregationMethod, Payload};
-use source;
+use source::{TCPStreamHandler, TCPConfig, TCP};
 use std::io;
 use std::io::Read;
 use std::str;
 use std::sync;
-use thread;
 use util;
 
 /// The native source
@@ -20,9 +18,6 @@ use util;
 /// `resources/protobufs/native.proto`. Clients may use the native protocol
 /// without having to obey the translation required in other sources or
 /// operators may set up cernan to cernan communication.
-pub struct NativeServer {
-    server: source::tcp::TCP,
-}
 
 /// Configuration for the native source
 #[derive(Debug, Clone, Deserialize)]
@@ -52,9 +47,9 @@ impl Default for NativeServerConfig {
     }
 }
 
-impl From<NativeServerConfig> for source::tcp::TCPConfig {
+impl From<NativeServerConfig> for TCPConfig {
     fn from(item: NativeServerConfig) -> Self {
-        source::tcp::TCPConfig {
+        TCPConfig {
             host: item.ip,
             port: item.port,
             tags: item.tags,
@@ -64,122 +59,115 @@ impl From<NativeServerConfig> for source::tcp::TCPConfig {
     }
 }
 
-fn handle_stream(
-    chans: util::Channel,
-    tags: &sync::Arc<metric::TagMap>,
-    poller: &mio::Poll,
-    stream: mio::net::TcpStream,
-) {
-    let mut reader = io::BufReader::new(stream);
-    loop {
-        let mut events = mio::Events::with_capacity(1024);
-        match poller.poll(&mut events, None) {
-            Err(e) => panic!(format!("Failed during poll {:?}", e)),
-            Ok(_num_events) => for event in events {
-                match event.token() {
-                    constants::SYSTEM => return,
-                    _stream_token => {
-                        let rchans = chans.clone();
-                        handle_stream_payload(rchans, tags, &mut reader);
+#[derive(Default, Debug, Clone, Deserialize)]
+pub struct NativeStreamHandler ;
+
+impl TCPStreamHandler for NativeStreamHandler {
+
+    fn handle_stream(&mut self, chans: util::Channel, tags: &sync::Arc<metric::TagMap>, poller: &mio::Poll, stream: mio::net::TcpStream)-> () {
+        let mut reader = io::BufReader::new(stream);
+        loop {
+            let mut events = mio::Events::with_capacity(1024);
+            match poller.poll(&mut events, None) {
+                Err(e) => panic!(format!("Failed during poll {:?}", e)),
+                Ok(_num_events) => for event in events {
+                    match event.token() {
+                        constants::SYSTEM => return,
+                        _stream_token => {
+                            let rchans = chans.clone();
+                            self.handle_stream_payload(rchans, tags, &mut reader);
+                        }
                     }
-                }
-            },
+                },
+            }
         }
     }
+
 }
 
-fn handle_stream_payload(
-    mut chans: util::Channel,
-    tags: &sync::Arc<metric::TagMap>,
-    reader: &mut io::BufReader<mio::net::TcpStream>,
-) {
-    let mut buf = Vec::with_capacity(4000);
-    let payload_size_in_bytes = match reader.read_u32::<BigEndian>() {
-        Ok(i) => i as usize,
-        Err(_) => return,
-    };
-    buf.resize(payload_size_in_bytes, 0);
-    if reader.read_exact(&mut buf).is_err() {
-        return;
-    }
-    match protobuf::parse_from_bytes::<Payload>(&buf) {
-        // TODO we have to handle bin_bounds. We'll use samples to get
-        // the values of each bounds' counter.
-        Ok(mut pyld) => {
-            for mut point in pyld.take_points().into_iter() {
-                let name: String = point.take_name();
-                let smpls: Vec<f64> = point.take_samples();
-                let aggr_type: AggregationMethod = point.get_method();
-                let mut meta = point.take_metadata();
-                // FIXME #166
-                let ts: i64 = (point.get_timestamp_ms() as f64 * 0.001) as i64;
+impl NativeStreamHandler {
 
-                if smpls.is_empty() {
-                    continue;
-                }
-                let mut metric = metric::Telemetry::new().name(name);
-                metric = metric.value(smpls[0]);
-                metric = match aggr_type {
-                    AggregationMethod::SET => {
-                        metric.kind(metric::AggregationMethod::Set)
-                    }
-                    AggregationMethod::SUM => {
-                        metric.kind(metric::AggregationMethod::Sum)
-                    }
-                    AggregationMethod::SUMMARIZE => {
-                        metric.kind(metric::AggregationMethod::Summarize)
-                    }
-                    AggregationMethod::BIN => {
-                        metric.kind(metric::AggregationMethod::Histogram)
-                    }
-                };
-                metric = metric.persist(point.get_persisted());
-                metric = metric.timestamp(ts);
-                let mut metric = metric.harden().unwrap(); // todo don't unwrap
-                metric = metric.overlay_tags_from_map(tags);
-                for (key, value) in meta.drain() {
-                    metric = metric.overlay_tag(key, value);
-                }
-                for smpl in &smpls[1..] {
-                    metric = metric.insert(*smpl);
-                }
-                util::send(&mut chans, metric::Event::new_telemetry(metric));
-            }
-            for mut line in pyld.take_lines().into_iter() {
-                let path: String = line.take_path();
-                let value: String = line.take_value();
-                let mut meta = line.take_metadata();
-                // FIXME #166
-                let ts: i64 = (line.get_timestamp_ms() as f64 * 0.001) as i64;
-
-                let mut logline = metric::LogLine::new(path, value);
-                logline = logline.time(ts);
-                logline = logline.overlay_tags_from_map(tags);
-                for (key, value) in meta.drain() {
-                    logline = logline.overlay_tag(key, value);
-                }
-                util::send(&mut chans, metric::Event::new_log(logline));
-            }
-        }
-        Err(err) => {
-            trace!("Unable to read payload: {:?}", err);
+    fn handle_stream_payload(
+        &mut self,
+        mut chans: util::Channel,
+        tags: &sync::Arc<metric::TagMap>,
+        reader: &mut io::BufReader<mio::net::TcpStream>,
+    ) {
+        let mut buf = Vec::with_capacity(4000);
+        let payload_size_in_bytes = match reader.read_u32::<BigEndian>() {
+            Ok(i) => i as usize,
+            Err(_) => return,
+        };
+        buf.resize(payload_size_in_bytes, 0);
+        if reader.read_exact(&mut buf).is_err() {
             return;
         }
-    }
-}
+        match protobuf::parse_from_bytes::<Payload>(&buf) {
+            // TODO we have to handle bin_bounds. We'll use samples to get
+            // the values of each bounds' counter.
+            Ok(mut pyld) => {
+                for mut point in pyld.take_points().into_iter() {
+                    let name: String = point.take_name();
+                    let smpls: Vec<f64> = point.take_samples();
+                    let aggr_type: AggregationMethod = point.get_method();
+                    let mut meta = point.take_metadata();
+                    // FIXME #166
+                    let ts: i64 = (point.get_timestamp_ms() as f64 * 0.001) as i64;
 
-impl source::Source<NativeServerConfig> for NativeServer {
-    /// Create a new NativeServer
-    fn new(
-        chans: Vec<hopper::Sender<metric::Event>>,
-        config: NativeServerConfig,
-    ) -> Self {
-        NativeServer {
-            server: source::TCP::new(chans, config.into()),
+                    if smpls.is_empty() {
+                        continue;
+                    }
+                    let mut metric = metric::Telemetry::new().name(name);
+                    metric = metric.value(smpls[0]);
+                    metric = match aggr_type {
+                        AggregationMethod::SET => {
+                            metric.kind(metric::AggregationMethod::Set)
+                        }
+                        AggregationMethod::SUM => {
+                            metric.kind(metric::AggregationMethod::Sum)
+                        }
+                        AggregationMethod::SUMMARIZE => {
+                            metric.kind(metric::AggregationMethod::Summarize)
+                        }
+                        AggregationMethod::BIN => {
+                            metric.kind(metric::AggregationMethod::Histogram)
+                        }
+                    };
+                    metric = metric.persist(point.get_persisted());
+                    metric = metric.timestamp(ts);
+                    let mut metric = metric.harden().unwrap(); // todo don't unwrap
+                    metric = metric.overlay_tags_from_map(tags);
+                    for (key, value) in meta.drain() {
+                        metric = metric.overlay_tag(key, value);
+                    }
+                    for smpl in &smpls[1..] {
+                        metric = metric.insert(*smpl);
+                    }
+                    util::send(&mut chans, metric::Event::new_telemetry(metric));
+                }
+                for mut line in pyld.take_lines().into_iter() {
+                    let path: String = line.take_path();
+                    let value: String = line.take_value();
+                    let mut meta = line.take_metadata();
+                    // FIXME #166
+                    let ts: i64 = (line.get_timestamp_ms() as f64 * 0.001) as i64;
+
+                    let mut logline = metric::LogLine::new(path, value);
+                    logline = logline.time(ts);
+                    logline = logline.overlay_tags_from_map(tags);
+                    for (key, value) in meta.drain() {
+                        logline = logline.overlay_tag(key, value);
+                    }
+                    util::send(&mut chans, metric::Event::new_log(logline));
+                }
+            }
+            Err(err) => {
+                trace!("Unable to read payload: {:?}", err);
+                return;
+            }
         }
     }
-
-    fn run(self) -> thread::ThreadHandle {
-        self.server.run(handle_stream)
-    }
 }
+
+/// Source for Cernan's native protocol.
+pub type NativeServer = TCP<NativeStreamHandler>;

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -168,12 +168,12 @@ fn handle_stream_payload(
     }
 }
 
-impl source::Source<NativeServer, NativeServerConfig> for NativeServer {
+impl source::Source<NativeServerConfig> for NativeServer {
     /// Create a new NativeServer
     fn new(
         chans: Vec<hopper::Sender<metric::Event>>,
         config: NativeServerConfig,
-    ) -> NativeServer {
+    ) -> Self {
         NativeServer {
             server: source::TCP::new(chans, config.into()),
         }

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -89,9 +89,9 @@ impl Default for StatsdConfig {
     }
 }
 
-impl source::Source<Statsd, StatsdConfig> for Statsd {
+impl source::Source<StatsdConfig> for Statsd {
     /// Create and spawn a new statsd source
-    fn new(chans: util::Channel, config: StatsdConfig) -> Statsd {
+    fn new(chans: util::Channel, config: StatsdConfig) -> Self {
         let mut conns = util::TokenSlab::<mio::net::UdpSocket>::new();
         let addrs = (config.host.as_str(), config.port).to_socket_addrs();
         match addrs {

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -112,7 +112,12 @@ impl source::Source<StatsdConfig> for Statsd {
         }
     }
 
-    fn run(self, mut chans: util::Channel, tags: &sync::Arc<metric::TagMap>, poller: mio::Poll) -> () {
+    fn run(
+        self,
+        mut chans: util::Channel,
+        tags: &sync::Arc<metric::TagMap>,
+        poller: mio::Poll,
+    ) -> () {
         for (idx, socket) in self.conns.iter() {
             poller
                 .register(
@@ -158,7 +163,10 @@ impl source::Source<StatsdConfig> for Statsd {
                                     &self.parse_config,
                                 ) {
                                     for m in metrics.drain(..) {
-                                        send(&mut chans, metric::Event::new_telemetry(m));
+                                        send(
+                                            &mut chans,
+                                            metric::Event::new_telemetry(m),
+                                        );
                                     }
                                     STATSD_GOOD_PACKET.fetch_add(1, Ordering::Relaxed);
                                 } else {

--- a/src/source/tcp.rs
+++ b/src/source/tcp.rs
@@ -1,7 +1,9 @@
 use constants;
 use metric;
 use mio;
+use source::Source;
 use std;
+use std::marker::PhantomData;
 use std::net::ToSocketAddrs;
 use std::sync;
 use thread;
@@ -36,109 +38,31 @@ impl Default for TCPConfig {
     }
 }
 
+/// Simple single threaded TCP Stream handler.
+pub trait TCPStreamHandler: 'static + Default + Clone + Sync + Send {
+
+    /// Constructs a new handler for mio::net::TCPStreams.
+    fn new() -> Self {
+        Default::default()
+    }
+
+    /// Handler for a single HTTP request.
+    fn handle_stream(&mut self, util::Channel, &sync::Arc<metric::TagMap>, &mio::Poll, mio::net::TcpStream)-> ();
+}
+
 /// State for a TCP backed source.
-pub struct TCP {
-    chans: util::Channel,
-    config: TCPConfig,
+pub struct TCP <H> {
     listeners: util::TokenSlab<mio::net::TcpListener>,
+    handlers: Vec<thread::ThreadHandle>,
+    phantom: PhantomData<H>,
 }
 
-fn spawn_stream_handlers<H>(
-    chans: util::Channel,
-    tags: &sync::Arc<metric::TagMap>,
-    listener: &mio::net::TcpListener,
-    handler_fn: H,
-    stream_handlers: &mut Vec<thread::ThreadHandle>,
-) -> ()
-where
-    H: Send
-        + Sync
-        + Copy
-        + 'static
-        + FnOnce(util::Channel, &sync::Arc<metric::TagMap>, &mio::Poll, mio::net::TcpStream)
-        -> (),
+impl <H> Source<TCPConfig> for TCP<H>
+    where
+        H: TCPStreamHandler
 {
-    loop {
-        match listener.accept() {
-            Ok((stream, _addr)) => {
-                let rchans = chans.clone();
-                let rtags = sync::Arc::clone(tags);
-                let new_stream = thread::spawn(move |poller| {
-                    poller
-                        .register(
-                            &stream,
-                            mio::Token(0),
-                            mio::Ready::readable(),
-                            mio::PollOpt::edge(),
-                        )
-                        .unwrap();
-
-                    handler_fn(rchans, &rtags, &poller, stream);
-                });
-                stream_handlers.push(new_stream);
-            }
-
-            Err(e) => match e.kind() {
-                std::io::ErrorKind::WouldBlock => {
-                    break;
-                }
-                _ => unimplemented!(),
-            },
-        };
-    }
-}
-
-fn accept_loop<H>(
-    mut chans: util::Channel,
-    tags: &sync::Arc<metric::TagMap>,
-    poll: mio::Poll,
-    listeners: util::TokenSlab<mio::net::TcpListener>,
-    handler_fn: H,
-) -> ()
-where
-    H: Send
-        + Sync
-        + Copy
-        + 'static
-        + FnOnce(util::Channel, &sync::Arc<metric::TagMap>, &mio::Poll, mio::net::TcpStream)
-        -> (),
-{
-    let mut stream_handlers: Vec<thread::ThreadHandle> = Vec::new();
-    loop {
-        let mut events = mio::Events::with_capacity(1024);
-        match poll.poll(&mut events, None) {
-            Err(e) => panic!(format!("Failed during poll {:?}", e)),
-            Ok(_num_events) => {
-                for event in events {
-                    match event.token() {
-                        constants::SYSTEM => {
-                            for handler in stream_handlers {
-                                handler.shutdown();
-                            }
-
-                            util::send(&mut chans, metric::Event::Shutdown);
-                            return;
-                        }
-                        listener_token => {
-                            let listener = &listeners[listener_token];
-                            spawn_stream_handlers(
-                                chans.clone(), // TODO: do not clone, make an Arc
-                                tags,
-                                listener,
-                                handler_fn,
-                                &mut stream_handlers,
-                            );
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-impl TCP {
     /// Constructs and starts a new TCP source.
-    pub fn new(chans: util::Channel, config: TCPConfig) -> Self {
+    fn init(config: TCPConfig) -> Self {
         let addrs = (config.host.as_str(), config.port).to_socket_addrs();
         let mut listeners = util::TokenSlab::<mio::net::TcpListener>::new();
         match addrs {
@@ -163,42 +87,111 @@ impl TCP {
         };
 
         TCP {
-            chans: chans,
-            config: config,
             listeners: listeners,
+            handlers: Vec::new(),
+            phantom: PhantomData,
         }
     }
 
     /// Starts the accept loop.
-    pub fn run<H>(self, stream_handler: H) -> thread::ThreadHandle
-    where
-        H: Send
-            + Sync
-            + Copy
-            + 'static
-            + FnOnce(
-            util::Channel,
-            &sync::Arc<metric::TagMap>,
-            &mio::Poll,
-            mio::net::TcpStream,
-        ) -> (),
+    fn run(self, chans: util::Channel, tags: &sync::Arc<metric::TagMap>, poller: mio::Poll) -> ()
     {
-        thread::spawn(move |poll| {
-            for (token, listener) in self.listeners.iter() {
-                poll.register(
-                    listener,
-                    mio::Token::from(token),
-                    mio::Ready::readable(),
-                    mio::PollOpt::edge(),
-                ).unwrap();
+        for (idx, listener) in self.listeners.iter() {
+            poller.register(
+                listener,
+                mio::Token::from(idx),
+                mio::Ready::readable(),
+                mio::PollOpt::edge(),
+            ).unwrap();
+        }
+
+        self.accept_loop(
+            chans,
+            tags,
+            poller,
+        )
+    }
+
+}
+
+impl<H> TCP<H>
+    where
+        H: TCPStreamHandler,
+{
+
+    fn accept_loop(
+        mut self,
+        mut chans: util::Channel,
+        tags: &sync::Arc<metric::TagMap>,
+        poll: mio::Poll,
+    ) -> ()
+    {
+        loop {
+            let mut events = mio::Events::with_capacity(1024);
+            match poll.poll(&mut events, None) {
+                Err(e) => panic!(format!("Failed during poll {:?}", e)),
+                Ok(_num_events) => {
+                    for event in events {
+                        match event.token() {
+                            constants::SYSTEM => {
+                                for handler in self.handlers.into_iter() {
+                                    handler.shutdown();
+                                }
+
+                                util::send(&mut chans, metric::Event::Shutdown);
+                                return;
+                            }
+                            listener_token => {
+                                self.spawn_stream_handlers(
+                                    chans.clone(), // TODO: do not clone, make an Arc
+                                    tags,
+                                    listener_token,
+                                );
+                            }
+                        }
+                    }
+                }
             }
-            accept_loop(
-                self.chans,
-                &sync::Arc::new(self.config.tags),
-                poll,
-                self.listeners,
-                stream_handler,
-            )
-        })
+        }
+    }
+
+    fn spawn_stream_handlers(
+        &mut self,
+        chans: util::Channel,
+        tags: &sync::Arc<metric::TagMap>,
+        listener_token: mio::Token,
+    ) -> ()
+    {
+
+        let listener = &(self.listeners[listener_token]);
+        loop {
+            match listener.accept() {
+                Ok((stream, _addr)) => {
+                    let rchans = chans.clone();
+                    let rtags = sync::Arc::clone(tags);
+                    let new_stream = thread::spawn(move |poller| {
+                        poller
+                            .register(
+                                &stream,
+                                mio::Token(0),
+                                mio::Ready::readable(),
+                                mio::PollOpt::edge(),
+                            )
+                            .unwrap();
+
+                        let mut handler = H::new();
+                        handler.handle_stream(rchans, &rtags, &poller, stream);
+                    });
+                    self.handlers.push(new_stream);
+                }
+
+                Err(e) => match e.kind() {
+                    std::io::ErrorKind::WouldBlock => {
+                        break;
+                    }
+                    _ => unimplemented!(),
+                },
+            };
+        }
     }
 }

--- a/src/source/tcp.rs
+++ b/src/source/tcp.rs
@@ -1,0 +1,218 @@
+use metric;
+use mio;
+use util;
+use constants;
+use source::Source;
+use std;
+use std::net::ToSocketAddrs;
+use std::sync;
+use thread;
+use thread::Stoppable;
+
+/// Configured for the `metric::Telemetry` source.
+#[derive(Debug, Deserialize, Clone)]
+pub struct TCPConfig {
+    /// The unique name of the source in the routing topology.
+    pub config_path: Option<String>,
+    /// The host that the source will listen on. May be an IP address or a DNS
+    /// hostname.
+    pub host: String,
+    /// The port that the source will listen on.
+    pub port: u16,
+    /// The tags that the source will apply to all Telemetry it creates.
+    pub tags: metric::TagMap,
+    /// The forwards that the source will send all its Telemetry.
+    pub forwards: Vec<String>,
+
+}
+
+impl Default for TCPConfig {
+    fn default() -> TCPConfig {
+        TCPConfig {
+            host: "localhost".to_string(),
+            port: 8080,
+            tags: metric::TagMap::default(),
+            forwards: Vec::new(),
+            config_path: Some("sources.tcp".to_string()),
+        }
+    }
+}
+
+/// State for a TCP backed source.
+pub struct TCP {
+    config: TCPConfig,
+    thread:  thread::ThreadHandle,
+}
+
+impl Source for TCP {
+
+    fn run(&mut self, _poll: mio::Poll) {
+        //let addrs = (host_port.to_socket_addrs();
+        //match addrs {
+        //    Ok(ips) => {
+        //        let ips: Vec<_> = ips.collect();
+        //        let mut listeners = util::TokenSlab::<mio::net::TcpListener>::new();
+
+        //        for addr in ips {
+        //            let listener = mio::net::TcpListener::bind(&addr)
+        //                .expect("Unable to bind to TCP socket");
+        //            info!("registered listener for {:?}", addr);
+        //            let token = listeners.insert(listener);
+        //            poll.register(
+        //                &listeners[token],
+        //                token,
+        //                mio::Ready::readable(),
+        //                mio::PollOpt::edge(),
+        //            ).unwrap();
+        //        }
+
+        //        accept_loop(poll, listeners);
+        //    }
+
+        //    Err(e) => {
+        //        panic!(
+        //            "Unable to perform DNS lookup on {} with error {}",
+        //            host_port, e);
+        //    }
+        //}
+    }
+}
+
+fn spawn_stream_handlers<H>(
+    chans: util::Channel,
+    tags: &sync::Arc<metric::TagMap>,
+    listener: &mio::net::TcpListener,
+    handler_fn: H,
+    stream_handlers: &mut Vec<thread::ThreadHandle>,
+) -> () 
+where
+    H: Send + Sync + Copy + 'static + FnOnce(util::Channel, &sync::Arc<metric::TagMap>, &mio::Poll, mio::net::TcpStream) -> ()
+{
+    loop {
+        match listener.accept() {
+            Ok((stream, _addr)) => {
+                let rchans = chans.clone();
+                let rtags = sync::Arc::clone(tags);
+                let new_stream = thread::spawn(move |poller| {
+                    poller
+                        .register(
+                            &stream,
+                            mio::Token(0),
+                            mio::Ready::readable(),
+                            mio::PollOpt::edge(),
+                        )
+                        .unwrap();
+
+                    handler_fn(rchans, &rtags, &poller, stream);
+                });
+                stream_handlers.push(new_stream);
+            }
+
+            Err(e) => match e.kind() {
+                std::io::ErrorKind::WouldBlock => {
+                    break;
+                }
+                _ => unimplemented!(),
+            },
+        };
+    }
+}
+
+
+fn accept_loop<H>(
+    mut chans: util::Channel,
+    tags: &sync::Arc<metric::TagMap>,
+    poll: mio::Poll,
+    listeners: util::TokenSlab<mio::net::TcpListener>, 
+    handler_fn: H,
+) -> ()
+where
+    H: Send + Sync + Copy + 'static + FnOnce(util::Channel, &sync::Arc<metric::TagMap>, &mio::Poll, mio::net::TcpStream) -> ()
+{
+    let mut stream_handlers: Vec<thread::ThreadHandle> = Vec::new();
+    loop {
+        let mut events = mio::Events::with_capacity(1024);
+        match poll.poll(&mut events, None) {
+            Err(e) => panic!(format!("Failed during poll {:?}", e)),
+            Ok(_num_events) => {
+                for event in events {
+                    match event.token() {
+                        constants::SYSTEM => {
+                            for handler in stream_handlers {
+                                handler.shutdown();
+                            }
+
+                            util::send(&mut chans, metric::Event::Shutdown);
+                            return;
+                        }
+                        listener_token => {
+                            let listener = &listeners[listener_token];
+                            spawn_stream_handlers(
+                                chans.clone(), // TODO: do not clone, make an Arc
+                                tags,
+                                listener,
+                                handler_fn,
+                                &mut stream_handlers,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl Stoppable for TCP {
+    fn join(self) {
+        self.thread.join();
+    }
+
+    fn shutdown(self) {
+        self.thread.shutdown();
+    }
+}
+
+impl TCP {
+
+    /// Constructs and starts a new TCP source.
+    pub fn new <H>(chans: util::Channel, config: TCPConfig, stream_handler: H) -> Self 
+    where
+        H: Send + Sync + Copy + 'static + FnOnce(util::Channel, &sync::Arc<metric::TagMap>, &mio::Poll, mio::net::TcpStream) -> ()
+    {
+        let addrs = (config.host.as_str(), config.port).to_socket_addrs();
+        trace!("ADDRS {:?}", addrs);
+        let mut listeners = util::TokenSlab::<mio::net::TcpListener>::new();
+        match addrs {
+            Ok(ips) => {
+                let ips: Vec<_> = ips.collect();
+                for addr in ips {
+                    let listener = mio::net::TcpListener::bind(&addr)
+                        .expect("Unable to bind to TCP socket");
+                    info!("registered listener for {:?}", addr);
+                    listeners.insert(listener);
+                }
+            }
+
+            Err(e) => {
+                panic!(
+                    "Unable to perform DNS lookup on {:?}:{:?} with error {}",
+                    config.host.as_str(), config.port, e);
+            }
+        };
+   
+        let tags = sync::Arc::new(config.clone().tags);
+        TCP {
+            config: config,
+            thread: thread::spawn(move |poll| {
+                for (token, listener) in listeners.iter() {
+                    poll.register(
+                        listener,
+                        mio::Token::from(token),
+                        mio::Ready::readable(),
+                        mio::PollOpt::edge(),
+                    ).unwrap();
+                };
+                accept_loop(chans, &tags, poll, listeners, stream_handler)}),
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -96,6 +96,11 @@ impl<E: mio::Evented> TokenSlab<E> {
         }
     }
 
+    /// Iterates over the underlying slab mapping index to mio::Evented.
+    pub fn iter(&self) -> slab::Iter<E> {
+        self.tokens.iter()
+    }
+
     /// Inserts a new Evented into the slab, returning a mio::Token
     /// corresponding to the index of the newly inserted type.
     pub fn insert(&mut self, thing: E) -> mio::Token {

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,7 +27,7 @@ pub type Channel = Vec<hopper::Sender<metric::Event>>;
 pub fn send(chans: &mut Channel, event: metric::Event) {
     if chans.is_empty() {
         // Nothing to send to.
-        return
+        return;
     }
 
     let max: usize = chans.len().saturating_sub(1);


### PR DESCRIPTION
New source accepts length prefixed (32 bits, big endian) avro payload.
Such payloads are wrapped as a new event type, metric::Event::Raw which
captures the payload as well as the encoding.

This mod also introduces a generic TCP source which can be reused by any
TCP backed source.  In addition, the Source trait has been extended to unify creation and execution of Source threads.

std::thread usage in `bin/cernan` has been replaced with `cernan:thread`.

Sinks can now consume Raw events by implementing a `deliver_raw` method.  By default, the event will simply be dropped.