### PR TITLE
[sinks/kafka] Promote `MessageTimedOut` to an error that will be retried

### DIFF
--- a/src/sink/kafka.rs
+++ b/src/sink/kafka.rs
@@ -284,6 +284,7 @@ impl Kafka {
                                 | RDKafkaError::NetworkException
                                 | RDKafkaError::GroupLoadInProgress
                                 | RDKafkaError::GroupCoordinatorNotAvailable
+                                | RDKafkaError::MessageTimedOut
                                 | RDKafkaError::NotCoordinatorForGroup
                                 | RDKafkaError::NotEnoughReplicas
                                 | RDKafkaError::NotEnoughReplicasAfterAppend
@@ -515,6 +516,7 @@ mod tests {
             RDKafkaError::NetworkException,
             RDKafkaError::GroupLoadInProgress,
             RDKafkaError::GroupCoordinatorNotAvailable,
+            RDKafkaError::MessageTimedOut,
             RDKafkaError::NotCoordinatorForGroup,
             RDKafkaError::NotEnoughReplicas,
             RDKafkaError::NotEnoughReplicasAfterAppend,


### PR DESCRIPTION
Whitelists the `MessagedTimedOut` error to be a retry case.