### PR TITLE
Fixes Usage of read_exact in Avro Source

### DIFF
--- a/src/source/avro.rs
+++ b/src/source/avro.rs
@@ -187,6 +187,8 @@ impl AvroStreamHandler {
 
         // with_capacity is not enough for read_exact to function.
         // We must manually resize the underlying slice.
+        //
+        // See - https://doc.rust-lang.org/std/vec/struct.Vec.html#capacity-and-reallocation
         let mut buf = Vec::new();
         buf.resize(payload_size_in_bytes, 0);
         if reader.read_exact(&mut buf).is_err() {

--- a/src/source/avro.rs
+++ b/src/source/avro.rs
@@ -185,7 +185,10 @@ impl AvroStreamHandler {
             return Err(format!("Received payload is too small!"))
         }
 
-        let mut buf = Vec::with_capacity(payload_size_in_bytes);
+        // with_capacity is not enough for read_exact to function.
+        // We must manually resize the underlying slice.
+        let mut buf = Vec::new();
+        buf.resize(payload_size_in_bytes, 0);
         if reader.read_exact(&mut buf).is_err() {
             return Err(format!("Failed to read payload from the wire!"))
         }


### PR DESCRIPTION
We now manually resize the input Vec, which correctly sets the size of
the slice we expect.