### PR TITLE
Introduces Kinesis Sink + Improves Sink Interface.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_firehose 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_kinesis 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-avro 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1279,6 +1280,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_core"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_credential 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rusoto_credential"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1320,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusoto_kinesis"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2030,8 +2063,10 @@ dependencies = [
 "checksum reqwest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f73a8482e3b2b20ef5c07168b27048fc3778a012ce9b11a021556a450a01e9b5"
 "checksum ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6f7d28b30a72c01b458428e0ae988d4149c20d902346902be881e3edc4bb325c"
 "checksum rusoto_core 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1655b3c1599e0506c0b2327cceccdf00d46961fb4fc0346054cc45430174767"
+"checksum rusoto_core 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "416154f868e6d42ae9fb6f8df6b008eab0c92c4af4c7b9bd71cca64a0010e310"
 "checksum rusoto_credential 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4e1cbcb471900c15925afa14c04a30f978f466800eeabc8d60a2e9622561d140"
 "checksum rusoto_firehose 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99bb2106edd9ec663d41f968c4fddcb29dfe8b72c1430bcc2d347ab68c5f48bf"
+"checksum rusoto_kinesis 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "577ece6b5020051248510c82fbec16d76bf8e80a9cf3e5bc38e49b18bcdafc77"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9743a7670d88d5d52950408ecdb7c71d8986251ab604d4689dd2ca25c9bca69"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bincode"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cernan"
 version = "0.8.6"
 dependencies = [
+ "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chan-signal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -202,8 +212,8 @@ dependencies = [
  "quantiles 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_firehose 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_firehose 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_kinesis 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1261,26 +1271,6 @@ dependencies = [
 
 [[package]]
 name = "rusoto_core"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_credential 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rusoto_core"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1315,11 +1305,11 @@ dependencies = [
 
 [[package]]
 name = "rusoto_firehose"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1934,6 +1924,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum base64 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c4a342b450b268e1be8036311e2c613d7f8a7ed31214dff1cc3b60852a3168d"
+"checksum base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "229d032f1a99302697f10b27167ae6d03d49d032e6a8e2550e8d3fc13356d2b4"
 "checksum bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9a6301db0b49fb63551bc15b5ae348147101cdf323242b93ec7546d5002ff1af"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
@@ -2062,10 +2053,9 @@ dependencies = [
 "checksum relay 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f301bafeb60867c85170031bdb2fcf24c8041f33aee09e7b116a58d4e9f781c5"
 "checksum reqwest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f73a8482e3b2b20ef5c07168b27048fc3778a012ce9b11a021556a450a01e9b5"
 "checksum ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6f7d28b30a72c01b458428e0ae988d4149c20d902346902be881e3edc4bb325c"
-"checksum rusoto_core 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1655b3c1599e0506c0b2327cceccdf00d46961fb4fc0346054cc45430174767"
 "checksum rusoto_core 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "416154f868e6d42ae9fb6f8df6b008eab0c92c4af4c7b9bd71cca64a0010e310"
 "checksum rusoto_credential 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4e1cbcb471900c15925afa14c04a30f978f466800eeabc8d60a2e9622561d140"
-"checksum rusoto_firehose 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99bb2106edd9ec663d41f968c4fddcb29dfe8b72c1430bcc2d347ab68c5f48bf"
+"checksum rusoto_firehose 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6988fee8f7d4a6b259fb70bb60c0c8f00b2a5e75ccea67563e035c383b49c82c"
 "checksum rusoto_kinesis 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "577ece6b5020051248510c82fbec16d76bf8e80a9cf3e5bc38e49b18bcdafc77"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quantiles 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_firehose 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ lua = { git = "https://github.com/blt/rust-lua53.git", branch = "master" }
 openssl-probe = "0.1"
 protobuf = "1.4"
 quantiles = { version = "0.7", features = ["serde_support"] }
+rand = "0.3"
 regex = "0.2"
 rusoto_core = "0.30"
 rusoto_firehose = "0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ openssl-probe = "0.1"
 protobuf = "1.4"
 quantiles = { version = "0.7", features = ["serde_support"] }
 regex = "0.2"
-rusoto_core = "0.29"
-rusoto_firehose = "0.29"
+rusoto_core = "0.30"
+rusoto_firehose = "0.30"
 seahash = "3.0"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
@@ -47,6 +47,7 @@ chan-signal = "0.3.1"
 mio = "0.6.11"
 tiny_http = "0.5.8"
 serde-avro = "0.5.0"
+base64 = "0.9.0"
 rusoto_kinesis = "0.30.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ chan-signal = "0.3.1"
 mio = "0.6.11"
 tiny_http = "0.5.8"
 serde-avro = "0.5.0"
+rusoto_kinesis = "0.30.0"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -366,9 +366,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path);
         sinks.insert(
             config.config_path.clone(),
-            cernan::thread::spawn(move |_poll| {
-                cernan::sink::Null::new(&config).run(recv, sources);
-            }),
+            cernan::sink::Null::new(recv, sources, config).run()
         );
     }
     if let Some(config) = mem::replace(&mut args.console, None) {
@@ -378,9 +376,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            cernan::thread::spawn(move |_poll| {
-                cernan::sink::Console::new(&config).run(recv, sources);
-            }),
+            cernan::sink::Console::new(recv, sources, config).run()
         );
     }
     if let Some(config) = mem::replace(&mut args.wavefront, None) {
@@ -390,17 +386,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            cernan::thread::spawn(move |_poll| {
-                match cernan::sink::Wavefront::new(config) {
-                    Ok(mut w) => {
-                        w.run(recv, sources);
-                    }
-                    Err(e) => {
-                        error!("Configuration error for Wavefront: {}", e);
-                        process::exit(1);
-                    }
-                }
-            }),
+            cernan::sink::Wavefront::new(recv, sources, config).run()
         );
     }
     if let Some(config) = mem::replace(&mut args.prometheus, None) {
@@ -410,9 +396,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            cernan::thread::spawn(move |_poll| {
-                cernan::sink::Prometheus::new(&config).run(recv, sources);
-            }),
+            cernan::sink::Prometheus::new(recv, sources, config).run()
         );
     }
     if let Some(config) = mem::replace(&mut args.influxdb, None) {
@@ -422,9 +406,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            cernan::thread::spawn(move |_poll| {
-                cernan::sink::InfluxDB::new(&config).run(recv, sources);
-            }),
+            cernan::sink::InfluxDB::new(recv, sources, config).run()
         );
     }
     if let Some(config) = mem::replace(&mut args.native_sink_config, None) {
@@ -434,9 +416,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            cernan::thread::spawn(move |_poll| {
-                cernan::sink::Native::new(config).run(recv, sources);
-            }),
+            cernan::sink::Native::new(recv, sources, config).run()
         );
     }
     if let Some(config) = mem::replace(&mut args.elasticsearch, None) {
@@ -446,9 +426,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            cernan::thread::spawn(move |_poll| {
-                cernan::sink::Elasticsearch::new(config).run(recv, sources);
-            }),
+            cernan::sink::Elasticsearch::new(recv, sources, config).run()
         );
     }
     if let Some(cfgs) = mem::replace(&mut args.firehosen, None) {
@@ -460,9 +438,7 @@ fn main() {
                 adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
             sinks.insert(
                 config.config_path.clone().unwrap(),
-                cernan::thread::spawn(move |_poll| {
-                    cernan::sink::Firehose::new(config).run(recv, sources);
-                }),
+                cernan::sink::Firehose::new(recv, sources, config).run()
             );
         }
     }

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -379,7 +379,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path);
         sinks.insert(
             config.config_path.clone(),
-            cernan::sink::Null::new(recv, sources, config).run()
+            cernan::sink::Null::new(recv, sources, config).run(),
         );
     }
     if let Some(config) = mem::replace(&mut args.console, None) {
@@ -389,7 +389,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            cernan::sink::Console::new(recv, sources, config).run()
+            cernan::sink::Console::new(recv, sources, config).run(),
         );
     }
     if let Some(config) = mem::replace(&mut args.wavefront, None) {
@@ -399,7 +399,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            cernan::sink::Wavefront::new(recv, sources, config).run()
+            cernan::sink::Wavefront::new(recv, sources, config).run(),
         );
     }
     if let Some(config) = mem::replace(&mut args.prometheus, None) {
@@ -409,7 +409,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            cernan::sink::Prometheus::new(recv, sources, config).run()
+            cernan::sink::Prometheus::new(recv, sources, config).run(),
         );
     }
     if let Some(config) = mem::replace(&mut args.influxdb, None) {
@@ -419,7 +419,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            cernan::sink::InfluxDB::new(recv, sources, config).run()
+            cernan::sink::InfluxDB::new(recv, sources, config).run(),
         );
     }
     if let Some(config) = mem::replace(&mut args.native_sink_config, None) {
@@ -429,7 +429,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            cernan::sink::Native::new(recv, sources, config).run()
+            cernan::sink::Native::new(recv, sources, config).run(),
         );
     }
     if let Some(config) = mem::replace(&mut args.elasticsearch, None) {
@@ -439,7 +439,7 @@ fn main() {
         let sources = adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
         sinks.insert(
             config.config_path.clone().unwrap(),
-            cernan::sink::Elasticsearch::new(recv, sources, config).run()
+            cernan::sink::Elasticsearch::new(recv, sources, config).run(),
         );
     }
     if let Some(cfgs) = mem::replace(&mut args.firehosen, None) {
@@ -451,7 +451,7 @@ fn main() {
                 adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
             sinks.insert(
                 config.config_path.clone().unwrap(),
-                cernan::sink::Firehose::new(recv, sources, config).run()
+                cernan::sink::Firehose::new(recv, sources, config).run(),
             );
         }
     }
@@ -464,7 +464,7 @@ fn main() {
                 adjacency_matrix.pop_nodes(&config.config_path.clone().unwrap());
             sinks.insert(
                 config.config_path.clone().unwrap(),
-                cernan::sink::Kinesis::new(recv, sources, config).run()
+                cernan::sink::Kinesis::new(recv, sources, config).run(),
             );
         }
     }

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -491,7 +491,7 @@ fn main() {
 
             let sources = adjacency_matrix.filter_nodes(
                 &config.config_path.clone().unwrap(),
-                |&(ref _k, ref option_v)| option_v.is_none(),
+                |&(_k, option_v)| option_v.is_none(),
             );
             let downstream_sends = adjacency_matrix.pop_metadata(&config_path);
             filters.insert(
@@ -528,7 +528,7 @@ fn main() {
 
             let sources = adjacency_matrix.filter_nodes(
                 &config.config_path.clone().unwrap(),
-                |&(ref _k, ref option_v)| option_v.is_none(),
+                |&(_k, option_v)| option_v.is_none(),
             );
             let downstream_sends = adjacency_matrix.pop_metadata(&config_path);
             filters.insert(
@@ -564,7 +564,7 @@ fn main() {
 
             let sources = adjacency_matrix.filter_nodes(
                 &config.config_path.clone().unwrap(),
-                |&(ref _k, ref option_v)| option_v.is_none(),
+                |&(_k, option_v)| option_v.is_none(),
             );
             let downstream_sends = adjacency_matrix.pop_metadata(&config_path);
             filters.insert(

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,10 +8,10 @@ use metric::TagMap;
 use rusoto_core::Region;
 use std::collections::HashMap;
 use std::env;
-use std::str::FromStr;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use toml;
 
 const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
@@ -724,7 +724,7 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
             firehosen
         });
 
-    args.kinesises = sinks.get("kinesis").map(|snk| {
+        args.kinesises = sinks.get("kinesis").map(|snk| {
             let mut kinesises = Vec::new();
             for (name, tbl) in snk.as_table().unwrap().iter() {
                 let is_enabled = tbl.get("enabled")
@@ -736,7 +736,9 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                     res.config_path = Some(format!("sinks.kinesis.{}", name));
 
                     let stream_name = tbl.get("stream_name").map(|x| {
-                        x.as_str().expect("stream_name must be a string").to_string()
+                        x.as_str()
+                            .expect("stream_name must be a string")
+                            .to_string()
                     });
 
                     if stream_name.is_none() {
@@ -753,9 +755,11 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                         })
                         .unwrap_or(args.flush_interval);
 
-                    let region_str = tbl.get("region").map(|x| x.as_str().expect("region must be a string"));
+                    let region_str = tbl.get("region")
+                        .map(|x| x.as_str().expect("region must be a string"));
                     if region_str.is_some() {
-                        res.region = Region::from_str(region_str.unwrap()).expect("Invalid region identifier")
+                        res.region = Region::from_str(region_str.unwrap())
+                            .expect("Invalid region identifier")
                     }
 
                     kinesises.push(res);
@@ -763,7 +767,6 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
             }
             kinesises
         });
-
     }
 
     // sources

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 //! our [wiki](https://github.com/postmates/cernan/wiki/).
 #![allow(unknown_lints)]
 #![deny(trivial_numeric_casts, missing_docs, unstable_features, unused_import_braces)]
+extern crate base64;
 extern crate byteorder;
 extern crate chrono;
 extern crate clap;
@@ -34,6 +35,7 @@ extern crate quantiles;
 extern crate regex;
 extern crate rusoto_core;
 extern crate rusoto_firehose;
+extern crate rusoto_kinesis;
 extern crate seahash;
 extern crate serde_avro;
 #[macro_use]

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -10,9 +10,16 @@ type AdjacencyMap<T> = util::HashMap<String, Option<T>>;
 type AdjacencyMatrix<T> = util::HashMap<String, AdjacencyMap<T>>;
 
 /// Adjacency matrix struct.
-#[derive(Default)]
 pub struct Adjacency<M: Clone> {
     edges: AdjacencyMatrix<M>,
+}
+
+impl<M: Clone + Debug> Default for Adjacency<M>{
+    fn default() -> Adjacency<M> {
+        Adjacency {
+            edges: Default::default(),
+        }
+    }
 }
 
 ///  Poor man's adjacency matrix biased towards incident edge queries.

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -1,3 +1,5 @@
+//! Console Event logger.
+
 use buckets::Buckets;
 use chrono::DateTime;
 use chrono::naive::NaiveDateTime;
@@ -15,31 +17,10 @@ pub struct Console {
     flush_interval: u64,
 }
 
-impl Console {
-    /// Create a new Console
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use cernan::sink::{Console, ConsoleConfig};
-    /// let config = ConsoleConfig { config_path:
-    /// Some("sinks.console".to_string()),
-    /// bin_width: 2, flush_interval: 60 };
-    /// let c = Console::new(&config);
-    /// ```
-    pub fn new(config: &ConsoleConfig) -> Console {
-        Console {
-            aggrs: Buckets::new(config.bin_width),
-            buffer: Vec::new(),
-            flush_interval: config.flush_interval,
-        }
-    }
-}
-
 /// The configuration struct for Console. There's not a whole lot to configure
 /// here, independent of other sinks, but Console does do aggregations and that
 /// requires knowing what the user wants for `bin_width`.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ConsoleConfig {
     /// The sink's unique name in the routing topology.
     pub config_path: Option<String>,
@@ -80,7 +61,15 @@ impl ConsoleConfig {
     }
 }
 
-impl Sink for Console {
+impl Sink<ConsoleConfig> for Console {
+    fn init(config: ConsoleConfig) -> Self {
+        Console {
+            aggrs: Buckets::new(config.bin_width),
+            buffer: Vec::new(),
+            flush_interval: config.flush_interval,
+        }
+    }
+
     fn valve_state(&self) -> Valve {
         Valve::Open
     }

--- a/src/sink/elasticsearch.rs
+++ b/src/sink/elasticsearch.rs
@@ -119,22 +119,6 @@ pub struct Elasticsearch {
 }
 
 impl Elasticsearch {
-    /// Construct a new Elasticsearch.
-    ///
-    /// Refer to the documentation on Elasticsearch for more details.
-    pub fn new(config: ElasticsearchConfig) -> Elasticsearch {
-        Elasticsearch {
-            buffer: Vec::new(),
-            secure: config.secure,
-            host: config.host,
-            port: config.port,
-            index_prefix: config.index_prefix,
-            index_type: config.index_type,
-            delivery_attempt_limit: config.delivery_attempt_limit,
-            flush_interval: config.flush_interval,
-        }
-    }
-
     fn bulk_body(&self, buffer: &mut String) -> () {
         assert!(!self.buffer.is_empty());
         use serde_json::{to_string, Value};
@@ -169,7 +153,20 @@ impl Elasticsearch {
     }
 }
 
-impl Sink for Elasticsearch {
+impl Sink<ElasticsearchConfig> for Elasticsearch {
+    fn init(config: ElasticsearchConfig) -> Self {
+        Elasticsearch {
+            buffer: Vec::new(),
+            secure: config.secure,
+            host: config.host,
+            port: config.port,
+            index_prefix: config.index_prefix,
+            index_type: config.index_type,
+            delivery_attempt_limit: config.delivery_attempt_limit,
+            flush_interval: config.flush_interval,
+        }
+    }
+
     fn flush_interval(&self) -> Option<u64> {
         Some(self.flush_interval)
     }

--- a/src/sink/firehose.rs
+++ b/src/sink/firehose.rs
@@ -61,7 +61,6 @@ pub struct Firehose {
 }
 
 impl Sink<FirehoseConfig> for Firehose {
-
     fn init(config: FirehoseConfig) -> Self {
         Firehose {
             buffer: Vec::new(),

--- a/src/sink/firehose.rs
+++ b/src/sink/firehose.rs
@@ -1,3 +1,5 @@
+//! Sink for AWS Firehose.
+
 use chrono::DateTime;
 use chrono::naive::NaiveDateTime;
 use chrono::offset::Utc;
@@ -58,11 +60,9 @@ pub struct Firehose {
     flush_interval: u64,
 }
 
-impl Firehose {
-    /// Create a new `Firehose`
-    ///
-    /// See documentation on `FirehoseConfig` for further details.
-    pub fn new(config: FirehoseConfig) -> Firehose {
+impl Sink<FirehoseConfig> for Firehose {
+
+    fn init(config: FirehoseConfig) -> Self {
         Firehose {
             buffer: Vec::new(),
             delivery_stream_name: config
@@ -73,9 +73,7 @@ impl Firehose {
             flush_interval: config.flush_interval,
         }
     }
-}
 
-impl Sink for Firehose {
     fn flush_interval(&self) -> Option<u64> {
         Some(self.flush_interval)
     }

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -103,7 +103,6 @@ where
 }
 
 impl InfluxDB {
-
     /// Convert the slice into a payload that can be sent to InfluxDB
     fn format_stats(&self, buffer: &mut String, telems: &[Telemetry]) -> () {
         use metric::AggregationMethod;
@@ -195,7 +194,6 @@ impl InfluxDB {
 }
 
 impl Sink<InfluxDBConfig> for InfluxDB {
-
     fn init(config: InfluxDBConfig) -> Self {
         let scheme = if config.secure { "https" } else { "http" };
         let uri = Url::parse(&format!(

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -309,7 +309,7 @@ mod test {
             tags: tags.clone(),
             flush_interval: 60,
         };
-        let mut influxdb = InfluxDB::new(&config);
+        let mut influxdb = InfluxDB::init(config);
         let dt_0 = Utc.ymd(1990, 6, 12).and_hms_milli(9, 10, 11, 00);
         let dt_1 = Utc.ymd(1990, 6, 12).and_hms_milli(9, 10, 12, 00);
         let dt_2 = Utc.ymd(1990, 6, 12).and_hms_milli(9, 10, 13, 00);

--- a/src/sink/kinesis.rs
+++ b/src/sink/kinesis.rs
@@ -94,6 +94,11 @@ impl Sink<KinesisConfig> for Kinesis {
     /// If the given record would put the buffer at capacity, then the contents
     /// are first flushed before the given record is added.
     fn deliver_raw(&mut self, _encoding: metric::Encoding, bytes: Vec<u8>) {
+        let record_too_big = bytes.len() > self.max_bytes_per_batch;
+        if record_too_big {
+            warn!("Discarding record with size {:?} as it is too large to publish!", bytes.len());
+        }
+
         let buffer_too_big = self.buffer_size + bytes.len() > self.max_bytes_per_batch;
         let buffer_too_long = self.buffer.len() > self.max_records_per_batch;;
         if buffer_too_big || buffer_too_long {

--- a/src/sink/kinesis.rs
+++ b/src/sink/kinesis.rs
@@ -1,0 +1,111 @@
+//! Kinesis sink for Raw events.
+
+extern crate base64;
+extern crate rusoto_core;
+extern crate rusoto_kinesis;
+
+use rusoto_core::default_tls_client;
+use rusoto_core::DefaultCredentialsProvider;
+use rusoto_kinesis::Kinesis as RusotoKinesis;
+
+use rusoto_kinesis::{KinesisClient, PutRecordInput, PutRecordError};
+
+use sink::Sink;
+use hyper;
+use metric;
+use metric::{LogLine, Telemetry};
+use std::ops::DerefMut;
+use std::sync;
+use util::Valve;
+
+/// Config options for Kinesis config.
+#[derive(Clone, Debug, Deserialize)]
+pub struct KinesisConfig {
+    stream_name: Option<String>,
+}
+
+impl Default for KinesisConfig {
+    fn default() -> KinesisConfig {
+        KinesisConfig {
+            stream_name: None,
+        }
+    }
+}
+
+/// Kinesis sink internal state.
+pub struct Kinesis {
+    client: Box<KinesisClient<DefaultCredentialsProvider, hyper::client::Client>>,
+
+    stream_name: String,
+}
+
+impl Sink<KinesisConfig> for Kinesis {
+
+    fn init(config: KinesisConfig) -> Self {
+        if config.stream_name.is_none() {
+            panic!("No Kinesis stream provided!");
+        };
+
+        let tls = default_tls_client().unwrap();
+        let provider = DefaultCredentialsProvider::new().unwrap();
+        let region = rusoto_core::region::default_region();
+        Kinesis {
+            client: Box::new(KinesisClient::new(tls, provider, region)),
+            stream_name: config.stream_name.unwrap(),
+        }
+    }
+
+    fn valve_state(&self) -> Valve {
+        // TODO - Something more clever.
+        Valve::Open
+    }
+
+    fn deliver(&mut self, _: sync::Arc<Option<Telemetry>>) -> () {
+        // Discard point
+    }
+
+    fn deliver_line(&mut self, _: sync::Arc<Option<LogLine>>) -> () {
+        // Discard line
+    }
+
+    fn deliver_raw(&mut self, _encoding: metric::Encoding, bytes: Vec<u8>) {
+        //  Try to publish to Kinesis
+        let client = self.client.deref_mut();
+        let input = PutRecordInput {
+            stream_name: self.stream_name.clone(),
+            data: base64::encode(&bytes).into_bytes(),
+            explicit_hash_key: None,
+            partition_key: String::from("foobar"),
+            sequence_number_for_ordering: None,
+        };
+
+        loop {
+            match client.put_record(&input) {
+                Ok(_output) => {
+                    // Nothing to see here.  All is well.
+                    break;
+                }
+
+                Err(PutRecordError::ProvisionedThroughputExceeded(_)) => {
+                    info!("Provisioned throughput exceeded on {:?}.  Retrying...", self.stream_name)
+                }
+
+                Err(err) => {
+                    panic!("Fatal exception during put_record: {:?}", err);
+                }
+            }
+        }
+    }
+
+    fn flush(&mut self) {
+        // We don't care about flushes.
+    }
+
+    fn flush_interval(&self) -> Option<u64> {
+        Some(1)
+    }
+
+    fn shutdown(self) -> () {
+        // Nothing to do as we don't batch internally.
+    }
+}

--- a/src/sink/kinesis.rs
+++ b/src/sink/kinesis.rs
@@ -160,7 +160,7 @@ impl Kinesis {
         self.buffer_size = 0;
         let mut buffer: Vec<PutRecordsRequestEntry> = self.buffer.drain(..).collect();
 
-        while buffer.len() > 0 {
+        while !buffer.is_empty() {
             let put_records_input = PutRecordsInput {
                 records: self.buffer.clone(),
                 stream_name: self.stream_name.clone(),
@@ -168,7 +168,7 @@ impl Kinesis {
 
             match self.client.put_records(&put_records_input) {
                 Ok(put_records_output) => {
-                    self.filter_successful(&mut buffer, put_records_output);
+                    self.filter_successful(&mut buffer, &put_records_output);
                     break;
                 }
 
@@ -192,7 +192,7 @@ impl Kinesis {
     pub fn filter_successful(
         &self,
         buffer: &mut Vec<PutRecordsRequestEntry>,
-        put_records_output: PutRecordsOutput,
+        put_records_output: &PutRecordsOutput,
     ) {
         if put_records_output.failed_record_count.is_none() {
             buffer.clear();

--- a/src/sink/kinesis.rs
+++ b/src/sink/kinesis.rs
@@ -21,15 +21,23 @@ use util::Valve;
 /// Config options for Kinesis config.
 #[derive(Clone, Debug, Deserialize)]
 pub struct KinesisConfig {
-    stream_name: Option<String>,
-    flush_interval: Option<u64>,
+    /// Canonical name for the given Kinesis sink.
+    pub config_path: Option<String>,
+    /// Region `stream_name` exists in.
+    pub region: rusoto_core::Region,
+    /// Kinesis stream identifier to publish to.
+    pub stream_name: Option<String>,
+    /// How often (seconds) the local buffer is published.  Default = 1 second.
+    pub flush_interval: u64,
 }
 
 impl Default for KinesisConfig {
     fn default() -> KinesisConfig {
         KinesisConfig {
+            config_path: None,
+            region: rusoto_core::region::default_region(),
             stream_name: None,
-            flush_interval: None
+            flush_interval: 1,
         }
     }
 }
@@ -59,8 +67,8 @@ impl Sink<KinesisConfig> for Kinesis {
 
         let tls = default_tls_client().unwrap();
         let provider = DefaultCredentialsProvider::new().unwrap();
-        let region = rusoto_core::region::default_region();
-        let flush_interval = if let Some(config_interval) = config.flush_interval { config_interval } else { 1 };
+        let region = config.region;
+        let flush_interval = config.flush_interval;
         let max_records = 1000;
         let max_bytes = 1 << 20; // 1MB
         Kinesis {

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -32,16 +32,15 @@ pub use self::null::{Null, NullConfig};
 pub use self::prometheus::{Prometheus, PrometheusConfig};
 pub use self::wavefront::{Wavefront, WavefrontConfig};
 
-
 /// Generic interface used to capture global sink configuration
 /// parameters as well as sink specific parameters.
 ///
 /// Stored configuration is consumed when the sink is spawned,
 /// resulting in a new thread executing the given sink.
 pub struct RunnableSink<S, SConfig>
-    where
-        S: Send + Sink<SConfig>,
-        SConfig: 'static + Send + Clone,
+where
+    S: Send + Sink<SConfig>,
+    SConfig: 'static + Send + Clone,
 {
     recv: hopper::Receiver<Event>,
     sources: Vec<String>,
@@ -52,12 +51,18 @@ pub struct RunnableSink<S, SConfig>
     config: PhantomData<SConfig>,
 }
 
-impl <S, SConfig> RunnableSink <S, SConfig> where S: 'static + Send + Sink<SConfig>, SConfig: 'static + Clone + Send
+impl<S, SConfig> RunnableSink<S, SConfig>
+where
+    S: 'static + Send + Sink<SConfig>,
+    SConfig: 'static + Clone + Send,
 {
-
-    /// Generic constructor for RunnableSink - execution wrapper around objects implementing Sink.
-    pub fn new (recv: hopper::Receiver<Event>, sources: Vec<String>, config: SConfig) -> RunnableSink<S, SConfig>
-    {
+    /// Generic constructor for RunnableSink - execution wrapper around objects
+    /// implementing Sink.
+    pub fn new(
+        recv: hopper::Receiver<Event>,
+        sources: Vec<String>,
+        config: SConfig,
+    ) -> RunnableSink<S, SConfig> {
         RunnableSink {
             recv: recv,
             sources: sources,
@@ -66,13 +71,12 @@ impl <S, SConfig> RunnableSink <S, SConfig> where S: 'static + Send + Sink<SConf
         }
     }
 
-    /// Spawns / consumes the given stateful sink, returning the corresponding thread.
+    /// Spawns / consumes the given stateful sink, returning the corresponding
+    /// thread.
     pub fn run(self) -> thread::ThreadHandle {
-        thread::spawn(
-            move |_poll| {
-                self.consume();
-            }
-        )
+        thread::spawn(move |_poll| {
+            self.consume();
+        })
     }
 
     fn consume(mut self) -> () //recv: hopper::Receiver<Event>, sources: Vec<String>, mut state: S) -> ()
@@ -128,7 +132,9 @@ impl <S, SConfig> RunnableSink <S, SConfig> where S: 'static + Send + Sink<SConf
                                 // every timer pulse we query the flush_interval
                                 // of the sink. If the interval and the idx
                                 // match up, we flush. Else, not.
-                                if let Some(flush_interval) = self.state.flush_interval() {
+                                if let Some(flush_interval) =
+                                    self.state.flush_interval()
+                                {
                                     if idx % flush_interval == 0 {
                                         self.state.flush();
                                     }
@@ -145,7 +151,7 @@ impl <S, SConfig> RunnableSink <S, SConfig> where S: 'static + Send + Sink<SConf
                             self.state.deliver_line(line);
                             break;
                         }
-                        Event::Raw{ encoding, bytes } => {
+                        Event::Raw { encoding, bytes } => {
                             self.state.deliver_raw(encoding, bytes);
                             break;
                         }
@@ -179,14 +185,16 @@ impl <S, SConfig> RunnableSink <S, SConfig> where S: 'static + Send + Sink<SConf
 
 /// A 'sink' is a sink for metrics.
 pub trait Sink<SConfig>
-    where
-        Self: 'static + Send + Sized,
-        SConfig: 'static + Send + Clone
+where
+    Self: 'static + Send + Sized,
+    SConfig: 'static + Send + Clone,
 {
-
     /// Generic constructor for sinks implementing this trait.
-    fn new(recv: hopper::Receiver<Event>, sources: Vec<String>, config: SConfig) -> RunnableSink<Self, SConfig>
-    {
+    fn new(
+        recv: hopper::Receiver<Event>,
+        sources: Vec<String>,
+        config: SConfig,
+    ) -> RunnableSink<Self, SConfig> {
         RunnableSink::<Self, SConfig>::new(recv, sources, config)
     }
 

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -33,7 +33,11 @@ pub use self::prometheus::{Prometheus, PrometheusConfig};
 pub use self::wavefront::{Wavefront, WavefrontConfig};
 
 
-/// Wrapper around a given sink implementation and its config.
+/// Generic interface used to capture global sink configuration
+/// parameters as well as sink specific parameters.
+///
+/// Stored configuration is consumed when the sink is spawned,
+/// resulting in a new thread executing the given sink.
 pub struct RunnableSink<S, SConfig>
     where
         S: Send + Sink<SConfig>,

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -12,11 +12,11 @@ use thread;
 use time;
 use util::Valve;
 
-pub mod console;
-pub mod firehose;
-pub mod null;
+mod console;
+mod firehose;
+mod null;
 pub mod wavefront;
-pub mod native;
+mod native;
 pub mod influxdb;
 pub mod prometheus;
 pub mod elasticsearch;

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -7,14 +7,15 @@
 use hopper;
 use metric::{Encoding, Event, LogLine, Telemetry};
 use std::sync;
+use thread;
 use time;
 use util::Valve;
 
-mod console;
-mod firehose;
-mod null;
+pub mod console;
+pub mod firehose;
+pub mod null;
 pub mod wavefront;
-mod native;
+pub mod native;
 pub mod influxdb;
 pub mod prometheus;
 pub mod elasticsearch;
@@ -28,42 +29,48 @@ pub use self::null::{Null, NullConfig};
 pub use self::prometheus::{Prometheus, PrometheusConfig};
 pub use self::wavefront::{Wavefront, WavefrontConfig};
 
-/// A 'sink' is a sink for metrics.
-pub trait Sink {
-    /// Lookup the `Sink`'s specific flush interval. This determines how often a
-    /// sink will obey the periodic flush pulse.
-    ///
-    /// If the value is `None` this is a signal that the sink will NEVER flush
-    /// EXCEPT in the case where the sink's valve_state is Closed.
-    fn flush_interval(&self) -> Option<u64>;
-    /// Perform the `Sink` specific flush. The rate at which this occurs is
-    /// determined by the global `flush_interval` or the sink specific flush
-    /// interval. Pulses occur at a rate of once per second, subject to
-    /// communication delays in the routing topology.
-    fn flush(&mut self) -> ();
-    /// Lookup the `Sink` valve state. See `Valve` documentation for more
-    /// information.
-    fn valve_state(&self) -> Valve;
-    /// Deliver a `Telemetry` to the `Sink`. Exact behaviour varies by
-    /// implementation.
-    fn deliver(&mut self, point: sync::Arc<Option<Telemetry>>) -> ();
-    /// Deliver a `LogLine` to the `Sink`. Exact behaviour varies by
-    /// implementation.
-    fn deliver_line(&mut self, line: sync::Arc<Option<LogLine>>) -> ();
-    /// Deliver a 'Raw' series of encoded bytes to the sink.
-    fn deliver_raw(&mut self, _encoding: Encoding, _bytes: Vec<u8>) -> () {
-        // Not all sinks accept raw events.  By default, we do nothing.
-        return;
+
+/// Wrapper around a given sink implementation and its config.
+pub struct StatefulSink<S, SConfig>
+    where
+        S: Send + Sync + Sink<SConfig>,
+        SConfig: 'static + Send + Sync + Clone,
+{
+    recv: hopper::Receiver<Event>,
+    sources: Vec<String>,
+    #[allow(dead_code)] // Only here to avoid using PhantomData.
+    config: SConfig,
+    state: S,
+}
+
+impl <S, SConfig> StatefulSink <S, SConfig> where S: 'static + Send + Sync + Sink<SConfig>, SConfig: 'static + Clone + Send + Sync
+{
+
+    /// Generic constructor for StatefulSink - execution wrapper around objects implementing Sink.
+    pub fn new (recv: hopper::Receiver<Event>, sources: Vec<String>, config: SConfig) -> StatefulSink<S, SConfig>
+    {
+        StatefulSink {
+            recv: recv,
+            sources: sources,
+            config: config.clone(),
+            state: S::init(config),
+        }
+
     }
-    /// Provide a hook to shutdown a sink. This is necessary for sinks which
-    /// have their own long-running threads.
-    fn shutdown(self) -> ();
-    /// The run-loop of the `Sink`. It's expect that few sinks will ever need to
-    /// provide their own implementation. Please take care to obey `Valve`
-    /// states and `flush_interval` configurations.
-    fn run(&mut self, recv: hopper::Receiver<Event>, sources: Vec<String>) {
+
+    /// Spawns / consumes the given stateful sink, returning the corresponding thread.
+    pub fn run(self) -> thread::ThreadHandle {
+        thread::spawn(
+            move |_poll| {
+                self.consume_loop();
+            }
+        )
+    }
+
+    fn consume_loop(mut self) -> () //recv: hopper::Receiver<Event>, sources: Vec<String>, mut state: S) -> ()
+    {
         let mut attempts = 0;
-        let mut recv = recv.into_iter();
+        let mut recv = self.recv.into_iter();
         let mut last_flush_idx = 0;
         let mut total_shutdowns = 0;
         // The run-loop of a sink is two nested loops. The outer loop pulls a
@@ -94,7 +101,7 @@ pub trait Sink {
                 // then we flush. If the flush_interval is Some and DOES NOT
                 // match then we do not flush. If the flush_interval is NONE
                 // then we never flush.
-                match self.valve_state() {
+                match self.state.valve_state() {
                     Valve::Open => match event {
                         Event::TimerFlush(idx) => {
                             // Flush timers are interesting. The timer thread
@@ -113,9 +120,9 @@ pub trait Sink {
                                 // every timer pulse we query the flush_interval
                                 // of the sink. If the interval and the idx
                                 // match up, we flush. Else, not.
-                                if let Some(flush_interval) = self.flush_interval() {
+                                if let Some(flush_interval) = self.state.flush_interval() {
                                     if idx % flush_interval == 0 {
-                                        self.flush();
+                                        self.state.flush();
                                     }
                                 }
                                 last_flush_idx = idx;
@@ -123,15 +130,15 @@ pub trait Sink {
                             break;
                         }
                         Event::Telemetry(metric) => {
-                            self.deliver(metric);
+                            self.state.deliver(metric);
                             break;
                         }
                         Event::Log(line) => {
-                            self.deliver_line(line);
+                            self.state.deliver_line(line);
                             break;
                         }
-                        Event::Raw { encoding, bytes } => {
-                            self.deliver_raw(encoding, bytes);
+                        Event::Raw{ encoding, bytes } => {
+                            self.state.deliver_raw(encoding, bytes);
                             break;
                         }
                         Event::Shutdown => {
@@ -145,18 +152,65 @@ pub trait Sink {
                             // from each of its
                             // upstream sources/filters.
                             total_shutdowns += 1;
-                            if total_shutdowns >= sources.len() {
-                                trace!("Received shutdown from every configured source: {:?}", sources);
+                            if total_shutdowns >= self.sources.len() {
+                                trace!("Received shutdown from every configured source: {:?}", self.sources);
+                                self.state.shutdown();
                                 return;
                             }
                         }
                     },
                     Valve::Closed => {
-                        self.flush();
+                        self.state.flush();
                         continue;
                     }
                 }
             }
         }
     }
+}
+
+/// A 'sink' is a sink for metrics.
+pub trait Sink<SConfig>
+    where
+        Self: 'static + Send + Sync + Sized,
+        SConfig: 'static + Send + Sync + Clone
+{
+
+    /// Generic constructor for sinks implementing this trait.
+    fn new(recv: hopper::Receiver<Event>, sources: Vec<String>, config: SConfig) -> StatefulSink<Self, SConfig>
+    {
+        StatefulSink::<Self, SConfig>::new(recv, sources, config)
+    }
+
+    /// Constructs a new sink.
+    fn init(config: SConfig) -> Self;
+
+    /// Lookup the `Sink`'s specific flush interval. This determines how often a
+    /// sink will obey the periodic flush pulse.
+    ///
+    /// If the value is `None` this is a signal that the sink will NEVER flush
+    /// EXCEPT in the case where the sink's valve_state is Closed.
+    fn flush_interval(&self) -> Option<u64>;
+    /// Perform the `Sink` specific flush. The rate at which this occurs is
+    /// determined by the global `flush_interval` or the sink specific flush
+    /// interval. Pulses occur at a rate of once per second, subject to
+    /// communication delays in the routing topology.
+    fn flush(&mut self) -> ();
+    /// Lookup the `Sink` valve state. See `Valve` documentation for more
+    /// information.
+    fn valve_state(&self) -> Valve;
+    /// Deliver a `Telemetry` to the `Sink`. Exact behaviour varies by
+    /// implementation.
+    fn deliver(&mut self, point: sync::Arc<Option<Telemetry>>) -> ();
+    /// Deliver a `LogLine` to the `Sink`. Exact behaviour varies by
+    /// implementation.
+    fn deliver_line(&mut self, line: sync::Arc<Option<LogLine>>) -> ();
+    /// Deliver a 'Raw' series of encoded bytes to the sink.
+    fn deliver_raw(&mut self, _encoding: Encoding, _bytes: Vec<u8>) -> () {
+        // Not all sinks accept raw events.  By default, we do nothing.
+        return;
+    }
+    /// Provide a hook to shutdown a sink. This is necessary for sinks which
+    /// have their own long-running threads.
+    fn shutdown(self) -> ();
 }

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -1,5 +1,6 @@
+//! Sink for Cernan's native protocol.
+
 use byteorder::{BigEndian, ByteOrder};
-use hopper;
 use metric;
 use protobuf::Message;
 use protobuf::repeated::RepeatedField;
@@ -30,7 +31,7 @@ pub struct Native {
 }
 
 /// Configuration for the native sink
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct NativeConfig {
     /// The port to communicate with the native host
     pub port: u16,
@@ -50,23 +51,6 @@ impl Default for NativeConfig {
             host: "localhost".to_string(),
             config_path: None,
             flush_interval: 60,
-        }
-    }
-}
-
-impl Native {
-    /// Create a new native sink
-    ///
-    /// Please see the documentation of NativeConfig for further details.
-    pub fn new(config: NativeConfig) -> Native {
-        let stream = connect(&config.host, config.port);
-        Native {
-            port: config.port,
-            host: config.host,
-            buffer: Vec::new(),
-            flush_interval: config.flush_interval,
-            delivery_attempts: 0,
-            stream: stream,
         }
     }
 }
@@ -98,54 +82,30 @@ fn connect(host: &str, port: u16) -> Option<TcpStream> {
     }
 }
 
-impl Sink for Native {
+impl Sink<NativeConfig> for Native {
+
+    fn init(config: NativeConfig) -> Self {
+        let stream = connect(&config.host, config.port);
+        Native {
+            port: config.port,
+            host: config.host,
+            buffer: Vec::new(),
+            flush_interval: config.flush_interval,
+            delivery_attempts: 0,
+            stream: stream,
+        }
+    }
+
     fn valve_state(&self) -> Valve {
         Valve::Open
     }
 
-    fn deliver(&mut self, _: sync::Arc<Option<metric::Telemetry>>) -> () {
-        // discard point
+    fn deliver(&mut self, telemetry: sync::Arc<Option<metric::Telemetry>>) -> () {
+        self.buffer.push(metric::Event::Telemetry(telemetry));
     }
 
-    fn deliver_line(&mut self, _: sync::Arc<Option<metric::LogLine>>) -> () {
-        // discard point
-    }
-
-    fn run(&mut self, recv: hopper::Receiver<metric::Event>, sources: Vec<String>) {
-        let mut attempts = 0;
-        let mut recv = recv.into_iter();
-        let mut last_flush_idx = 0;
-        let mut total_shutdowns = 0;
-        loop {
-            time::delay(attempts);
-            if self.buffer.len() > 10_000 {
-                attempts += 1;
-                continue;
-            }
-            match recv.next() {
-                None => attempts += 1,
-                Some(event) => {
-                    attempts = 0;
-                    match event {
-                        metric::Event::TimerFlush(idx) => if idx > last_flush_idx {
-                            if let Some(flush_interval) = self.flush_interval() {
-                                if idx % flush_interval == 0 {
-                                    self.flush();
-                                }
-                            }
-                            last_flush_idx = idx;
-                        },
-                        metric::Event::Shutdown => {
-                            total_shutdowns += 1;
-                            if total_shutdowns == sources.len() {
-                                return;
-                            }
-                        }
-                        _ => self.buffer.push(event),
-                    }
-                }
-            }
-        }
+    fn deliver_line(&mut self, line: sync::Arc<Option<metric::LogLine>>) -> () {
+        self.buffer.push(metric::Event::Log(line));
     }
 
     fn flush_interval(&self) -> Option<u64> {

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -83,7 +83,6 @@ fn connect(host: &str, port: u16) -> Option<TcpStream> {
 }
 
 impl Sink<NativeConfig> for Native {
-
     fn init(config: NativeConfig) -> Self {
         let stream = connect(&config.host, config.port);
         Native {

--- a/src/sink/null.rs
+++ b/src/sink/null.rs
@@ -1,3 +1,5 @@
+//! Sink equivalent of /dev/null.
+
 use metric::{LogLine, Telemetry};
 use sink::{Sink, Valve};
 use std::sync;
@@ -8,15 +10,8 @@ use std::sync;
 /// it receives will be deallocated.
 pub struct Null {}
 
-impl Null {
-    /// Create a new Null sink
-    pub fn new(_config: &NullConfig) -> Null {
-        Null {}
-    }
-}
-
 /// Configuration for the `Null` sink
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct NullConfig {
     /// The sink's unique name in the routing topology.
     pub config_path: String,
@@ -31,7 +26,12 @@ impl NullConfig {
     }
 }
 
-impl Sink for Null {
+impl Sink<NullConfig> for Null {
+
+    fn init(_config: NullConfig) -> Self {
+        Null {}
+    }
+
     fn valve_state(&self) -> Valve {
         Valve::Open
     }

--- a/src/sink/null.rs
+++ b/src/sink/null.rs
@@ -27,7 +27,6 @@ impl NullConfig {
 }
 
 impl Sink<NullConfig> for Null {
-
     fn init(_config: NullConfig) -> Self {
         Null {}
     }

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -380,7 +380,6 @@ fn connect(host: &str, port: u16) -> Option<TcpStream> {
 }
 
 impl Wavefront {
-
     /// Convert the buckets into a String that
     /// can be sent to the the wavefront proxy
     pub fn format_stats(&mut self) -> () {
@@ -566,7 +565,6 @@ impl Wavefront {
 }
 
 impl Sink<WavefrontConfig> for Wavefront {
-
     fn init(config: WavefrontConfig) -> Self {
         if config.host == "" {
             panic!("Host can not be empty".to_string());

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -73,7 +73,7 @@ pub struct Wavefront {
 /// Configuration for `wavefront`. The challenge of Wavefront is controlling
 /// point spreads emission and accuracy of aggregation. The knobs in this struct
 /// reflect that.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct WavefrontConfig {
     /// The width of aggregation bins. A `bin_width` of N will consider points
     /// with timestamps N seconds appart to have occured at the 'same time'.
@@ -380,27 +380,6 @@ fn connect(host: &str, port: u16) -> Option<TcpStream> {
 }
 
 impl Wavefront {
-    /// Create a new wavefront sink.
-    pub fn new(config: WavefrontConfig) -> Result<Wavefront, String> {
-        if config.host == "" {
-            return Err("Host can not be empty".to_string());
-        }
-        let stream = connect(&config.host, config.port);
-        Ok(Wavefront {
-            host: config.host,
-            port: config.port,
-            bin_width: config.bin_width,
-            aggrs: buckets::Buckets::new(config.bin_width),
-            delivery_attempts: 0,
-            percentiles: config.percentiles,
-            stats: String::with_capacity(8_192),
-            stream: stream,
-            flush_interval: config.flush_interval,
-            age_threshold: config.age_threshold,
-            last_seen: HashMap::default(),
-            pad_control: config.pad_control,
-        })
-    }
 
     /// Convert the buckets into a String that
     /// can be sent to the the wavefront proxy
@@ -586,7 +565,29 @@ impl Wavefront {
     }
 }
 
-impl Sink for Wavefront {
+impl Sink<WavefrontConfig> for Wavefront {
+
+    fn init(config: WavefrontConfig) -> Self {
+        if config.host == "" {
+            panic!("Host can not be empty".to_string());
+        }
+        let stream = connect(&config.host, config.port);
+        Wavefront {
+            host: config.host,
+            port: config.port,
+            bin_width: config.bin_width,
+            aggrs: buckets::Buckets::new(config.bin_width),
+            delivery_attempts: 0,
+            percentiles: config.percentiles,
+            stats: String::with_capacity(8_192),
+            stream: stream,
+            flush_interval: config.flush_interval,
+            age_threshold: config.age_threshold,
+            last_seen: HashMap::default(),
+            pad_control: config.pad_control,
+        }
+    }
+
     fn flush_interval(&self) -> Option<u64> {
         Some(self.flush_interval)
     }

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -986,7 +986,7 @@ mod test {
             pad_control: pad_control,
             age_threshold: None,
         };
-        let mut wavefront = Wavefront::new(config).unwrap();
+        let mut wavefront = Wavefront::init(config);
         let dt_0 = Utc.ymd(1990, 6, 12)
             .and_hms_milli(9, 10, 11, 00)
             .timestamp();

--- a/src/source/flush.rs
+++ b/src/source/flush.rs
@@ -10,7 +10,7 @@ use util::send;
 /// The source of all flush pulses.
 pub struct FlushTimer;
 
-/// Nil config for FlushTimer.
+/// Nil config for `FlushTimer`.
 #[derive(Clone, Debug, Deserialize)]
 pub struct FlushTimerConfig;
 

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -97,6 +97,7 @@ impl source::Source<InternalConfig> for Internal {
         Internal {}
     }
 
+    #[allow(cyclomatic_complexity)]
     fn run(
         self,
         mut chans: util::Channel,
@@ -427,7 +428,7 @@ impl source::Source<InternalConfig> for Internal {
                         );
                         while let Some(mut telem) = Q.pop() {
                             if !chans.is_empty() {
-                                telem = telem.overlay_tags_from_map(&tags);
+                                telem = telem.overlay_tags_from_map(tags);
                                 util::send(
                                     &mut chans,
                                     metric::Event::new_telemetry(telem),

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -383,6 +383,12 @@ impl source::Source<InternalConfig> for Internal {
                             chans
                         );
                         atom_non_zero_telem!(
+                            "cernan.sinks.kinesis.publish.discard",
+                            sink::kinesis::KINESIS_PUBLISH_DISCARD_SUM,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
                             "cernan.sinks.kinesis.publish.failure",
                             sink::kinesis::KINESIS_PUBLISH_FAILURE_SUM,
                             tags,

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -375,6 +375,25 @@ impl source::Source<InternalConfig> for Internal {
                             tags,
                             chans
                         );
+                        // sink::kinesis
+                        atom_non_zero_telem!(
+                            "cernan.sinks.kinesis.publish.success",
+                            sink::kinesis::KINESIS_PUBLISH_SUCCESS_SUM,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.kinesis.publish.failure",
+                            sink::kinesis::KINESIS_PUBLISH_FAILURE_SUM,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.sinks.kinesis.publish.fatal",
+                            sink::kinesis::KINESIS_PUBLISH_FATAL_SUM,
+                            tags,
+                            chans
+                        );
                         // filter::delay_filter
                         atom_non_zero_telem!(
                             "cernan.filters.delay.telemetry.accept",

--- a/src/source/tcp.rs
+++ b/src/source/tcp.rs
@@ -116,7 +116,7 @@ where
                 .unwrap();
         }
 
-        self.accept_loop(chans, tags, poller)
+        self.accept_loop(chans, tags, &poller)
     }
 }
 
@@ -128,7 +128,7 @@ where
         mut self,
         mut chans: util::Channel,
         tags: &sync::Arc<metric::TagMap>,
-        poll: mio::Poll,
+        poll: &mio::Poll,
     ) -> () {
         loop {
             let mut events = mio::Events::with_capacity(1024);
@@ -138,7 +138,7 @@ where
                     for event in events {
                         match event.token() {
                             constants::SYSTEM => {
-                                for handler in self.handlers.into_iter() {
+                                for handler in self.handlers {
                                     handler.shutdown();
                                 }
 


### PR DESCRIPTION
Bringing Sink semantics more "in line" with Source semantics:

* sink::Sink now implements a generic new function which generates a
so-called `RunnableSink`. `RunnableSink` exposes an API which allows
users to consume initial state and execute the corresponding Sink as a
thread.

* Implementing sinks are now required to implement an `init` function
rather than a new. This enables new to have a generic, default
implementation which returns `RunnableSink` constructs. `init` serves
the same function as the previous `new`, namely initializing local
state for the given sink.

* Native sink no longer implements its own run function.

A baseline Kinesis sink has been introduced which, currently, accepts only Raw events. This new sink publishes records in batch to Kinesis, bounded by time and space.