### PR TITLE
Update hopper to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "hopper 0.4.0-pre (git+https://github.com/postmates/hopper.git?branch=ingress_shedding)",
+ "hopper 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -695,8 +695,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hopper"
-version = "0.4.0-pre"
-source = "git+https://github.com/postmates/hopper.git?branch=ingress_shedding#5a1980625fcb65cef2ada2c20c06b1e183ea49db"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2124,7 +2124,7 @@ dependencies = [
 "checksum geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3484ce9e9560be7e5dffe685dfe2cf2dbf785fc3dac2f193fb42c56a797c3d1"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
-"checksum hopper 0.4.0-pre (git+https://github.com/postmates/hopper.git?branch=ingress_shedding)" = "<none>"
+"checksum hopper 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "704305bc2ef2ddac557e9d090f3d8e7965b8e44dc9e5ff6f70eab1bacf662349"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum hyper 0.11.14 (registry+https://github.com/rust-lang/crates.io-index)" = "f57f74deb81fb91b776012ed7605e96b1ffb88c4fd5c031ce5c90534b604a6e0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "hopper 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopper 0.4.0-pre (git+https://github.com/postmates/hopper.git?branch=ingress_shedding)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -695,10 +695,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hopper"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.4.0-pre"
+source = "git+https://github.com/postmates/hopper.git?branch=ingress_shedding#5a1980625fcb65cef2ada2c20c06b1e183ea49db"
 dependencies = [
  "bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2122,7 +2124,7 @@ dependencies = [
 "checksum geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3484ce9e9560be7e5dffe685dfe2cf2dbf785fc3dac2f193fb42c56a797c3d1"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
-"checksum hopper 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ec6ec0a31d8f81b4dd9c42c912afffaede4e7645edbc0fc7270b9f6ad087571c"
+"checksum hopper 0.4.0-pre (git+https://github.com/postmates/hopper.git?branch=ingress_shedding)" = "<none>"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum hyper 0.11.14 (registry+https://github.com/rust-lang/crates.io-index)" = "f57f74deb81fb91b776012ed7605e96b1ffb88c4fd5c031ce5c90534b604a6e0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,8 +17,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -37,6 +37,14 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "arrayvec"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ascii"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,7 +56,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -59,8 +67,8 @@ dependencies = [
  "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -92,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "0.9.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -138,7 +146,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -159,29 +167,29 @@ dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chan-signal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "coco 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "elastic 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "elastic_types 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "fern 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elastic 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elastic_types 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fern 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "hopper 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopper 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "mond 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quantiles 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdkafka 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_firehose 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_kinesis 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -191,10 +199,10 @@ dependencies = [
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny_http 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny_http 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -209,16 +217,16 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chan"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -227,7 +235,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chan 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chan 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -237,7 +245,7 @@ name = "chrono"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -246,7 +254,7 @@ name = "chrono"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -263,25 +271,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.29.2"
+version = "2.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "coco"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -323,7 +322,7 @@ name = "criterion"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion-plot 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion-stats 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -353,10 +352,41 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cast 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -371,16 +401,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "elastic"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "elastic_reqwest 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "elastic_types 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elastic_reqwest 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elastic_types 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -390,29 +420,29 @@ dependencies = [
 
 [[package]]
 name = "elastic_requests"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "elastic_reqwest"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "elastic_requests 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "elastic_responses 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elastic_requests 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elastic_responses 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "elastic_responses"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -423,11 +453,11 @@ dependencies = [
 
 [[package]]
 name = "elastic_types"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "elastic_types_derive 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elastic_types_derive 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "geohash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -438,17 +468,17 @@ dependencies = [
 
 [[package]]
 name = "elastic_types_derive"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "elastic_types_derive_internals 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elastic_types_derive_internals 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "elastic_types_derive_internals"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -519,12 +549,20 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "encoding_rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -564,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "fern"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -617,7 +655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -625,7 +663,7 @@ name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -648,7 +686,7 @@ name = "geo"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -658,7 +696,7 @@ name = "geo"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "spade 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -678,7 +716,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -695,10 +733,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hopper"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -724,27 +762,28 @@ dependencies = [
  "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hyper"
-version = "0.11.14"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "relay 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -765,11 +804,11 @@ name = "hyper-tls"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -786,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "iovec"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -929,6 +968,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "mime"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,12 +1010,12 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1012,9 +1056,9 @@ dependencies = [
  "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "matrixmultiply 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1025,11 +1069,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.9.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "schannel 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1056,68 +1100,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-bigint 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-rational"
-version = "0.1.40"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-bigint 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.1.41"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1138,14 +1190,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.9.23"
+version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1155,7 +1207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.24"
+version = "0.9.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1197,7 +1249,7 @@ version = "0.7.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1235,7 +1287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quickcheck"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1250,11 +1302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1264,7 +1317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1277,19 +1330,19 @@ name = "rayon"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rayon-core 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1297,7 +1350,7 @@ name = "rdkafka"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdkafka-sys 0.11.3-0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1332,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1349,32 +1402,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "relay"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding_rs 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libflate 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1403,10 +1466,10 @@ dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1416,10 +1479,10 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1450,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1460,10 +1523,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1477,7 +1540,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1517,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1609,7 +1672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1620,7 +1683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1632,7 +1695,7 @@ dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1687,14 +1750,14 @@ dependencies = [
  "cgmath 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clamp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nalgebra 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "strsim"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1731,10 +1794,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tempdir"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1785,12 +1849,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tiny_http"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1798,7 +1862,6 @@ dependencies = [
  "chunked_transfer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1808,23 +1871,23 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-io"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1832,15 +1895,15 @@ name = "tokio-proto"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1849,7 +1912,7 @@ name = "tokio-service"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1857,10 +1920,10 @@ name = "tokio-tls"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1950,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1968,7 +2031,7 @@ name = "uuid"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1977,7 +2040,7 @@ name = "uuid"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2007,11 +2070,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2021,12 +2084,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2053,13 +2116,14 @@ dependencies = [
 "checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
+"checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
 "checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "229d032f1a99302697f10b27167ae6d03d49d032e6a8e2550e8d3fc13356d2b4"
-"checksum bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9a6301db0b49fb63551bc15b5ae348147101cdf323242b93ec7546d5002ff1af"
+"checksum bincode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bda13183df33055cbb84b847becce220d392df502ebe7a4a78d7021771ed94d0"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
@@ -2071,14 +2135,13 @@ dependencies = [
 "checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum cgmath 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f3f4e27f2647652606e9faab058dd8686513a23b276fcd16e85eb0927838ddc"
-"checksum chan 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "ff4461b5d67544413e087a2d8ed94309f8ab2fc6dcfcdbd5e5f8df4a052d9fc6"
+"checksum chan 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "9af7c487bb99c929ba2715b1a3a7bf45f5062bf5b6eae5d32b292a96c5865172"
 "checksum chan-signal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f1f1e11f6e1c14c9e805a87c622cb8fcb636283b3119a2150af390cc6702d7fe"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum chunked_transfer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "498d20a7aaf62625b9bf26e637cf7736417cde1d0c99f1d04d1170229a85cf87"
 "checksum clamp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0113a8ae379a061c89a71d57a809439f5ce550b6a76063ab5ba2b1cb180971f"
-"checksum clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4151c5790817c7d21bbdc6c3530811f798172915f93258244948b93ba19604a6"
-"checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
+"checksum clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c07b9257a00f3fc93b7f3c417fc15607ec7a56823bc2c37ec744e266387de5b"
 "checksum coco 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04d5eef9c9354cbb35d5069c39054c657469d2aa7789d4c71d0a6b686dc48bea"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
@@ -2086,15 +2149,18 @@ dependencies = [
 "checksum criterion 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f58b0200bf321214bdda8c797cf0071bcc638171c40ec198c3f652a4edaacde3"
 "checksum criterion-plot 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "885431f7865f9d4956b466126674e5ea40a0f193d42157e56630c356c5501957"
 "checksum criterion-stats 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c71521cb4c7b7eac76b540e75447fb0172c4234d6333729001b886aaa21d6da4"
+"checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
+"checksum crossbeam-epoch 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "59796cc6cbbdc6bb319161349db0c3250ec73ec7fcb763a51065ec4e2e158552"
+"checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
-"checksum elastic 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)" = "da2e8708fa07bd65240be5cca4f35c8091c0fc9ff635ae77fb93f31da0fb25f2"
-"checksum elastic_requests 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)" = "37c344aad9b7dde5d57b2d9cbf3532ee279a6da7ba8374fac1f1ee31ae6786cd"
-"checksum elastic_reqwest 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)" = "567ae5ea80f0e71297f079efe36bb2c5ff5a516dbd03597820808d22176e17f7"
-"checksum elastic_responses 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)" = "40e9a376e2be4a1515c93563bc2b46960c99de86d66409836216a6a0b471cfe6"
-"checksum elastic_types 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)" = "a42b2b98f80c87176c43f368ca9df699b36591f9fe6c313bdcf39767e285b19e"
-"checksum elastic_types_derive 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)" = "89c280c68bd3463cd2b1f3dc27f6e040f1f276a321a4a5264908633e8edfca81"
-"checksum elastic_types_derive_internals 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)" = "71d3c1dd06501ef2b1ef50710c73210453ee1c3a718b88e2b7e792321c55e453"
+"checksum elastic 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa059d90c25191fcc37eb7bc154d40e0f19e491fb2a9911486a9a67b5111b35"
+"checksum elastic_requests 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1cc929c5e2da0ce6cfae670ba96c41aa968a33dc0b21d9215c081458fb2b7091"
+"checksum elastic_reqwest 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9c6b71eee3a3233b3ebf47e91fc96ebed891e23393e1b24b979230c181045c5c"
+"checksum elastic_responses 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)" = "79b38bdd036483c692830a7c5b21f01522c3bc052861e1de7a45eca908d659f0"
+"checksum elastic_types 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2179834f28b49b288f53d42d9546bec28d1b392b2721a0dca5aef23f1e4dde49"
+"checksum elastic_types_derive 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f20840d73acfddf8d28a2b4e66f23d600e1029352aa48750366e38ac0d5d6c0a"
+"checksum elastic_types_derive_internals 0.20.9 (registry+https://github.com/rust-lang/crates.io-index)" = "4597cc554e471314866f84953aa15043378832ba9432c108a80a4a4c0d24c99f"
 "checksum encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
 "checksum encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
 "checksum encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
@@ -2102,19 +2168,20 @@ dependencies = [
 "checksum encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
 "checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+"checksum encoding_rs 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98fd0f24d1fb71a4a6b9330c8ca04cbd4e7cc5d846b54ca74ff376bc7c9f798d"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e92ecf0a508c8e074c0e6fa8fe0fa38414848ad4dfc4db6f74c5e9753330b248"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
-"checksum fern 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "590f46271b9c28b01f3cf81c18d41cecc70b1424aa22bd0c2e39525b76effebc"
+"checksum fern 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "50475651fccc56343c766e4d1889428ea753308a977e1315db358ada28cc8c9d"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
 "checksum flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fac2277e84e5e858483756647a9d0aa8d9a2b7cba517fd84325a0aaa69a0909"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "118b49cac82e04121117cbd3121ede3147e885627d82c4546b87c702debb90c1"
+"checksum futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab5b5e94f5c31fc764ba5dd9ad16568aae5d4825538c01d6bca680c9bf94a7"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
@@ -2124,14 +2191,14 @@ dependencies = [
 "checksum geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3484ce9e9560be7e5dffe685dfe2cf2dbf785fc3dac2f193fb42c56a797c3d1"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
-"checksum hopper 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "704305bc2ef2ddac557e9d090f3d8e7965b8e44dc9e5ff6f70eab1bacf662349"
+"checksum hopper 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5a42a5b368a15c1b64afd2c59985dbe41b3543a573aa1ade2a6d1adc9c3a6c6f"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
-"checksum hyper 0.11.14 (registry+https://github.com/rust-lang/crates.io-index)" = "f57f74deb81fb91b776012ed7605e96b1ffb88c4fd5c031ce5c90534b604a6e0"
+"checksum hyper 0.11.18 (registry+https://github.com/rust-lang/crates.io-index)" = "c4f9b276c87e3fc1902a8bdfcce264c3f7c8a1c35e5e0c946062739f55026664"
 "checksum hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72332e4a35d3059583623b50e98e491b78f8b96c5521fcb3f428167955aa56e8"
 "checksum hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c81fa95203e2a6087242c38691a0210f23e9f3f8f944350bd676522132e2985"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
-"checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
+"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum isatty 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f2a233726c7bb76995cec749d59582e5664823b7245d4970354408f1d79a7a2"
 "checksum itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "c4a9b56eb56058f43dc66e58f40a214b2ccbc9f3df51861b63d51dec7b65bc3f"
 "checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
@@ -2151,11 +2218,12 @@ dependencies = [
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum matrixmultiply 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cac1a66eab356036af85ea093101a14223dc6e3f4c02a59b7d572e5b93270bf7"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e00e17be181010a91dbfefb01660b17311059dc8c7f48b9017677721e732bd"
 "checksum mime_guess 2.0.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)" = "013572795763289e14710c7b279461295f2673b2b338200c235082cd7ca9e495"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
-"checksum mio 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "75f72a93f046f1517e3cfddc0a096eb756a2ba727d36edc8227dee769a50a9b0"
+"checksum mio 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7da01a5e23070d92d99b1ecd1cd0af36447c6fd44b0fe283c2db199fa136724f"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum mond 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "55ba3d33d9d3328a600682e8685e1fdc3d43cd93f4d287105d7f9105b05036e1"
 "checksum nalgebra 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c8516d8710f28c64cfc75b274c75c55c967ad4ece7090521b3c065de1d12336b"
@@ -2163,18 +2231,19 @@ dependencies = [
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum nom 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
-"checksum num 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "cc4083e14b542ea3eb9b5f33ff48bd373a92d78687e74f4cc0a30caeb754f0ca"
-"checksum num-bigint 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "bdc1494b5912f088f260b775799468d9b9209ac60885d8186a547a0476289e23"
-"checksum num-complex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "58de7b4bf7cf5dbecb635a5797d489864eadd03b107930cbccf9e0fd7428b47c"
-"checksum num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "d1452e8b06e448a07f0e6ebb0bb1d92b8890eea63288c0b627331d53514d0fba"
-"checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
-"checksum num-rational 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "0c7cb72a95250d8a370105c828f388932373e0e94414919891a0f945222310fe"
-"checksum num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "cacfcab5eb48250ee7d0c7896b51a2c5eec99c1feea5f32025635f5ae4b00070"
+"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+"checksum num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "81b483ea42927c463e191802e7334556b48e7875297564c0e9951bd3a0ae53e3"
+"checksum num-complex 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "26ff8edeab9f1d8cf6b595e35138c2a389ea29f4f57a0e6bc44abf406e4b0077"
+"checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
+"checksum num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
+"checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
+"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+"checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
 "checksum num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "cee7e88156f3f9e19bdd598f8d6c9db7bf4078f99f8381f43a55b09648d1a6e3"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
-"checksum openssl 0.9.23 (registry+https://github.com/rust-lang/crates.io-index)" = "169a4b9160baf9b9b1ab975418c673686638995ba921683a7f1e01470dcb8854"
+"checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-"checksum openssl-sys 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "14ba54ac7d5a4eabd1d5f2c1fdeb7e7c14debfa669d94b983d01b465e767ba9e"
+"checksum openssl-sys 0.9.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5a41ce2f5f2d939c80decde8fcfcf5837c203ca6c06a553510a2fcb84fa3ef1"
 "checksum pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "cb325642290f28ee14d8c6201159949a872f220c62af6e110a56ea914fbe42fc"
@@ -2185,29 +2254,30 @@ dependencies = [
 "checksum protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bec26e67194b7d991908145fdf21b7cae8b08423d96dcb9e860cd31f854b9506"
 "checksum quantiles 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a319a2d5001dc3599c53c7262e3fc8b40ab6fa84608731b2ef4aedd42f54e2"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
-"checksum quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13f4460d3daa06eb1c4b9a3c55dffe65cb030dd70cf1bfdd482532f48ab24f74"
+"checksum quickcheck 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "15cda2c09a11b72e8563c57760dd5cf8b1fb3bb595df5759b5653048ab04e030"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
+"checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
 "checksum rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8"
-"checksum rayon-core 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e64b609139d83da75902f88fd6c01820046840a18471e4dfcd5ac7c0f46bea53"
+"checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
 "checksum rdkafka 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fec65d5bd7508b9dd7d096c4ec77b8cb6b082c0310c38b26c18433167ee385a0"
 "checksum rdkafka-sys 0.11.3-0 (registry+https://github.com/rust-lang/crates.io-index)" = "aaf25fc8636600a9d06b857f3636dc8471a4f25b052a4bc0fa91232157bdc4cb"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "744554e01ccbd98fff8c457c3b092cd67af62a555a43bfe97ae8a0451f7799fa"
+"checksum regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5be5347bde0c48cfd8c3fdc0766cdfe9d8a755ef84d620d6794c778c91de8b2b"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
-"checksum relay 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f301bafeb60867c85170031bdb2fcf24c8041f33aee09e7b116a58d4e9f781c5"
-"checksum reqwest 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3161ca63fd11ce36c7718af239e6492a25a3dbfcec54240f959b9d816cf42413"
+"checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
+"checksum remove_dir_all 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5d2f806b0fcdabd98acd380dc8daef485e22bcb7cddc811d1337967f2528cf5"
+"checksum reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "241faa9a8ca28a03cbbb9815a5d085f271d4c0168a19181f106aa93240c22ddb"
 "checksum ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6f7d28b30a72c01b458428e0ae988d4149c20d902346902be881e3edc4bb325c"
 "checksum rusoto_core 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "416154f868e6d42ae9fb6f8df6b008eab0c92c4af4c7b9bd71cca64a0010e310"
 "checksum rusoto_credential 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4e1cbcb471900c15925afa14c04a30f978f466800eeabc8d60a2e9622561d140"
 "checksum rusoto_firehose 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6988fee8f7d4a6b259fb70bb60c0c8f00b2a5e75ccea67563e035c383b49c82c"
 "checksum rusoto_kinesis 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "577ece6b5020051248510c82fbec16d76bf8e80a9cf3e5bc38e49b18bcdafc77"
-"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
+"checksum rustc-demangle 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f312457f8a4fa31d3581a6f423a70d6c33a10b95291985df55f1ff670ec10ce8"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-"checksum rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9743a7670d88d5d52950408ecdb7c71d8986251ab604d4689dd2ca25c9bca69"
+"checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "acece75e0f987c48863a6c792ec8b7d6c4177d4a027f8ccc72f849794f437016"
 "checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
@@ -2215,7 +2285,7 @@ dependencies = [
 "checksum seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e048636bed25842fcdc36e5ad1ec6295b72d4b5b8a4b759b64915a4ce2b9d09d"
 "checksum security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfa44ee9c54ce5eecc9de7d5acbad112ee58755239381f687e564004ba4a2332"
 "checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
-"checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"
@@ -2236,21 +2306,21 @@ dependencies = [
 "checksum smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f8266519bc1d17d0b5b16f6c21295625d562841c708f6376f49028a43e9c11e"
 "checksum snap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "174451758f7045084ae92070f18e5d8e5c53a716f4172a9c6b17ce03e7b82573"
 "checksum spade 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1e0a4f3487c79e3b935e22ff7b686596b9d3866117f852de0ff54722bef4a77e"
-"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
-"checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
+"checksum tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f73eebdb68c14bcb24aef74ea96079830e7fa7b31a6106e42ea7ee887c1e134e"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
-"checksum tiny_http 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "016f040cfc9b5be610de3619eaaa57017fa0b0b678187327bde75fc146e2a41f"
+"checksum tiny_http 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2f4d55c9a213880d1f0c89ded183f209c6e45b912ca6c7df6f93c163773572e1"
 "checksum tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "52b4e32d8edbf29501aabb3570f027c6ceb00ccef6538f4bddba0200503e74e8"
-"checksum tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "514aae203178929dbf03318ad7c683126672d4d96eccb77b29603d33c9e25743"
+"checksum tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b9532748772222bf70297ec0e2ad0f17213b4a7dd0e6afb68e0a0768f69f4e4f"
 "checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
 "checksum tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "772f4b04e560117fe3b0a53e490c16ddc8ba6ec437015d91fa385564996ed913"
@@ -2267,7 +2337,7 @@ dependencies = [
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"
 "checksum url 0.2.38 (registry+https://github.com/rust-lang/crates.io-index)" = "cbaa8377a162d88e7d15db0cf110c8523453edcbc5bc66d2b6fffccffa34a068"
-"checksum url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa35e768d4daf1d85733418a49fb42e10d7f633e394fccab4ab7aba897053fe2"
+"checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "78c590b5bd79ed10aad8fb75f078a59d8db445af6c743e55c4a53227fc01c13f"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
@@ -2276,9 +2346,9 @@ dependencies = [
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b09fb3b6f248ea4cd42c9a65113a847d612e17505d6ebd1f7357ad68a8bf8693"
+"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-"checksum winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ec6667f60c23eca65c561e63a13d81b44234c2e38a6b6c959025ee907ec614cc"
-"checksum winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98f12c52b2630cd05d2c3ffd8e008f7f48252c042b4871c72aed9dc733b96668"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ fern = "0.5"
 flate2 = "1.0"
 futures = "0.1.17"
 glob = "0.2.11"
-hopper = { git = "https://github.com/postmates/hopper.git", branch = "ingress_shedding" }
+hopper = "0.4"
 hyper = "0.10" # 0.10 specifically required by rusoto_kinesis' KinesisClient
 lazy_static = "1.0"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ fern = "0.5"
 flate2 = "1.0"
 futures = "0.1.17"
 glob = "0.2.11"
-hopper = "0.3"
+hopper = { git = "https://github.com/postmates/hopper.git", branch = "ingress_shedding" }
 hyper = "0.10" # 0.10 specifically required by rusoto_kinesis' KinesisClient
 lazy_static = "1.0"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rusoto_core = "0.30"
 rusoto_firehose = "0.30"
 rusoto_kinesis = "0.30.0"
 seahash = "3.0"
-serde = { version = "1.0", features = ["rc"] }
+serde = "1.0"
 serde-avro = "0.5.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -140,10 +140,12 @@ fn main() {
     //
     // SINKS
     if let Some(ref config) = args.null {
-        let (send, recv) = hopper::channel_with_max_bytes(
+        let (send, recv) = hopper::channel_with_explicit_capacity(
             &config.config_path,
             &args.data_directory,
+            args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
+            args.max_hopper_queue_files,
         ).unwrap();
         senders.insert(config.config_path.clone(), send);
         receivers.insert(config.config_path.clone(), recv);
@@ -151,10 +153,12 @@ fn main() {
     }
     if let Some(ref config) = args.console {
         let config_path = cfg_conf!(config);
-        let (send, recv) = hopper::channel_with_max_bytes(
+        let (send, recv) = hopper::channel_with_explicit_capacity(
             &config_path,
             &args.data_directory,
+            args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
+            args.max_hopper_queue_files,
         ).unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
@@ -162,10 +166,12 @@ fn main() {
     }
     if let Some(ref config) = args.wavefront {
         let config_path = cfg_conf!(config);
-        let (send, recv) = hopper::channel_with_max_bytes(
+        let (send, recv) = hopper::channel_with_explicit_capacity(
             &config_path,
             &args.data_directory,
+            args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
+            args.max_hopper_queue_files,
         ).unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
@@ -173,10 +179,12 @@ fn main() {
     }
     if let Some(ref config) = args.prometheus {
         let config_path = cfg_conf!(config);
-        let (send, recv) = hopper::channel_with_max_bytes(
+        let (send, recv) = hopper::channel_with_explicit_capacity(
             &config_path,
             &args.data_directory,
+            args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
+            args.max_hopper_queue_files,
         ).unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
@@ -184,10 +192,12 @@ fn main() {
     }
     if let Some(ref config) = args.influxdb {
         let config_path = cfg_conf!(config);
-        let (send, recv) = hopper::channel_with_max_bytes(
+        let (send, recv) = hopper::channel_with_explicit_capacity(
             &config_path,
             &args.data_directory,
+            args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
+            args.max_hopper_queue_files,
         ).unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
@@ -195,10 +205,12 @@ fn main() {
     }
     if let Some(ref config) = args.native_sink_config {
         let config_path = cfg_conf!(config);
-        let (send, recv) = hopper::channel_with_max_bytes(
+        let (send, recv) = hopper::channel_with_explicit_capacity(
             &config_path,
             &args.data_directory,
+            args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
+            args.max_hopper_queue_files,
         ).unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
@@ -206,10 +218,12 @@ fn main() {
     }
     if let Some(ref config) = args.elasticsearch {
         let config_path = cfg_conf!(config);
-        let (send, recv) = hopper::channel_with_max_bytes(
+        let (send, recv) = hopper::channel_with_explicit_capacity(
             &config_path,
             &args.data_directory,
+            args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
+            args.max_hopper_queue_files,
         ).unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
@@ -218,10 +232,12 @@ fn main() {
     if let Some(ref configs) = args.firehosen {
         for config in configs {
             let config_path = cfg_conf!(config);
-            let (send, recv) = hopper::channel_with_max_bytes(
+            let (send, recv) = hopper::channel_with_explicit_capacity(
                 &config_path,
                 &args.data_directory,
+                args.max_hopper_in_memory_bytes,
                 args.max_hopper_queue_bytes,
+                args.max_hopper_queue_files,
             ).unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
@@ -231,10 +247,12 @@ fn main() {
     if let Some(ref configs) = args.kafkas {
         for config in configs {
             let config_path = cfg_conf!(config);
-            let (send, recv) = hopper::channel_with_max_bytes(
+            let (send, recv) = hopper::channel_with_explicit_capacity(
                 &config_path,
                 &args.data_directory,
+                args.max_hopper_in_memory_bytes,
                 args.max_hopper_queue_bytes,
+                args.max_hopper_queue_files,
             ).unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
@@ -244,10 +262,12 @@ fn main() {
     if let Some(ref configs) = args.kinesises {
         for config in configs {
             let config_path = cfg_conf!(config);
-            let (send, recv) = hopper::channel_with_max_bytes(
+            let (send, recv) = hopper::channel_with_explicit_capacity(
                 &config_path,
                 &args.data_directory,
+                args.max_hopper_in_memory_bytes,
                 args.max_hopper_queue_bytes,
+                args.max_hopper_queue_files,
             ).unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
@@ -257,10 +277,12 @@ fn main() {
     // FILTERS
     if let Some(ref configs) = args.programmable_filters {
         for (config_path, config) in configs {
-            let (send, recv) = hopper::channel_with_max_bytes(
+            let (send, recv) = hopper::channel_with_explicit_capacity(
                 config_path,
                 &args.data_directory,
+                args.max_hopper_in_memory_bytes,
                 args.max_hopper_queue_bytes,
+                args.max_hopper_queue_files,
             ).unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
@@ -274,10 +296,12 @@ fn main() {
     }
     if let Some(ref configs) = args.delay_filters {
         for (config_path, config) in configs {
-            let (send, recv) = hopper::channel_with_max_bytes(
+            let (send, recv) = hopper::channel_with_explicit_capacity(
                 config_path,
                 &args.data_directory,
+                args.max_hopper_in_memory_bytes,
                 args.max_hopper_queue_bytes,
+                args.max_hopper_queue_files,
             ).unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
@@ -291,10 +315,12 @@ fn main() {
     }
     if let Some(ref configs) = args.flush_boundary_filters {
         for (config_path, config) in configs {
-            let (send, recv) = hopper::channel_with_max_bytes(
+            let (send, recv) = hopper::channel_with_explicit_capacity(
                 config_path,
                 &args.data_directory,
+                args.max_hopper_in_memory_bytes,
                 args.max_hopper_queue_bytes,
+                args.max_hopper_queue_files,
             ).unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,13 @@ fn default_version() -> String {
 /// on `parse_args` in this module for more details.
 #[derive(Debug)]
 pub struct Args {
+    /// The maximum size -- in bytes -- that a hopper queue may hold in memory
+    /// before flushing to disk.
+    pub max_hopper_in_memory_bytes: usize,
+    /// The maximum number of queue files that hopper may hold on disk. The
+    /// maximum discu consumption of a single hopper queue will be
+    /// `max_hopper_queue_files * max_hopper_queue_bytes`.
+    pub max_hopper_queue_files: usize,
     /// The maximum size -- in bytes -- that a hopper queue may grow to before
     /// being cycled.
     pub max_hopper_queue_bytes: usize,
@@ -127,7 +134,9 @@ pub struct Args {
 impl Default for Args {
     fn default() -> Self {
         Args {
+            max_hopper_in_memory_bytes: 1_048_576,
             max_hopper_queue_bytes: 1_048_576 * 100,
+            max_hopper_queue_files: 100,
             data_directory: default_data_directory(),
             scripts_directory: default_scripts_directory(),
             flush_interval: 60,
@@ -226,6 +235,14 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                 .expect("could not parse max-hopper-queue-bytes") as usize
         })
         .unwrap_or(args.max_hopper_queue_bytes);
+
+    args.max_hopper_queue_files = value
+        .get("max-hopper-queue-files")
+        .map(|s| {
+            s.as_integer()
+                .expect("could not parse max-hopper-queue-files") as usize
+        })
+        .unwrap_or(args.max_hopper_queue_files);
 
     args.data_directory = value
         .get("data-directory")

--- a/src/config.rs
+++ b/src/config.rs
@@ -244,6 +244,15 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
         })
         .unwrap_or(args.max_hopper_queue_files);
 
+    args.max_hopper_in_memory_bytes = value
+        .get("max-hopper-in-memory-bytes")
+        .map(|s| {
+            s.as_integer()
+                .expect("could not parse max-hopper-in-memory-bytes")
+                as usize
+        })
+        .unwrap_or(args.max_hopper_in_memory_bytes);
+
     args.data_directory = value
         .get("data-directory")
         .map(|s| {
@@ -1253,9 +1262,13 @@ data-directory = "/foo/bar"
     fn config_max_hopper_queue_bytes() {
         let config = r#"
 max-hopper-queue-bytes = 10
+max-hopper-queue-files = 1024
+max-hopper-in-memory-bytes = 4048
 "#;
         let args = parse_config_file(config, 4);
         assert_eq!(args.max_hopper_queue_bytes, 10);
+        assert_eq!(args.max_hopper_queue_files, 1024);
+        assert_eq!(args.max_hopper_in_memory_bytes, 4048);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,8 +17,8 @@ use toml;
 const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 
 use filter::DelayFilterConfig;
-use filter::JSONEncodeFilterConfig;
 use filter::FlushBoundaryFilterConfig;
+use filter::JSONEncodeFilterConfig;
 use filter::ProgrammableFilterConfig;
 use sink::ConsoleConfig;
 use sink::ElasticsearchConfig;
@@ -65,7 +65,7 @@ pub struct Args {
     /// before flushing to disk.
     pub max_hopper_in_memory_bytes: usize,
     /// The maximum number of queue files that hopper may hold on disk. The
-    /// maximum discu consumption of a single hopper queue will be
+    /// maximum disk consumption of a single hopper queue will be
     /// `max_hopper_queue_files * max_hopper_queue_bytes`.
     pub max_hopper_queue_files: usize,
     /// The maximum size -- in bytes -- that a hopper queue may grow to before
@@ -91,8 +91,8 @@ pub struct Args {
     /// The delay filters to use in this cernan run. See `filters::DelayFilter`
     /// for more.
     pub delay_filters: Option<HashMap<String, DelayFilterConfig>>,
-    /// The json_encode filters to use in this cernan run. See `filters::JSONEncodeFilter`
-    /// for more.
+    /// The json_encode filters to use in this cernan run. See
+    /// `filters::JSONEncodeFilter` for more.
     pub json_encode_filters: Option<HashMap<String, JSONEncodeFilterConfig>>,
     /// The flush boundaryfilters to use in this cernan run. See
     /// `filters::FlushBoundaryFilter` for more.
@@ -352,7 +352,9 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
             let mut filters: HashMap<String, JSONEncodeFilterConfig> = HashMap::new();
             for (name, tbl) in fltr.as_table().unwrap().iter() {
                 let parse_line = if let Some(parse_line) = tbl.get("parse_line") {
-                    parse_line.as_bool().expect("could not parse parse_line as boolean")
+                    parse_line
+                        .as_bool()
+                        .expect("could not parse parse_line as boolean")
                 } else {
                     false
                 };
@@ -372,7 +374,7 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                     config_path: Some(config_path.clone()),
                 };
                 filters.insert(config_path, config);
-            };
+            }
             filters
         });
 

--- a/src/filter/delay_filter.rs
+++ b/src/filter/delay_filter.rs
@@ -75,14 +75,8 @@ impl filter::Filter for DelayFilter {
                     DELAY_LOG_REJECT.fetch_add(1, Ordering::Relaxed);
                 }
             }
-            timer @ metric::Event::TimerFlush { .. } => {
-                res.push(timer);
-            }
-            raw @ metric::Event::Raw { .. } => {
-                res.push(raw);
-            }
-            metric::Event::Shutdown => {
-                res.push(metric::Event::Shutdown);
+            ev => {
+                res.push(ev);
             }
         }
         Ok(())

--- a/src/metric/telemetry.rs
+++ b/src/metric/telemetry.rs
@@ -920,7 +920,6 @@ mod tests {
     use metric::{AggregationMethod, Event, Telemetry};
     use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
     use std::cmp;
-    use std::sync::Arc;
 
     #[test]
     fn set_bounds_no_crash() {
@@ -1046,7 +1045,7 @@ mod tests {
             let i: usize = g.gen();
             match i % 3 {
                 0 => Event::TimerFlush(g.gen()),
-                _ => Event::Telemetry(Arc::new(Some(Arbitrary::arbitrary(g)))),
+                _ => Event::Telemetry(Arbitrary::arbitrary(g)),
             }
         }
     }

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -6,7 +6,6 @@ use chrono::naive::NaiveDateTime;
 use chrono::offset::Utc;
 use metric::{AggregationMethod, LogLine, Telemetry};
 use sink::{Sink, Valve};
-use std::sync;
 
 /// The 'console' sink exists for development convenience. The sink will
 /// aggregate according to [buckets](../buckets/struct.Buckets.html) method and
@@ -74,13 +73,11 @@ impl Sink<ConsoleConfig> for Console {
         Valve::Open
     }
 
-    fn deliver(&mut self, mut point: sync::Arc<Option<Telemetry>>) -> () {
-        self.aggrs
-            .add(sync::Arc::make_mut(&mut point).take().unwrap());
+    fn deliver(&mut self, point: Telemetry) -> () {
+        self.aggrs.add(point);
     }
 
-    fn deliver_line(&mut self, mut lines: sync::Arc<Option<LogLine>>) -> () {
-        let line: LogLine = sync::Arc::make_mut(&mut lines).take().unwrap();
+    fn deliver_line(&mut self, line: LogLine) -> () {
         self.buffer.append(&mut vec![line]);
     }
 

--- a/src/sink/elasticsearch.rs
+++ b/src/sink/elasticsearch.rs
@@ -7,11 +7,10 @@ use elastic::client::responses::bulk;
 use elastic::error;
 use elastic::error::Result;
 use elastic::prelude::*;
-use metric::{LogLine, Telemetry};
+use metric::LogLine;
 use sink::{Sink, Valve};
 use std::cmp;
 use std::error::Error;
-use std::sync;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use uuid;
@@ -339,12 +338,7 @@ impl Sink<ElasticsearchConfig> for Elasticsearch {
         self.flush();
     }
 
-    fn deliver(&mut self, _: sync::Arc<Option<Telemetry>>) -> () {
-        // nothing, intentionally
-    }
-
-    fn deliver_line(&mut self, mut lines: sync::Arc<Option<LogLine>>) -> () {
-        let line: LogLine = sync::Arc::make_mut(&mut lines).take().unwrap();
+    fn deliver_line(&mut self, line: LogLine) -> () {
         let uuid = uuid::Uuid::new_v4();
         self.buffer.push(Line {
             uuid: uuid,

--- a/src/sink/firehose.rs
+++ b/src/sink/firehose.rs
@@ -3,7 +3,7 @@
 use chrono::DateTime;
 use chrono::naive::NaiveDateTime;
 use chrono::offset::Utc;
-use metric::{LogLine, Telemetry};
+use metric::LogLine;
 use rusoto_core::{DefaultCredentialsProvider, Region};
 use rusoto_core::default_tls_client;
 use rusoto_firehose::{KinesisFirehose, KinesisFirehoseClient, PutRecordBatchInput,
@@ -14,7 +14,6 @@ use serde_json::Map;
 use serde_json::value::Value;
 use sink::{Sink, Valve};
 use source::report_full_telemetry;
-use std::sync;
 use uuid::Uuid;
 
 /// Configuration struct for the Firehose sink
@@ -296,12 +295,7 @@ impl Sink<FirehoseConfig> for Firehose {
         self.flush();
     }
 
-    fn deliver(&mut self, _: sync::Arc<Option<Telemetry>>) -> () {
-        // nothing, intentionally
-    }
-
-    fn deliver_line(&mut self, mut lines: sync::Arc<Option<LogLine>>) -> () {
-        let line: LogLine = sync::Arc::make_mut(&mut lines).take().unwrap();
+    fn deliver_line(&mut self, line: LogLine) -> () {
         self.buffer.append(&mut vec![line]);
     }
 

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -2,12 +2,11 @@
 
 use hyper::Client;
 use hyper::header;
-use metric::{LogLine, TagMap, Telemetry};
+use metric::{TagMap, Telemetry};
 use quantiles::histogram::Bound;
 use sink::{Sink, Valve};
 use std::cmp;
 use std::string;
-use std::sync;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use time;
@@ -267,13 +266,8 @@ impl Sink<InfluxDBConfig> for InfluxDB {
         self.flush();
     }
 
-    fn deliver(&mut self, mut point: sync::Arc<Option<Telemetry>>) -> () {
-        self.aggrs
-            .push(sync::Arc::make_mut(&mut point).take().unwrap());
-    }
-
-    fn deliver_line(&mut self, _: sync::Arc<Option<LogLine>>) -> () {
-        // nothing, intentionally
+    fn deliver(&mut self, point: Telemetry) -> () {
+        self.aggrs.push(point);
     }
 
     fn valve_state(&self) -> Valve {

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -286,7 +286,6 @@ mod test {
     use metric::{TagMap, Telemetry};
     use metric::AggregationMethod;
     use sink::Sink;
-    use std::sync::Arc;
 
     #[test]
     fn test_format_influxdb() {
@@ -305,7 +304,7 @@ mod test {
         let dt_0 = Utc.ymd(1990, 6, 12).and_hms_milli(9, 10, 11, 00);
         let dt_1 = Utc.ymd(1990, 6, 12).and_hms_milli(9, 10, 12, 00);
         let dt_2 = Utc.ymd(1990, 6, 12).and_hms_milli(9, 10, 13, 00);
-        influxdb.deliver(Arc::new(Some(
+        influxdb.deliver(
             Telemetry::new()
                 .name("test.counter.no.tags")
                 .value(-1.0)
@@ -314,8 +313,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&TagMap::default()),
-        )));
-        influxdb.deliver(Arc::new(Some(
+        );
+        influxdb.deliver(
             Telemetry::new()
                 .name("test.counter")
                 .value(-1.0)
@@ -324,8 +323,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        influxdb.deliver(Arc::new(Some(
+        );
+        influxdb.deliver(
             Telemetry::new()
                 .name("test.counter")
                 .value(2.0)
@@ -334,8 +333,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        influxdb.deliver(Arc::new(Some(
+        );
+        influxdb.deliver(
             Telemetry::new()
                 .name("test.counter")
                 .value(3.0)
@@ -344,8 +343,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        influxdb.deliver(Arc::new(Some(
+        );
+        influxdb.deliver(
             Telemetry::new()
                 .name("test.gauge")
                 .value(3.211)
@@ -354,8 +353,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        influxdb.deliver(Arc::new(Some(
+        );
+        influxdb.deliver(
             Telemetry::new()
                 .name("test.gauge")
                 .value(4.322)
@@ -364,8 +363,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        influxdb.deliver(Arc::new(Some(
+        );
+        influxdb.deliver(
             Telemetry::new()
                 .name("test.gauge")
                 .value(5.433)
@@ -374,8 +373,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        influxdb.deliver(Arc::new(Some(
+        );
+        influxdb.deliver(
             Telemetry::new()
                 .name("test.timer")
                 .value(12.101)
@@ -384,8 +383,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        influxdb.deliver(Arc::new(Some(
+        );
+        influxdb.deliver(
             Telemetry::new()
                 .name("test.timer")
                 .value(1.101)
@@ -394,8 +393,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        influxdb.deliver(Arc::new(Some(
+        );
+        influxdb.deliver(
             Telemetry::new()
                 .name("test.timer")
                 .value(3.101)
@@ -404,8 +403,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        influxdb.deliver(Arc::new(Some(
+        );
+        influxdb.deliver(
             Telemetry::new()
                 .name("test.raw")
                 .value(1.0)
@@ -414,8 +413,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        influxdb.deliver(Arc::new(Some(
+        );
+        influxdb.deliver(
             Telemetry::new()
                 .name("test.raw")
                 .value(2.0)
@@ -424,7 +423,7 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
+        );
         let mut buffer = String::new();
         influxdb.format_stats(&mut buffer, influxdb.aggr_slice());
         let lines: Vec<&str> = buffer.lines().collect();

--- a/src/sink/kafka.rs
+++ b/src/sink/kafka.rs
@@ -1,6 +1,6 @@
 //! Kafka sink for Raw events.
 use futures::future::Future;
-use metric::{self, LogLine, Telemetry};
+use metric;
 use rdkafka::client::EmptyContext;
 use rdkafka::config::ClientConfig;
 use rdkafka::error::{KafkaError, RDKafkaError};
@@ -201,14 +201,6 @@ impl Sink<KafkaConfig> for Kafka {
         } else {
             Valve::Closed
         }
-    }
-
-    fn deliver(&mut self, _: Arc<Option<Telemetry>>) -> () {
-        // Discard point
-    }
-
-    fn deliver_line(&mut self, _: Arc<Option<LogLine>>) -> () {
-        // Discard line
     }
 
     /// Fire off the given event to librdkafka. That library handles buffering and

--- a/src/sink/kinesis.rs
+++ b/src/sink/kinesis.rs
@@ -2,7 +2,6 @@
 use base64;
 use hyper;
 use metric;
-use metric::{LogLine, Telemetry};
 use rusoto_core;
 use rusoto_core::DefaultCredentialsProvider;
 use rusoto_core::default_tls_client;
@@ -103,14 +102,6 @@ impl Sink<KinesisConfig> for Kinesis {
     fn valve_state(&self) -> Valve {
         // We never close up shop.
         Valve::Open
-    }
-
-    fn deliver(&mut self, _: Arc<Option<Telemetry>>) -> () {
-        // Discard point
-    }
-
-    fn deliver_line(&mut self, _: Arc<Option<LogLine>>) -> () {
-        // Discard line
     }
 
     /// Encodes and records the given event into the internal buffer.

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -7,7 +7,6 @@
 use hopper;
 use metric::{Encoding, Event, LogLine, Telemetry};
 use std::marker::PhantomData;
-use std::sync;
 use thread;
 use time;
 use util::Valve;
@@ -81,8 +80,7 @@ where
         })
     }
 
-    fn consume(mut self) -> () //recv: hopper::Receiver<Event>, sources: Vec<String>, mut state: S) -> ()
-    {
+    fn consume(mut self) -> () {
         let mut attempts = 0;
         let mut recv = self.recv.into_iter();
         let mut last_flush_idx = 0;
@@ -220,13 +218,20 @@ where
     fn flush(&mut self) -> ();
     /// Lookup the `Sink` valve state. See `Valve` documentation for more
     /// information.
-    fn valve_state(&self) -> Valve;
+    fn valve_state(&self) -> Valve {
+        // never close up shop
+        Valve::Open
+    }
     /// Deliver a `Telemetry` to the `Sink`. Exact behaviour varies by
     /// implementation.
-    fn deliver(&mut self, point: sync::Arc<Option<Telemetry>>) -> ();
+    fn deliver(&mut self, _telem: Telemetry) -> () {
+        // nothing, intentionally
+    }
     /// Deliver a `LogLine` to the `Sink`. Exact behaviour varies by
     /// implementation.
-    fn deliver_line(&mut self, line: sync::Arc<Option<LogLine>>) -> ();
+    fn deliver_line(&mut self, _line: LogLine) -> () {
+        // nothing, intentionally
+    }
     /// Deliver a 'Raw' series of encoded bytes to the sink.
     fn deliver_raw(
         &mut self,
@@ -235,7 +240,6 @@ where
         _bytes: Vec<u8>,
     ) -> () {
         // Not all sinks accept raw events.  By default, we do nothing.
-        return;
     }
     /// Provide a hook to shutdown a sink. This is necessary for sinks which
     /// have their own long-running threads.

--- a/src/sink/null.rs
+++ b/src/sink/null.rs
@@ -1,6 +1,4 @@
 //! Sink equivalent of /dev/null.
-
-use metric::{LogLine, Telemetry};
 use sink::{Sink, Valve};
 
 /// Null sink
@@ -32,14 +30,6 @@ impl Sink<NullConfig> for Null {
 
     fn valve_state(&self) -> Valve {
         Valve::Open
-    }
-
-    fn deliver(&mut self, _: Telemetry) -> () {
-        // discard point
-    }
-
-    fn deliver_line(&mut self, _: LogLine) -> () {
-        // discard point
     }
 
     fn flush_interval(&self) -> Option<u64> {

--- a/src/sink/null.rs
+++ b/src/sink/null.rs
@@ -2,7 +2,6 @@
 
 use metric::{LogLine, Telemetry};
 use sink::{Sink, Valve};
-use std::sync;
 
 /// Null sink
 ///
@@ -35,11 +34,11 @@ impl Sink<NullConfig> for Null {
         Valve::Open
     }
 
-    fn deliver(&mut self, _: sync::Arc<Option<Telemetry>>) -> () {
+    fn deliver(&mut self, _: Telemetry) -> () {
         // discard point
     }
 
-    fn deliver_line(&mut self, _: sync::Arc<Option<LogLine>>) -> () {
+    fn deliver_line(&mut self, _: LogLine) -> () {
         // discard point
     }
 

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -515,7 +515,7 @@ where
                             enc.write_all(b"+Inf")?;
                         }
                     }
-                    for (k, v) in &(*value.tags) {
+                    for (k, v) in &value.tags {
                         enc.write_all(b"\", ")?;
                         enc.write_all(k.as_bytes())?;
                         enc.write_all(b"=\"")?;
@@ -553,7 +553,7 @@ where
                     enc.write_all(sanitized_name.as_bytes())?;
                     enc.write_all(b"{quantile=\"")?;
                     enc.write_all(q.to_string().as_bytes())?;
-                    for (k, v) in &(*value.tags) {
+                    for (k, v) in &value.tags {
                         enc.write_all(b"\", ")?;
                         enc.write_all(k.as_bytes())?;
                         enc.write_all(b"=\"")?;
@@ -639,8 +639,7 @@ impl Sink<PrometheusConfig> for Prometheus {
         }
     }
 
-    fn deliver(&mut self, mut point: sync::Arc<Option<metric::Telemetry>>) -> () {
-        let telem: metric::Telemetry = sync::Arc::make_mut(&mut point).take().unwrap();
+    fn deliver(&mut self, telem: metric::Telemetry) -> () {
         if let Some(age_threshold) = self.age_threshold {
             if (telem.timestamp - time::now()).abs() <= (age_threshold as i64) {
                 self.aggrs.insert(telem);
@@ -650,17 +649,9 @@ impl Sink<PrometheusConfig> for Prometheus {
         }
     }
 
-    fn deliver_line(&mut self, _: sync::Arc<Option<metric::LogLine>>) -> () {
-        // nothing, intentionally
-    }
-
     fn shutdown(mut self) -> () {
         self.flush();
         self.http_srv.shutdown();
-    }
-
-    fn valve_state(&self) -> Valve {
-        Valve::Open
     }
 }
 

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -17,7 +17,7 @@ use http;
 use metric;
 use metric::{AggregationMethod, TagMap};
 use quantiles::histogram::Bound;
-use sink::{Sink, Valve};
+use sink::Sink;
 use std::f64;
 use std::io;
 use std::io::Write;
@@ -163,6 +163,7 @@ impl Accumulator {
                         }
                     }
                 }
+                assert!(samples.len() <= cap);
             }
         }
     }

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -652,7 +652,6 @@ mod test {
     use metric::{AggregationMethod, TagMap, Telemetry};
     use quickcheck::{QuickCheck, TestResult};
     use sink::Sink;
-    use std::sync::Arc;
 
     #[test]
     fn test_pad_across_flush() {
@@ -1031,7 +1030,7 @@ mod test {
         let dt_2 = Utc.ymd(1990, 6, 12)
             .and_hms_milli(9, 10, 13, 00)
             .timestamp();
-        wavefront.deliver(Arc::new(Some(
+        wavefront.deliver(
             Telemetry::new()
                 .name("test.counter")
                 .value(-1.0)
@@ -1040,8 +1039,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        wavefront.deliver(Arc::new(Some(
+        );
+        wavefront.deliver(
             Telemetry::new()
                 .name("test.counter")
                 .value(2.0)
@@ -1050,8 +1049,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        wavefront.deliver(Arc::new(Some(
+        );
+        wavefront.deliver(
             Telemetry::new()
                 .name("test.counter")
                 .value(3.0)
@@ -1060,8 +1059,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        wavefront.deliver(Arc::new(Some(
+        );
+        wavefront.deliver(
             Telemetry::new()
                 .name("test.gauge")
                 .value(3.211)
@@ -1070,8 +1069,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        wavefront.deliver(Arc::new(Some(
+        );
+        wavefront.deliver(
             Telemetry::new()
                 .name("test.gauge")
                 .value(4.322)
@@ -1080,8 +1079,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        wavefront.deliver(Arc::new(Some(
+        );
+        wavefront.deliver(
             Telemetry::new()
                 .name("test.gauge")
                 .value(5.433)
@@ -1090,8 +1089,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        wavefront.deliver(Arc::new(Some(
+        );
+        wavefront.deliver(
             Telemetry::new()
                 .name("test.timer")
                 .value(12.101)
@@ -1100,8 +1099,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        wavefront.deliver(Arc::new(Some(
+        );
+        wavefront.deliver(
             Telemetry::new()
                 .name("test.timer")
                 .value(1.101)
@@ -1110,8 +1109,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        wavefront.deliver(Arc::new(Some(
+        );
+        wavefront.deliver(
             Telemetry::new()
                 .name("test.timer")
                 .value(3.101)
@@ -1120,8 +1119,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        wavefront.deliver(Arc::new(Some(
+        );
+        wavefront.deliver(
             Telemetry::new()
                 .name("test.raw")
                 .value(1.0)
@@ -1130,8 +1129,8 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
-        wavefront.deliver(Arc::new(Some(
+        );
+        wavefront.deliver(
             Telemetry::new()
                 .name("test.raw")
                 .value(2.0)
@@ -1140,7 +1139,7 @@ mod test {
                 .harden()
                 .unwrap()
                 .overlay_tags_from_map(&tags),
-        )));
+        );
         wavefront.format_stats();
         let lines: Vec<&str> = wavefront.stats.lines().collect();
 

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -118,6 +118,18 @@ impl source::Source<InternalConfig> for Internal {
                 }
                 Ok(_) => {
                     if !chans.is_empty() {
+                        atom_telem!(
+                            "cernan.util.hopper.error.full",
+                            util::UTIL_SEND_HOPPER_ERROR_FULL,
+                            tags,
+                            chans
+                        );
+                        atom_telem!(
+                            "cernan.util.hopper.success",
+                            util::UTIL_SEND_HOPPER_SUCCESS,
+                            tags,
+                            chans
+                        );
                         // source::graphite
                         atom_telem!(
                             "cernan.graphite.new_peer",

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,15 @@ use slab;
 use std::collections;
 use std::hash;
 use std::ops::{Index, IndexMut};
+use std::sync;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+lazy_static! {
+    /// Number of dropped events due to channel being totally full
+    pub static ref UTIL_SEND_HOPPER_ERROR_FULL: sync::Arc<AtomicUsize> = sync::Arc::new(AtomicUsize::new(0));
+    /// Number of successfully sent events through the channels
+    pub static ref UTIL_SEND_HOPPER_SUCCESS: sync::Arc<AtomicUsize> = sync::Arc::new(AtomicUsize::new(0));
+}
 
 /// Cernan hashmap
 ///
@@ -21,32 +30,55 @@ pub type HashMap<K, V> =
 pub type Channel = Vec<hopper::Sender<metric::Event>>;
 
 /// Send a `metric::Event` into a `Channel`.
-pub fn send(chans: &mut Channel, event: metric::Event) {
+pub fn send(chans: &mut Channel, mut event: metric::Event) {
     if chans.is_empty() {
         // Nothing to send to.
         return;
     }
 
-    for chan in &mut chans[..] {
-        let mut snd_event = event.clone();
-        loop {
-            if let Err(res) = chan.send(snd_event) {
-                // The are a variety of errors that hopper will signal back up
-                // when we do a send. The only one we care about is
-                // `Error::Full`, meaning that all disk and memory buffer space
-                // is consumed. We drop the event on the floor in that case.
-                match res.1 {
-                    hopper::Error::Full => {
-                        break;
+    let max: usize = chans.len().saturating_sub(1);
+    if max != 0 {
+        for chan in &mut chans[1..] {
+            let mut snd_event = event.clone();
+            loop {
+                if let Err(res) = chan.send(snd_event) {
+                    // The are a variety of errors that hopper will signal back up
+                    // when we do a send. The only one we care about is
+                    // `Error::Full`, meaning that all disk and memory buffer space
+                    // is consumed. We drop the event on the floor in that case.
+                    match res.1 {
+                        hopper::Error::Full => {
+                            UTIL_SEND_HOPPER_ERROR_FULL
+                                .fetch_add(1, Ordering::Relaxed);
+                            break;
+                        }
+                        _ => {
+                            snd_event = res.0;
+                            continue;
+                        }
                     }
-                    _ => {
-                        snd_event = res.0;
-                        continue;
-                    }
+                } else {
+                    UTIL_SEND_HOPPER_SUCCESS.fetch_add(1, Ordering::Relaxed);
+                    break;
                 }
-            } else {
-                break;
             }
+        }
+    }
+    loop {
+        if let Err(res) = chans[0].send(event) {
+            match res.1 {
+                hopper::Error::Full => {
+                    UTIL_SEND_HOPPER_ERROR_FULL.fetch_add(1, Ordering::Relaxed);
+                    break;
+                }
+                _ => {
+                    event = res.0;
+                    continue;
+                }
+            }
+        } else {
+            UTIL_SEND_HOPPER_SUCCESS.fetch_add(1, Ordering::Relaxed);
+            break;
         }
     }
 }

--- a/tests/programmable_filter.rs
+++ b/tests/programmable_filter.rs
@@ -8,7 +8,6 @@ mod integration {
         use self::cernan::metric;
         use self::cernan::metric::AggregationMethod;
         use std::path::PathBuf;
-        use std::sync::Arc;
 
         #[test]
         fn test_id_filter() {
@@ -420,8 +419,7 @@ mod integration {
             println!("EVENTS: {:?}", events);
             assert_eq!(events[2], metric::Event::TimerFlush(1));
             match events[1] {
-                metric::Event::Telemetry(ref mut m) => {
-                    let p = ::std::sync::Arc::make_mut(m).take().unwrap();
+                metric::Event::Telemetry(ref mut p) => {
                     assert_eq!(p.name, "count_per_tick");
                     assert_eq!(p.set(), Some(5.0));
                 }
@@ -450,8 +448,7 @@ mod integration {
             println!("EVENTS: {:?}", events);
             assert_eq!(events[2], metric::Event::TimerFlush(2));
             match events[1] {
-                metric::Event::Telemetry(ref mut m) => {
-                    let p = ::std::sync::Arc::make_mut(m).take().unwrap();
+                metric::Event::Telemetry(ref mut p) => {
                     assert_eq!(p.name, "count_per_tick");
                     assert_eq!(p.set(), Some(2.0));
                 }
@@ -505,8 +502,7 @@ mod integration {
 
             for event in events {
                 match event {
-                    metric::Event::Telemetry(mut m) => {
-                        let met = Arc::make_mut(&mut m).take().unwrap();
+                    metric::Event::Telemetry(mut met) => {
                         assert_eq!(met.name, expected);
                     }
                     _ => {
@@ -551,8 +547,7 @@ mod integration {
 
             for event in events {
                 match event {
-                    metric::Event::Telemetry(mut m) => {
-                        let met = Arc::make_mut(&mut m).take().unwrap();
+                    metric::Event::Telemetry(mut met) => {
                         assert_eq!(met.name, expected);
                     }
                     _ => {


### PR DESCRIPTION
This commit incorporates changes made to hopper to allow for ingress shedding in overload conditions. We expose these configuration parameters in cernan, allowing operations to choose to shed data rather than eat up disk space until a crash.

By default each hopper queue file will consume 1_048_576 * 100 * 100 bytes on disk, at a maximum.

This resolves #412.

This cannot be merged until https://github.com/postmates/hopper/pull/20 lands and hopper 0.4.0 is properly cut.

We've removed the reference-count encoding via serde. It forced a copy and interacted badly with the new hopper. In particular, serializing Rcs and shipping them through hopper causes a memory leak for reasons that are not clear to me. Serde shies you off from serializing Rcs and I can't say I much disagree.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>