### PR TITLE
Force release builds to abort on panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cernan"
-version = "0.8.12"
+version = "0.8.13-pre"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.8.12"
+version = "0.8.13-pre"
 
 [[bin]]
 name = "cernan"
@@ -66,6 +66,7 @@ codegen-units = 4
 [profile.release]
 lto = true
 codegen-units = 1
+panic = "abort"
 
 [[bench]]
 name = "buckets"


### PR DESCRIPTION
This corrects #406. As @pulltab notes there's a cleaner way of
recovering from internal failures but we'll opt for now to let
the init system or what not catch us when we fall.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>