### PR TITLE
Removes Undesirable Panics From statsd/tcp Sources.

### DIFF
--- a/src/source/graphite.rs
+++ b/src/source/graphite.rs
@@ -79,7 +79,7 @@ impl TCPStreamHandler for GraphiteStreamHandler {
         loop {
             let mut events = mio::Events::with_capacity(1024);
             match poller.poll(&mut events, None) {
-                Err(e) => panic!(format!("Failed during poll {:?}", e)),
+                Err(e) => panic!("Failed during poll {:?}", e),
                 Ok(_num_events) => for event in events {
                     match event.token() {
                         constants::SYSTEM => return,

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -81,7 +81,7 @@ impl TCPStreamHandler for NativeStreamHandler {
         while streaming {
             let mut events = mio::Events::with_capacity(1024);
             match poller.poll(&mut events, None) {
-                Err(e) => panic!(format!("Failed during poll {:?}", e)),
+                Err(e) => panic!("Failed during poll {:?}", e),
                 Ok(_num_events) => {
                     for event in events {
                         match event.token() {

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -172,14 +172,19 @@ impl source::Source<StatsdConfig> for Statsd {
         poller: mio::Poll,
     ) -> () {
         for (idx, socket) in self.conns.iter() {
-            poller
+            match poller
                 .register(
                     socket,
                     mio::Token::from(idx),
                     mio::Ready::readable(),
                     mio::PollOpt::edge(),
                 )
-                .unwrap();
+            {
+                Ok(_) => {}
+                Err(e) => {
+                    error!("Failed to register {:?} - {:?}!", socket, e);
+                }
+            }
         }
 
         let mut buf = vec![0; 16_250];

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -88,15 +88,19 @@ impl Default for StatsdConfig {
     }
 }
 
+enum StatsdHandlerErr {
+    Fatal,
+}
+
+
 impl Statsd {
     fn handle_datagrams(
-        &mut self,
+        & self,
         mut chans: &mut util::Channel,
         tags: &sync::Arc<metric::TagMap>,
-        token: mio::Token,
+        socket: &mio::net::UdpSocket,
         mut buf: &mut Vec<u8>,
-    ) {
-        let socket = &self.conns[token];
+    ) -> Result<(), StatsdHandlerErr>{
         let mut metrics = Vec::new();
         let basic_metric = sync::Arc::new(Some(
             metric::Telemetry::default().overlay_tags_from_map(tags),
@@ -127,14 +131,13 @@ impl Statsd {
                         break;
                     }
                     _ => {
-                        panic!(format!(
-                            "Could not read UDP socket with error {:?}",
-                            e
-                        ));
+                        error!("Could not read UDP socket with error {:?}", e);
+                        return Err(StatsdHandlerErr::Fatal);
                     }
                 },
             }
         }
+        return Ok(())
     }
 }
 
@@ -164,7 +167,7 @@ impl source::Source<StatsdConfig> for Statsd {
     }
 
     fn run(
-        mut self,
+        self,
         mut chans: util::Channel,
         tags: &sync::Arc<metric::TagMap>,
         poller: mio::Poll,
@@ -192,7 +195,14 @@ impl source::Source<StatsdConfig> for Statsd {
                         }
 
                         token => {
-                            self.handle_datagrams(&mut chans, tags, token, &mut buf);
+                            let mut socket = &self.conns[token];
+                            match self.handle_datagrams(&mut chans, tags, &socket, &mut buf) {
+                                Ok(_) => {}
+                                Err(_fatal) => {
+                                    error!("Deregistering {:?} due to unrecoverable error!", *socket);
+                                    let _ = poller.deregister(socket);
+                                }
+                            }
                         }
                     }
                 },

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -92,15 +92,14 @@ enum StatsdHandlerErr {
     Fatal,
 }
 
-
 impl Statsd {
     fn handle_datagrams(
-        & self,
+        &self,
         mut chans: &mut util::Channel,
         tags: &sync::Arc<metric::TagMap>,
         socket: &mio::net::UdpSocket,
         mut buf: &mut Vec<u8>,
-    ) -> Result<(), StatsdHandlerErr>{
+    ) -> Result<(), StatsdHandlerErr> {
         let mut metrics = Vec::new();
         let basic_metric = sync::Arc::new(Some(
             metric::Telemetry::default().overlay_tags_from_map(tags),
@@ -137,7 +136,7 @@ impl Statsd {
                 },
             }
         }
-        return Ok(())
+        return Ok(());
     }
 }
 
@@ -196,7 +195,12 @@ impl source::Source<StatsdConfig> for Statsd {
 
                         token => {
                             let mut socket = &self.conns[token];
-                            match self.handle_datagrams(&mut chans, tags, &socket, &mut buf) {
+                            match self.handle_datagrams(
+                                &mut chans,
+                                tags,
+                                &socket,
+                                &mut buf,
+                            ) {
                                 Ok(_) => {}
                                 Err(_fatal) => {
                                     error!("Deregistering {:?} due to unrecoverable error!", *socket);

--- a/src/source/tcp.rs
+++ b/src/source/tcp.rs
@@ -193,7 +193,7 @@ where
                     self.handlers.push(new_stream);
                 }
                 Err(e) => match e.kind() {
-                    ErrorKind::ConnectionAborted | ErrorKind::Interrupted | ErrorKind::Timedout => {
+                    ErrorKind::ConnectionAborted | ErrorKind::Interrupted | ErrorKind::TimedOut => {
                         // Connection was closed before we could accept or
                         // we were interrupted. Press on.
                         continue;

--- a/src/source/tcp.rs
+++ b/src/source/tcp.rs
@@ -200,7 +200,7 @@ where
                     handlers.push(new_stream);
                 }
                 Err(e) => match e.kind() {
-                    ErrorKind::ConnectionAborted | ErrorKind::Interrupted => {
+                    ErrorKind::ConnectionAborted | ErrorKind::Interrupted | ErrorKind::Timedout => {
                         // Connection was closed before we could accept or
                         // we were interrupted. Press on.
                         continue;

--- a/src/source/tcp.rs
+++ b/src/source/tcp.rs
@@ -106,7 +106,7 @@ where
         poller: mio::Poll,
     ) -> () {
         for (idx, listener) in self.listeners.iter() {
-            match poller
+            if let Err(e) = poller
                 .register(
                     listener,
                     mio::Token::from(idx),
@@ -114,10 +114,7 @@ where
                     mio::PollOpt::edge(),
                 )
             {
-                Ok(_) => {}
-                Err(e) => {
-                    error!("Failed to register {:?} - {:?}!", socket, e);
-                }
+                error!("Failed to register {:?} - {:?}!", listener, e);
             }
         }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,7 +7,7 @@ use seahash::SeaHasher;
 use slab;
 use std::collections;
 use std::hash;
-use std::ops::Index;
+use std::ops::{Index, IndexMut};
 
 /// Cernan hashmap
 ///
@@ -78,6 +78,12 @@ impl<E: mio::Evented> Index<mio::Token> for TokenSlab<E> {
     /// Returns Evented object corresponding to Token.
     fn index(&self, token: mio::Token) -> &E {
         &self.tokens[token_to_idx(&token)]
+    }
+}
+
+impl<E: mio::Evented> IndexMut<mio::Token> for TokenSlab<E> {
+    fn index_mut(&mut self, token: mio::Token) -> &mut E {
+        &mut self.tokens[token_to_idx(&token)]
     }
 }
 


### PR DESCRIPTION
In order to support graceful shutdown, we require sources to be durable
in the presence of errors.  This change alters the following failure
scenarios:

* A tcp source fails to spawn a stream handler thread - instead of
panicking we now remove listener interfaces.  Effectively shutting down
the listener, reducing it to listening only for System events.

* A udp source fails to read from its socket - instead of panicking when a udp
socket operation returned an unsupported error, we now remove that
interface from the mio poller.  Allowing the source to still respond to
System events.

Note - file_server contains many `except`s and has not been addressed in
this PR.  I feel a specific refactoring is in order for file_server.

Lastly, sources continue to panic should polling for mio events ever
fails.  This is justified as without an ability to poll for mio events
the system cannot fulfill its mission.