### PR TITLE
Move to 0.8.8-pre, minor fiddling with kinesis sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cernan"
-version = "0.8.7"
+version = "0.8.8-pre"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,16 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.8.7"
+version = "0.8.8-pre"
 
 [[bin]]
 name = "cernan"
 doc = false
 
 [dependencies]
+base64 = "0.9.0"
 byteorder = "1.0"
+chan-signal = "0.3.1"
 chrono = "0.4"
 clap = "2.27"
 coco = "0.3"
@@ -24,11 +26,12 @@ fern = "0.5"
 flate2 = "1.0"
 glob = "0.2.11"
 hopper = "0.3"
-hyper = "0.10"
+hyper = "0.10" # 0.10 specifically required by rusoto_kinesis' KinesisClient
 lazy_static = "1.0"
 libc = "0.2"
 log = "0.4"
 lua = { git = "https://github.com/blt/rust-lua53.git", branch = "master" }
+mio = "0.6.11"
 openssl-probe = "0.1"
 protobuf = "1.4"
 quantiles = { version = "0.7", features = ["serde_support"] }
@@ -36,20 +39,17 @@ rand = "0.4"
 regex = "0.2"
 rusoto_core = "0.30"
 rusoto_firehose = "0.30"
+rusoto_kinesis = "0.30.0"
 seahash = "3.0"
 serde = { version = "1.0", features = ["rc"] }
+serde-avro = "0.5.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 slab = "0.4"
+tiny_http = "0.5.8"
 toml = "0.4"
 url = "1.6"
 uuid = {version = "0.5", features = ["v4"]}
-chan-signal = "0.3.1"
-mio = "0.6.11"
-tiny_http = "0.5.8"
-serde-avro = "0.5.0"
-base64 = "0.9.0"
-rusoto_kinesis = "0.30.0"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/sink/kinesis.rs
+++ b/src/sink/kinesis.rs
@@ -1,11 +1,7 @@
 //! Kinesis sink for Raw events.
-
-extern crate base64;
-extern crate rand;
-extern crate rusoto_core;
-extern crate rusoto_kinesis;
-
+use base64;
 use hyper;
+use rusoto_core;
 use metric;
 use metric::{LogLine, Telemetry};
 use rusoto_core::DefaultCredentialsProvider;


### PR DESCRIPTION
I'd hoped in this commit to update our hyper to 0.11 but we're stuck
on 0.10 until rusoto updates as well, since their kinesis type exposes
a trait that is only implemented for 0.10's Client. Ah well.

I removed some externs from src/sink/kinesis and plopped them at the
top of the cernan crate.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>