### PR TITLE
Remove extern in src/constants.rs

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,5 @@
 //! Library level constants
-
-extern crate mio;
+use mio;
 
 /// MIO token used to distinguish system events
 /// from other event sources.


### PR DESCRIPTION
We try to keep all externs to either bin/cernan.rs or src/lib.rs.
This commit removes an extern inside of the cernan library.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>