### PR TITLE
value -> valve

### DIFF
--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -310,7 +310,7 @@ impl source::Source<InternalConfig> for Internal {
                             chans
                         );
                         atom_non_zero_telem!(
-                            "cernan.sinks.wavefront.value.closed",
+                            "cernan.sinks.wavefront.valve.closed",
                             sink::wavefront::WAVEFRONT_VALVE_CLOSED,
                             tags,
                             chans


### PR DESCRIPTION
The correct spelling of cernan.sinks.wavefront.value.closed is
cernan.sinks.wavefront.valve.closed. This commit just flips that
one character as appropriate.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>