### PR TITLE
Fixes Graphite Consumption Regression.

### DIFF
--- a/src/source/graphite.rs
+++ b/src/source/graphite.rs
@@ -84,7 +84,7 @@ impl TCPStreamHandler for GraphiteStreamHandler {
                     match event.token() {
                         constants::SYSTEM => return,
                         _stream_token => {
-                            if let Ok(len) = line_reader.read_line(&mut line) {
+                            while let Ok(len) = line_reader.read_line(&mut line) {
                                 if len > 0 {
                                     if parse_graphite(&line, &mut res, &basic_metric) {
                                         assert!(!res.is_empty());


### PR DESCRIPTION
The mio event loops introduced since 0.8.6 brought with them a regression in
the Graphite source in which one metric is emitted per mio
readiness interval.

This change brings us back to the previous behavior wherein each EOF
delimited payload is parsed in its entirety before the Graphite source
returns to polling for System events.