### PR TITLE
Use blt/mond, not blt/rust-lua53

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
  "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "mond 0.1.0 (git+https://github.com/blt/mond.git)",
+ "mond 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quantiles 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "mond"
 version = "0.1.0"
-source = "git+https://github.com/blt/mond.git#5028d86b4be0fdbba0a02e6e7802d7a64dfcda40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1998,7 +1998,7 @@ dependencies = [
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum mio 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "75f72a93f046f1517e3cfddc0a096eb756a2ba727d36edc8227dee769a50a9b0"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum mond 0.1.0 (git+https://github.com/blt/mond.git)" = "<none>"
+"checksum mond 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "55ba3d33d9d3328a600682e8685e1fdc3d43cd93f4d287105d7f9105b05036e1"
 "checksum nalgebra 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c8516d8710f28c64cfc75b274c75c55c967ad4ece7090521b3c065de1d12336b"
 "checksum native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04b781c9134a954c84f0594b9ab3f5606abc516030388e8511887ef4c204a1e5"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,11 +123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -180,8 +175,8 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lua 0.0.11 (git+https://github.com/blt/rust-lua53.git)",
  "mio 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mond 0.1.0 (git+https://github.com/blt/mond.git)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quantiles 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -817,16 +812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lua"
-version = "0.0.11"
-source = "git+https://github.com/blt/rust-lua53.git#44c0a8168e5fb2bd2f8292ca8966e6372e7a7c7e"
-dependencies = [
- "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "matches"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +895,16 @@ dependencies = [
  "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mond"
+version = "0.1.0"
+source = "git+https://github.com/blt/mond.git#5028d86b4be0fdbba0a02e6e7802d7a64dfcda40"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1918,7 +1913,6 @@ dependencies = [
 "checksum bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9a6301db0b49fb63551bc15b5ae348147101cdf323242b93ec7546d5002ff1af"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
-"checksum bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a6577517ecd0ee0934f48a7295a89aaef3e6dfafeac404f94c0b3448518ddfe"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e90dc84f5e62d2ebe7676b83c22d33b6db8bd27340fb6ffbff0a364efa0cb9c9"
@@ -1995,7 +1989,6 @@ dependencies = [
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
-"checksum lua 0.0.11 (git+https://github.com/blt/rust-lua53.git)" = "<none>"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum matrixmultiply 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cac1a66eab356036af85ea093101a14223dc6e3f4c02a59b7d572e5b93270bf7"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
@@ -2005,6 +1998,7 @@ dependencies = [
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum mio 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "75f72a93f046f1517e3cfddc0a096eb756a2ba727d36edc8227dee769a50a9b0"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum mond 0.1.0 (git+https://github.com/blt/mond.git)" = "<none>"
 "checksum nalgebra 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c8516d8710f28c64cfc75b274c75c55c967ad4ece7090521b3c065de1d12336b"
 "checksum native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04b781c9134a954c84f0594b9ab3f5606abc516030388e8511887ef4c204a1e5"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ hyper = "0.10" # 0.10 specifically required by rusoto_kinesis' KinesisClient
 lazy_static = "1.0"
 libc = "0.2"
 log = "0.4"
-lua = { git = "https://github.com/blt/rust-lua53.git", branch = "master" }
+mond = { git = "https://github.com/blt/mond.git", branch = "master" }
 mio = "0.6.11"
 openssl-probe = "0.1"
 protobuf = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ hyper = "0.10" # 0.10 specifically required by rusoto_kinesis' KinesisClient
 lazy_static = "1.0"
 libc = "0.2"
 log = "0.4"
-mond = { git = "https://github.com/blt/mond.git", branch = "master" }
+mond = "0.1"
 mio = "0.6.11"
 openssl-probe = "0.1"
 protobuf = "1.4"

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -1,8 +1,8 @@
 use filter;
 use libc::c_int;
-use lua;
-use lua::{Function, State, ThreadStatus};
-use lua::ffi::lua_State;
+use mond;
+use mond::{Function, State, ThreadStatus};
+use mond::ffi::lua_State;
 use metric;
 use std::path::PathBuf;
 use std::sync;
@@ -87,7 +87,7 @@ impl<'a> Payload<'a> {
 
     #[allow(non_snake_case)]
     unsafe extern "C" fn lua_push_metric(L: *mut lua_State) -> c_int {
-        let mut state = State::from_ptr(L);
+        let state = State::from_ptr(L);
         let pyld = state.to_userdata(1) as *mut Payload;
         let val = state.to_number(3);
         match state.to_str(2) {
@@ -109,7 +109,7 @@ impl<'a> Payload<'a> {
 
     #[allow(non_snake_case)]
     unsafe extern "C" fn lua_clear_metrics(L: *mut lua_State) -> c_int {
-        let mut state = State::from_ptr(L);
+        let state = State::from_ptr(L);
         let pyld = state.to_userdata(1) as *mut Payload;
         (*pyld).metrics.clear();
         0
@@ -117,7 +117,7 @@ impl<'a> Payload<'a> {
 
     #[allow(non_snake_case)]
     unsafe extern "C" fn lua_push_log(L: *mut lua_State) -> c_int {
-        let mut state = State::from_ptr(L);
+        let state = State::from_ptr(L);
         let pyld = state.to_userdata(1) as *mut Payload;
         match state.to_str(2) {
             Some(line) => {
@@ -134,7 +134,7 @@ impl<'a> Payload<'a> {
 
     #[allow(non_snake_case)]
     unsafe extern "C" fn lua_clear_logs(L: *mut lua_State) -> c_int {
-        let mut state = State::from_ptr(L);
+        let state = State::from_ptr(L);
         let pyld = state.to_userdata(1) as *mut Payload;
         (*pyld).logs.clear();
         0
@@ -405,7 +405,7 @@ const PAYLOAD_LIB: [(&str, Function); 16] = [
 /// The programmable filter is a general purpose filter that can be programmed
 /// by end-users with a lua script.
 pub struct ProgrammableFilter {
-    state: lua::State,
+    state: mond::State,
     path: String,
     global_tags: metric::TagMap,
     last_flush_idx: u64,
@@ -441,7 +441,7 @@ impl Default for ProgrammableFilterConfig {
 impl ProgrammableFilter {
     /// Create a new ProgrammableFilter
     pub fn new(config: ProgrammableFilterConfig) -> ProgrammableFilter {
-        let mut state = lua::State::new();
+        let mut state = mond::State::new();
         state.open_libs();
 
         state.get_global("package");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ extern crate glob;
 extern crate hopper;
 extern crate hyper;
 extern crate libc;
-extern crate lua;
+extern crate mond;
 extern crate mio;
 extern crate protobuf;
 extern crate quantiles;


### PR DESCRIPTION
This commit moves cernan to use a more serious fork of the rust-lua53
library that we've historically used. The intention is for mond to
land in crates, then for cernan to also be available in crates again.
There's changes to mond that we'll make to better support cernan, as
well.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>