### PR TITLE
Warn if Wavefront bin_width > flush_interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cernan"
-version = "0.8.9"
+version = "0.8.10-pre"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.8.9"
+version = "0.8.10-pre"
 
 [[bin]]
 name = "cernan"

--- a/src/config.rs
+++ b/src/config.rs
@@ -483,6 +483,9 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                         as u64
                 })
                 .unwrap_or(args.flush_interval);
+            if res.bin_width > (res.flush_interval as i64) {
+                warn!("bin_width > flush_interval. bin_width will be effectively flush_interval due to flush behaviour.")
+            }
 
             res.tags = global_tags.clone();
 


### PR DESCRIPTION
When a flush happens in the Wavefront sink the aggregations held in
Bucket are flushed. This means that the bin_width of any aggregation
is effectively min(bin_width, flush_interval). That's surprising
and, previously, there was no warning of this.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>