### PR TITLE
Fix the lack of tags in ES sink, introduced in 0.8.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cernan"
-version = "0.8.14"
+version = "0.8.15-pre"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "cernan"
 readme = "README.md"
 repository = "https://github.com/postmates/cernan"
-version = "0.8.14"
+version = "0.8.15-pre"
 
 [[bin]]
 name = "cernan"

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -12,7 +12,7 @@ extern crate log;
 extern crate openssl_probe;
 
 use cernan::filter::{DelayFilterConfig, Filter, FlushBoundaryFilterConfig,
-                     ProgrammableFilterConfig, JSONEncodeFilterConfig};
+                     JSONEncodeFilterConfig, ProgrammableFilterConfig};
 use cernan::matrix;
 use cernan::metric;
 use cernan::sink::Sink;
@@ -642,7 +642,7 @@ fn main() {
             filters.insert(
                 config.config_path.clone().unwrap(),
                 cernan::thread::spawn(move |_poll| {
-                    cernan::filter::JSONEncodeFilter::new(&c).run(
+                    cernan::filter::JSONEncodeFilter::new(c).run(
                         recv,
                         sources,
                         downstream_sends,

--- a/src/config.rs
+++ b/src/config.rs
@@ -372,6 +372,7 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                     parse_line: parse_line,
                     forwards: fwds,
                     config_path: Some(config_path.clone()),
+                    tags: global_tags.clone(),
                 };
                 filters.insert(config_path, config);
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -471,6 +471,8 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                 })
                 .unwrap_or(args.flush_interval);
 
+            res.tags = global_tags.clone();
+
             res
         });
 
@@ -703,6 +705,8 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                 })
                 .unwrap_or(args.flush_interval);
 
+            res.tags = global_tags.clone();
+
             res
         });
 
@@ -790,6 +794,8 @@ pub fn parse_config_file(buffer: &str, verbosity: u64) -> Args {
                         Some("us-west-2") => Some(Region::UsWest2),
                         Some(_) | None => res.region,
                     };
+
+                    res.tags = global_tags.clone();
 
                     firehosen.push(res);
                 }

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -170,14 +170,16 @@ impl<'a> Payload<'a> {
         let pyld = state.to_userdata(1) as *mut Payload;
         let idx = idx(state.to_integer(2), (*pyld).logs.len());
         match state.to_str(3).map(|k| k.to_owned()) {
-            Some(key) => match (*pyld).logs[idx].tags.get(&key) {
-                Some(v) => {
-                    state.push_string(v);
+            Some(key) => {
+                match (*pyld).logs[idx].get_from_tags(&key, (*pyld).global_tags) {
+                    Some(v) => {
+                        state.push_string(v);
+                    }
+                    None => {
+                        state.push_nil();
+                    }
                 }
-                None => {
-                    state.push_nil();
-                }
-            },
+            }
             None => {
                 error!("[log_tag_value] no key provided");
                 state.push_nil();
@@ -267,7 +269,7 @@ impl<'a> Payload<'a> {
         let idx = idx(state.to_integer(2), (*pyld).logs.len());
         match state.to_str(3).map(|k| k.to_owned()) {
             Some(key) => match state.to_str(4).map(|v| v.to_owned()) {
-                Some(val) => match (*pyld).logs[idx].tags.insert(key, val) {
+                Some(val) => match (*pyld).logs[idx].insert_tag(key, val) {
                     Some(old_v) => {
                         state.push_string(&old_v);
                     }
@@ -324,7 +326,7 @@ impl<'a> Payload<'a> {
         match state.to_str(3).map(|k| k.to_owned()) {
             Some(key) => {
                 (*pyld).logs[idx].value = key;
-            },
+            }
             None => {
                 error!("[log_set_value] no val provided");
             }
@@ -361,7 +363,7 @@ impl<'a> Payload<'a> {
         let pyld = state.to_userdata(1) as *mut Payload;
         let idx = idx(state.to_integer(2), (*pyld).logs.len());
         match state.to_str(3).map(|k| k.to_owned()) {
-            Some(key) => match (*pyld).logs[idx].tags.remove(&key) {
+            Some(key) => match (*pyld).logs[idx].remove_tag(&key) {
                 Some(old_v) => {
                     state.push_string(&old_v);
                 }

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -49,14 +49,6 @@ impl Default for ConsoleConfig {
 impl ConsoleConfig {
     /// Convenience method to create a ConsoleConfig with `bin_width` equal to
     /// 1.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use cernan::sink::ConsoleConfig;
-    /// let config = ConsoleConfig::new("sinks.console".to_string(), 60);
-    /// assert_eq!(1, config.bin_width);
-    /// ```
     pub fn new(
         config_path: String,
         flush_interval: u64,

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -151,16 +151,16 @@ impl Sink<NativeConfig> for Native {
                 }
                 metric::Event::Log(mut l) => {
                     let mut ll = LogLine::new();
-                    ll.set_path(l.path);
-                    ll.set_value(l.value);
                     let mut meta = HashMap::new();
                     // TODO
                     //
                     // Learn how to consume bits of the metric without having to
                     // clone like crazy
-                    for (k, v) in &l.tags {
+                    for (k, v) in l.tags(&self.tags) {
                         meta.insert(k.clone(), v.clone());
                     }
+                    ll.set_path(l.path);
+                    ll.set_value(l.value);
                     ll.set_metadata(meta);
                     ll.set_timestamp_ms(l.time * 1000); // FIXME #166
 


### PR DESCRIPTION
This commit repairs a defect with 0.8.13/14 in which tags were not
being correctly distributed to ES and Firehose sinks, causing LogLines
traveling out through those sinks to go out tag-less.

LogLine now follows Telemetry and does not bundle tags by default. There's
a trait in here somewhere, TaggableEvent or some such. Should cut down
on the code duplication.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>