### PR TITLE
Add new filter json_encode to convert loglines to json-encoded raw

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1812,6 +1812,25 @@ scripts-directory = "/foo/bar"
     }
 
     #[test]
+    fn config_filters_json_encode() {
+        let config = r#"
+    [filters]
+        [filters.json_encode.test]
+        parse_line = true
+        forwards = ["sinks.console"]
+    "#;
+
+        let args = parse_config_file(config, 4);
+        assert!(args.json_encode_filters.is_some());
+        let filters = args.json_encode_filters.unwrap();
+
+        let config0: &JSONEncodeFilterConfig =
+            filters.get("filters.json_encode.test").unwrap();
+        assert_eq!(config0.parse_line, true);
+        assert_eq!(config0.forwards, vec!["sinks.console"]);
+    }
+
+    #[test]
     fn config_file_wavefront_sinks_style() {
         let config = r#"
     [sinks]

--- a/src/filter/json_encode_filter.rs
+++ b/src/filter/json_encode_filter.rs
@@ -1,0 +1,137 @@
+//! Convert LogLine events into Raw events encoded as JSON.
+//!
+//! This filter takes LogLines and encodes them into JSON, emitting the encoded
+//! event as a Raw event. This allows further filters or sinks to operate on the
+//! JSON without needing to understand a LogLine event in particular.
+//! If the LogLine value is a valid JSON object and parse_line config option is true,
+//! then the JSON will be merged with LogLine metadata. Otherwise, the original line
+//! will be included simply as a string.
+
+use chrono::DateTime;
+use chrono::naive::NaiveDateTime;
+use chrono::offset::Utc;
+use filter;
+use metric;
+use metric::TagMap;
+use rand::random;
+use serde_json;
+use serde_json::Value;
+use serde_json::map::Map;
+use std::iter::FromIterator;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+lazy_static! {
+    /// Total number of logline processed
+    pub static ref JSON_ENCODE_LOG_PROCESSED: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    /// Total number of logline with JSON value successfully parsed
+    pub static ref JSON_ENCODE_LOG_PARSED: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+}
+
+impl From<TagMap> for Map<String, Value> {
+    fn from(tagmap: TagMap) -> Self {
+        Map::from_iter(
+            tagmap.into_iter().map(|(k, v)| (k.clone(), v.clone().into()))
+        )
+    }
+}
+
+/// Convert LogLine events into Raw events encoded as JSON.
+///
+/// This filter takes LogLines and encodes them into JSON, emitting the encoded
+/// event as a Raw event. This allows further filters or sinks to operate on the
+/// JSON without needing to understand a LogLine event in particular.
+/// If the LogLine value is a valid JSON object and parse_line config option is true,
+/// then the JSON will be merged with LogLine metadata. Otherwise, the original line
+/// will be included simply as a string.
+pub struct JSONEncodeFilter {
+    parse_line: bool,
+}
+
+/// Configuration for `JSONEncodeFilter`
+#[derive(Clone, Debug)]
+pub struct JSONEncodeFilterConfig {
+    /// The filter's unique name in the routing topology.
+    pub config_path: Option<String>,
+    /// The forwards along which the filter will emit its `metric::Event`s.
+    pub forwards: Vec<String>,
+    /// Whether the filter should attempt to parse LogLine values that are valid JSON objects.
+    pub parse_line: bool,
+}
+
+impl JSONEncodeFilter {
+    /// Create a new JSONEncodeFilter
+    pub fn new(config: &JSONEncodeFilterConfig) -> JSONEncodeFilter {
+        JSONEncodeFilter {
+            parse_line: config.parse_line,
+        }
+    }
+}
+
+impl filter::Filter for JSONEncodeFilter {
+    fn process(
+        &mut self,
+        event: metric::Event,
+        res: &mut Vec<metric::Event>,
+    ) -> Result<(), filter::FilterError> {
+        match event {
+            metric::Event::Log(l) => if let Some(ref log) = *l {
+                let naive_time = NaiveDateTime::from_timestamp(log.time, 0);
+                let utc_time: DateTime<Utc> = DateTime::from_utc(naive_time, Utc);
+                let metadata = json_to_object(json!({
+                    "time": utc_time.to_rfc3339(),
+                    "path": log.path.clone(),
+                    "tags": Map::from(log.tags.clone()),
+                }));
+                // If parse_line is true, and line is parsable as a JSON object, parse it.
+                // Otherwise get an object containing the original line.
+                let value = (if self.parse_line { Some(()) } else { None })
+                    .and_then(|_| serde_json::from_str::<Value>(&log.value).ok())
+                    .and_then(|v| if let Value::Object(obj) = v { Some(obj) } else { None })
+                    .map(|v| { JSON_ENCODE_LOG_PARSED.fetch_add(1, Ordering::Relaxed); v })
+                    .unwrap_or_else(|| json_to_object(json!({"message": log.value.clone()})));
+                // Combine our various sources of data.
+                // Data that is more likely to be correct (more specific to the source) overrides
+                // other data. So the parsed value is authoritative, followed by any fields we could
+                // parse by filters, then finally the metadata we were able to work out on our own.
+                let value = merge_objects(&[value, log.fields.clone().into(), metadata]);
+                res.push(metric::Event::Raw {
+                    order_by: random(),
+                    encoding: metric::Encoding::JSON,
+                    bytes: serde_json::to_string(&value).unwrap().into(), // serde_json::Value will never fail to encode
+                });
+                JSON_ENCODE_LOG_PROCESSED.fetch_add(1, Ordering::Relaxed);
+            },
+            // All other event types are passed through.
+            event => {
+                res.push(event);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Convenience helper to take a json!() macro you know is an object and get back a Map<String, Value>,
+/// instead of a generic Value.
+fn json_to_object(v: Value) -> Map<String, Value>  {
+    if let Value::Object(obj) = v {
+        obj
+    } else {
+        unreachable!()
+    }
+}
+
+/// Merge JSON objects, with values from earlier objects in the list overriding later ones.
+/// Note this is not a recursive merge - if the same key is in many objects, we simply take
+/// the value from the earliest one.
+fn merge_objects(objs: &[Map<String, Value>]) -> Map<String, Value> {
+    let mut result = Map::new();
+    for obj in objs {
+        for key in obj.keys() {
+            if !result.contains_key(key) {
+                result.insert(key.clone(), obj[key].clone());
+            }
+        }
+    };
+    result
+}

--- a/src/filter/json_encode_filter.rs
+++ b/src/filter/json_encode_filter.rs
@@ -143,6 +143,7 @@ mod test {
     use super::*;
     use filter::Filter;
     use metric;
+    use quickcheck::QuickCheck;
     use serde_json::Value;
     use serde_json::map::Map;
 
@@ -245,8 +246,9 @@ mod test {
         ).collect()
     }
 
-    quickcheck! {
-        fn merged_objects_contain_all_keys(vecs: Vec<Vec<(String, String)>>) -> bool {
+    #[test]
+    fn merged_objects_contain_all_keys() {
+        fn inner(vecs: Vec<Vec<(String, String)>>) -> bool {
             let result = merge_objects(vecs_to_objs(&vecs).as_slice());
             for obj in vecs {
                 for (k, _v) in obj {
@@ -257,8 +259,12 @@ mod test {
             }
             true
         }
+        QuickCheck::new().quickcheck(inner as fn(Vec<Vec<(String, String)>>) -> bool);
+    }
 
-        fn merged_objects_takes_first_value(vecs: Vec<Vec<(String, String)>>) -> bool {
+    #[test]
+    fn merged_objects_takes_first_value() {
+        fn inner(vecs: Vec<Vec<(String, String)>>) -> bool {
             let objs = vecs_to_objs(&vecs);
             let result = merge_objects(objs.as_slice());
             for (key, result_value) in result {
@@ -271,5 +277,6 @@ mod test {
             }
             true
         }
+        QuickCheck::new().quickcheck(inner as fn(Vec<Vec<(String, String)>>) -> bool);
     }
 }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -13,9 +13,11 @@ use util;
 mod programmable_filter;
 pub mod delay_filter;
 mod flush_boundary_filter;
+pub mod json_encode_filter;
 
 pub use self::delay_filter::{DelayFilter, DelayFilterConfig};
 pub use self::flush_boundary_filter::{FlushBoundaryFilter, FlushBoundaryFilterConfig};
+pub use self::json_encode_filter::{JSONEncodeFilter, JSONEncodeFilterConfig};
 pub use self::programmable_filter::{ProgrammableFilter, ProgrammableFilterConfig};
 
 /// Errors that can strike a Filter

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,6 @@ extern crate lazy_static;
 extern crate serde_derive;
 
 #[cfg(test)]
-#[macro_use]
 extern crate quickcheck;
 
 pub mod sink;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ extern crate mio;
 extern crate mond;
 extern crate protobuf;
 extern crate quantiles;
+extern crate rand;
 extern crate rdkafka;
 extern crate regex;
 extern crate rusoto_core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ extern crate lazy_static;
 extern crate serde_derive;
 
 #[cfg(test)]
+#[macro_use]
 extern crate quickcheck;
 
 pub mod sink;

--- a/src/metric/event.rs
+++ b/src/metric/event.rs
@@ -8,6 +8,8 @@ pub enum Encoding {
     Raw,
     /// Avro
     Avro,
+    /// JSON
+    JSON,
 }
 
 /// Event: the central cernan datastructure

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -483,6 +483,19 @@ impl source::Source<InternalConfig> for Internal {
                             tags,
                             chans
                         );
+                        // filter::json_encode_filter
+                        atom_telem!(
+                            "cernan.filters.json_encode.log.processed",
+                            filter::json_encode_filter::JSON_ENCODE_LOG_PROCESSED,
+                            tags,
+                            chans
+                        );
+                        atom_telem!(
+                            "cernan.filters.json_encode.log.parsed",
+                            filter::json_encode_filter::JSON_ENCODE_LOG_PARSED,
+                            tags,
+                            chans
+                        );
                         while let Some(mut telem) = Q.pop() {
                             if !chans.is_empty() {
                                 telem = telem.overlay_tags_from_map(tags);


### PR DESCRIPTION
It will also optionally try to parse the log line as JSON and include
that at the top level.

This is needed for our structured logging so we can emit json
to disk and have cernan forward it to kafka.