### PR TITLE
Correct bin_width goof in Wavefront sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cernan"
-version = "0.8.8"
+version = "0.8.9-pre"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -82,9 +82,12 @@ impl Buckets {
     /// ```
     /// extern crate cernan;
     ///
-    /// let metric =
-    /// cernan::metric::Telemetry::new().name("foo").value(1.0).kind(cernan::
-    /// metric::AggregationMethod::Sum).harden().unwrap();
+    /// let metric = cernan::metric::Telemetry::new()
+    ///     .name("foo")
+    ///     .value(1.0)
+    ///     .kind(cernan::metric::AggregationMethod::Sum)
+    ///     .harden()
+    ///     .unwrap();
     /// let mut buckets = cernan::buckets::Buckets::default();
     ///
     /// assert_eq!(true, buckets.is_empty());
@@ -131,9 +134,12 @@ impl Buckets {
     /// ```
     /// extern crate cernan;
     ///
-    /// let metric =
-    /// cernan::metric::Telemetry::new().name("foo").value(1.0).kind(cernan::
-    /// metric::AggregationMethod::Sum).harden().unwrap();
+    /// let metric = cernan::metric::Telemetry::new()
+    ///     .name("foo")
+    ///     .value(1.0)
+    ///     .kind(cernan::metric::AggregationMethod::Sum)
+    ///     .harden()
+    ///     .unwrap();
     /// let mut bucket = cernan::buckets::Buckets::default();
     /// bucket.add(metric);
     /// ```
@@ -206,6 +212,11 @@ impl Buckets {
             key_index: 0,
             value_index: 0,
         }
+    }
+
+    #[cfg(test)]
+    pub fn bin_width(&self) -> i64 {
+        self.bin_width
     }
 }
 
@@ -431,9 +442,7 @@ mod test {
                     "DID NOT FIND ONE FOR {:?} |::|::| MODEL: {:?}
     |::|::| SUT: \
                                    {:?}",
-                    v,
-                    mp,
-                    ms
+                    v, mp, ms
                 );
             }
             TestResult::passed()


### PR DESCRIPTION
It turns out we were incorrectly dropping the bin_width configuration
passed into the Wavefront sink after a format_stats run. This is now
corrected and tested for.

Much thanks to @benley for the catch.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>