### PR TITLE
Resolve space explosion in the native source

### DIFF
--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -125,9 +125,7 @@ impl Sink<NativeConfig> for Native {
                         metric::AggregationMethod::Histogram => AggregationMethod::BIN,
                         metric::AggregationMethod::Sum => AggregationMethod::SUM,
                         metric::AggregationMethod::Set => AggregationMethod::SET,
-                        metric::AggregationMethod::Summarize => {
-                            AggregationMethod::SUMMARIZE
-                        }
+                        metric::AggregationMethod::Summarize => AggregationMethod::SUMMARIZE,
                     };
                     let persist = m.persist;
                     telem.set_persisted(persist);

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -156,6 +156,19 @@ impl source::Source<InternalConfig> for Internal {
                             tags,
                             chans
                         );
+                        // source::native
+                        atom_non_zero_telem!(
+                            "cernan.native.payload.success",
+                            source::native::NATIVE_PAYLOAD_SUCCESS_SUM,
+                            tags,
+                            chans
+                        );
+                        atom_non_zero_telem!(
+                            "cernan.native.payload.parse.failure",
+                            source::native::NATIVE_PAYLOAD_PARSE_FAILURE_SUM,
+                            tags,
+                            chans
+                        );
                         // source::avro
                         atom_non_zero_telem!(
                             "cernan.avro.payload.success",


### PR DESCRIPTION
For reasons unknown when we spew tons of packets into the
native source a small percentage -- around 1% -- will fail to
parse. Previously we did not correctly signal to the streaming
loop that a parse failure had happened, resulting in reading
nonsense offsets off the wire. As a result, we allocated a massive
amount of buffer space and blew up clients.

The allocation issue is now corrected. The parse problem is not.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>