### PR TITLE
Remove extra lazy_statics

### DIFF
--- a/src/filter/delay_filter.rs
+++ b/src/filter/delay_filter.rs
@@ -7,20 +7,17 @@
 
 use filter;
 use metric;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use time;
 
-lazy_static! {
-    /// Total number of telemetry rejected for age
-    pub static ref DELAY_TELEM_REJECT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of telemetry accepted for age
-    pub static ref DELAY_TELEM_ACCEPT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of logline rejected for age
-    pub static ref DELAY_LOG_REJECT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of logline accepted for age
-    pub static ref DELAY_LOG_ACCEPT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-}
+/// Total number of telemetry rejected for age
+pub static DELAY_TELEM_REJECT: AtomicUsize = AtomicUsize::new(0);
+/// Total number of telemetry accepted for age
+pub static DELAY_TELEM_ACCEPT: AtomicUsize = AtomicUsize::new(0);
+/// Total number of logline rejected for age
+pub static DELAY_LOG_REJECT: AtomicUsize = AtomicUsize::new(0);
+/// Total number of logline accepted for age
+pub static DELAY_LOG_ACCEPT: AtomicUsize = AtomicUsize::new(0);
 
 /// Filter streams to within a bounded interval of current time.
 ///

--- a/src/filter/json_encode_filter.rs
+++ b/src/filter/json_encode_filter.rs
@@ -17,15 +17,12 @@ use serde_json;
 use serde_json::Value;
 use serde_json::map::Map;
 use std::iter::FromIterator;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-lazy_static! {
-    /// Total number of logline processed
-    pub static ref JSON_ENCODE_LOG_PROCESSED: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of logline with JSON value successfully parsed
-    pub static ref JSON_ENCODE_LOG_PARSED: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-}
+/// Total number of logline processed
+pub static JSON_ENCODE_LOG_PROCESSED: AtomicUsize = AtomicUsize::new(0);
+/// Total number of logline with JSON value successfully parsed
+pub static JSON_ENCODE_LOG_PARSED: AtomicUsize = AtomicUsize::new(0);
 
 /// Convert `LogLine` events into Raw events encoded as JSON.
 ///

--- a/src/sink/elasticsearch.rs
+++ b/src/sink/elasticsearch.rs
@@ -11,47 +11,45 @@ use metric::{LogLine, TagMap};
 use sink::{Sink, Valve};
 use std::cmp;
 use std::error::Error;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use uuid;
 
-lazy_static! {
-    /// Total deliveries made
-    pub static ref ELASTIC_RECORDS_DELIVERY: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total internal buffer entries
-    pub static ref ELASTIC_INTERNAL_BUFFER_LEN: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total records delivered in the last delivery
-    pub static ref ELASTIC_RECORDS_TOTAL_DELIVERED: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total records that failed to be delivered due to error
-    pub static ref ELASTIC_RECORDS_TOTAL_FAILED: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Unknown error occurred during attempted flush
-    pub static ref ELASTIC_ERROR_UNKNOWN: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of index bulk action errors
-    pub static ref ELASTIC_BULK_ACTION_INDEX_ERR: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of create bulk action errors
-    pub static ref ELASTIC_BULK_ACTION_CREATE_ERR: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of update bulk action errors
-    pub static ref ELASTIC_BULK_ACTION_UPDATE_ERR: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of delete bulk action errors
-    pub static ref ELASTIC_BULK_ACTION_DELETE_ERR: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+/// Total deliveries made
+pub static ELASTIC_RECORDS_DELIVERY: AtomicUsize = AtomicUsize::new(0);
+/// Total internal buffer entries
+pub static ELASTIC_INTERNAL_BUFFER_LEN: AtomicUsize = AtomicUsize::new(0);
+/// Total records delivered in the last delivery
+pub static ELASTIC_RECORDS_TOTAL_DELIVERED: AtomicUsize = AtomicUsize::new(0);
+/// Total records that failed to be delivered due to error
+pub static ELASTIC_RECORDS_TOTAL_FAILED: AtomicUsize = AtomicUsize::new(0);
+/// Unknown error occurred during attempted flush
+pub static ELASTIC_ERROR_UNKNOWN: AtomicUsize = AtomicUsize::new(0);
+/// Total number of index bulk action errors
+pub static ELASTIC_BULK_ACTION_INDEX_ERR: AtomicUsize = AtomicUsize::new(0);
+/// Total number of create bulk action errors
+pub static ELASTIC_BULK_ACTION_CREATE_ERR: AtomicUsize = AtomicUsize::new(0);
+/// Total number of update bulk action errors
+pub static ELASTIC_BULK_ACTION_UPDATE_ERR: AtomicUsize = AtomicUsize::new(0);
+/// Total number of delete bulk action errors
+pub static ELASTIC_BULK_ACTION_DELETE_ERR: AtomicUsize = AtomicUsize::new(0);
 
-    /// Total number of api errors due to index not found
-    pub static ref ELASTIC_ERROR_API_INDEX_NOT_FOUND: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of api errors due to parsing
-    pub static ref ELASTIC_ERROR_API_PARSING: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of api errors due to mapper parsing
-    pub static ref ELASTIC_ERROR_API_MAPPER_PARSING: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of api errors due to action request validation
-    pub static ref ELASTIC_ERROR_API_ACTION_REQUEST_VALIDATION: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of api errors due to missing document
-    pub static ref ELASTIC_ERROR_API_DOCUMENT_MISSING: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of api errors due to index already existing
-    pub static ref ELASTIC_ERROR_API_INDEX_ALREADY_EXISTS: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of api errors due to unknown reasons
-    pub static ref ELASTIC_ERROR_API_UNKNOWN: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of client errors, no specific reasons
-    pub static ref ELASTIC_ERROR_CLIENT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-}
+/// Total number of api errors due to index not found
+pub static ELASTIC_ERROR_API_INDEX_NOT_FOUND: AtomicUsize = AtomicUsize::new(0);
+/// Total number of api errors due to parsing
+pub static ELASTIC_ERROR_API_PARSING: AtomicUsize = AtomicUsize::new(0);
+/// Total number of api errors due to mapper parsing
+pub static ELASTIC_ERROR_API_MAPPER_PARSING: AtomicUsize = AtomicUsize::new(0);
+/// Total number of api errors due to action request validation
+pub static ELASTIC_ERROR_API_ACTION_REQUEST_VALIDATION: AtomicUsize =
+    AtomicUsize::new(0);
+/// Total number of api errors due to missing document
+pub static ELASTIC_ERROR_API_DOCUMENT_MISSING: AtomicUsize = AtomicUsize::new(0);
+/// Total number of api errors due to index already existing
+pub static ELASTIC_ERROR_API_INDEX_ALREADY_EXISTS: AtomicUsize = AtomicUsize::new(0);
+/// Total number of api errors due to unknown reasons
+pub static ELASTIC_ERROR_API_UNKNOWN: AtomicUsize = AtomicUsize::new(0);
+/// Total number of client errors, no specific reasons
+pub static ELASTIC_ERROR_CLIENT: AtomicUsize = AtomicUsize::new(0);
 
 /// Configuration for the Elasticsearch sink
 ///

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -7,21 +7,18 @@ use quantiles::histogram::Bound;
 use sink::{Sink, Valve};
 use std::cmp;
 use std::string;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use time;
 use url::Url;
 
-lazy_static! {
-    /// total delivery attempts made by this sink
-    pub static ref INFLUX_DELIVERY_ATTEMPTS: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// total successful delivery attempts made by this sink
-    pub static ref INFLUX_SUCCESS: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// total failed delivery attempts because of client error
-    pub static ref INFLUX_FAILURE_CLIENT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// total failed delivery attempts because of server error
-    pub static ref INFLUX_FAILURE_SERVER: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-}
+/// total delivery attempts made by this sink
+pub static INFLUX_DELIVERY_ATTEMPTS: AtomicUsize = AtomicUsize::new(0);
+/// total successful delivery attempts made by this sink
+pub static INFLUX_SUCCESS: AtomicUsize = AtomicUsize::new(0);
+/// total failed delivery attempts because of client error
+pub static INFLUX_FAILURE_CLIENT: AtomicUsize = AtomicUsize::new(0);
+/// total failed delivery attempts because of server error
+pub static INFLUX_FAILURE_SERVER: AtomicUsize = AtomicUsize::new(0);
 
 /// The `InfluxDB` structure
 ///

--- a/src/sink/kafka.rs
+++ b/src/sink/kafka.rs
@@ -9,20 +9,18 @@ use rdkafka::producer::FutureProducer;
 use rdkafka::producer::future_producer::DeliveryFuture;
 use sink::Sink;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use util::Valve;
 
-lazy_static! {
-    /// Total records published.
-    pub static ref KAFKA_PUBLISH_SUCCESS_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total record publish retries.
-    pub static ref KAFKA_PUBLISH_RETRY_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total record publish failures.
-    pub static ref KAFKA_PUBLISH_FAILURE_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total record publish retry failures. This occurs when the error signal does not include the original message.
-    pub static ref KAFKA_PUBLISH_RETRY_FAILURE_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-}
+/// Total records published.
+pub static KAFKA_PUBLISH_SUCCESS_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total record publish retries.
+pub static KAFKA_PUBLISH_RETRY_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total record publish failures.
+pub static KAFKA_PUBLISH_FAILURE_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total record publish retry failures. This occurs when the error signal does
+/// not include the original message.
+pub static KAFKA_PUBLISH_RETRY_FAILURE_SUM: AtomicUsize = AtomicUsize::new(0);
 
 /// Config options for Kafka config.
 #[derive(Clone, Debug, Deserialize)]

--- a/src/sink/kinesis.rs
+++ b/src/sink/kinesis.rs
@@ -9,20 +9,17 @@ use rusoto_kinesis::{KinesisClient, PutRecordsError, PutRecordsInput,
                      PutRecordsOutput, PutRecordsRequestEntry};
 use rusoto_kinesis::Kinesis as RusotoKinesis;
 use sink::Sink;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use util::Valve;
 
-lazy_static! {
-    /// Total records published.
-    pub static ref KINESIS_PUBLISH_SUCCESS_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total records discarded due to constraint violations.
-    pub static ref KINESIS_PUBLISH_DISCARD_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total retryable publication errors.
-    pub static ref KINESIS_PUBLISH_FAILURE_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total fatal publication errors.
-    pub static ref KINESIS_PUBLISH_FATAL_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-}
+/// Total records published.
+pub static KINESIS_PUBLISH_SUCCESS_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total records discarded due to constraint violations.
+pub static KINESIS_PUBLISH_DISCARD_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total retryable publication errors.
+pub static KINESIS_PUBLISH_FAILURE_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total fatal publication errors.
+pub static KINESIS_PUBLISH_FATAL_SUM: AtomicUsize = AtomicUsize::new(0);
 
 /// Config options for Kinesis config.
 #[derive(Clone, Debug, Deserialize)]

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -21,7 +21,6 @@ use std::io;
 use std::io::Write;
 use std::str;
 use std::sync;
-use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
@@ -29,20 +28,18 @@ use thread::Stoppable;
 use time;
 use util;
 
-lazy_static! {
-    /// Total reportable metrics
-    pub static ref PROMETHEUS_AGGR_REPORTABLE: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total remaining metrics in aggr
-    pub static ref PROMETHEUS_AGGR_REMAINING: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total report successes
-    pub static ref PROMETHEUS_REPORT_SUCCESS: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total report errors
-    pub static ref PROMETHEUS_REPORT_ERROR: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Sum of delays in reporting (microseconds)
-    pub static ref PROMETHEUS_RESPONSE_DELAY_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total stale perpetual elements purged
-    pub static ref PROMETHEUS_AGGR_WINDOWED_PURGED: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-}
+/// Total reportable metrics
+pub static PROMETHEUS_AGGR_REPORTABLE: AtomicUsize = AtomicUsize::new(0);
+/// Total remaining metrics in aggr
+pub static PROMETHEUS_AGGR_REMAINING: AtomicUsize = AtomicUsize::new(0);
+/// Total report successes
+pub static PROMETHEUS_REPORT_SUCCESS: AtomicUsize = AtomicUsize::new(0);
+/// Total report errors
+pub static PROMETHEUS_REPORT_ERROR: AtomicUsize = AtomicUsize::new(0);
+/// Sum of delays in reporting (microseconds)
+pub static PROMETHEUS_RESPONSE_DELAY_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total stale perpetual elements purged
+pub static PROMETHEUS_AGGR_WINDOWED_PURGED: AtomicUsize = AtomicUsize::new(0);
 
 /// The prometheus sink
 ///

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -10,34 +10,31 @@ use std::mem;
 use std::net::TcpStream;
 use std::net::ToSocketAddrs;
 use std::string;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use time;
 
-lazy_static! {
-    /// Total number of connection attempts made to wavefront proxy
-    pub static ref WAVEFRONT_CONNECT_ATTEMPTS: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total number of stored aggregations
-    pub static ref WAVEFRONT_AGGR_STORED_VALUES: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total histograms emitted
-    pub static ref WAVEFRONT_AGGR_HISTO: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total sums emitted
-    pub static ref WAVEFRONT_AGGR_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total sets emitted
-    pub static ref WAVEFRONT_AGGR_SET: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total summarize emitted
-    pub static ref WAVEFRONT_AGGR_SUMMARIZE: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total percentiles for summarize emitted
-    pub static ref WAVEFRONT_AGGR_TOT_PERCENT: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total delivery successes
-    pub static ref WAVEFRONT_DELIVERY_SUCCESS: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total delivery failures
-    pub static ref WAVEFRONT_DELIVERY_FAILURE: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total valve closed
-    pub static ref WAVEFRONT_VALVE_CLOSED: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total valve open
-    pub static ref WAVEFRONT_VALVE_OPEN: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-}
+/// Total number of connection attempts made to wavefront proxy
+pub static WAVEFRONT_CONNECT_ATTEMPTS: AtomicUsize = AtomicUsize::new(0);
+/// Total number of stored aggregations
+pub static WAVEFRONT_AGGR_STORED_VALUES: AtomicUsize = AtomicUsize::new(0);
+/// Total histograms emitted
+pub static WAVEFRONT_AGGR_HISTO: AtomicUsize = AtomicUsize::new(0);
+/// Total sums emitted
+pub static WAVEFRONT_AGGR_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total sets emitted
+pub static WAVEFRONT_AGGR_SET: AtomicUsize = AtomicUsize::new(0);
+/// Total summarize emitted
+pub static WAVEFRONT_AGGR_SUMMARIZE: AtomicUsize = AtomicUsize::new(0);
+/// Total percentiles for summarize emitted
+pub static WAVEFRONT_AGGR_TOT_PERCENT: AtomicUsize = AtomicUsize::new(0);
+/// Total delivery successes
+pub static WAVEFRONT_DELIVERY_SUCCESS: AtomicUsize = AtomicUsize::new(0);
+/// Total delivery failures
+pub static WAVEFRONT_DELIVERY_FAILURE: AtomicUsize = AtomicUsize::new(0);
+/// Total valve closed
+pub static WAVEFRONT_VALVE_CLOSED: AtomicUsize = AtomicUsize::new(0);
+/// Total valve open
+pub static WAVEFRONT_VALVE_OPEN: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
 /// Controls which aggregrations will be padded

--- a/src/source/avro.rs
+++ b/src/source/avro.rs
@@ -5,20 +5,17 @@ use mio;
 use serde_avro;
 use source::{TCPStreamHandler, TCP};
 use source::nonblocking::{write_all, BufferedPayload, PayloadErr};
-use std::net;
 use std::io::{Cursor, Read};
-use std::sync::Arc;
+use std::net;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use util;
 
-lazy_static! {
-    /// Total payloads processed.
-    pub static ref AVRO_PAYLOAD_SUCCESS_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total fatal parse failures.
-    pub static ref AVRO_PAYLOAD_PARSE_FAILURE_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total fatal IO related errors.
-    pub static ref AVRO_PAYLOAD_IO_FAILURE_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-}
+/// Total payloads processed.
+pub static AVRO_PAYLOAD_SUCCESS_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total fatal parse failures.
+pub static AVRO_PAYLOAD_PARSE_FAILURE_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total fatal IO related errors.
+pub static AVRO_PAYLOAD_IO_FAILURE_SUM: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct AvroStreamHandler;

--- a/src/source/graphite.rs
+++ b/src/source/graphite.rs
@@ -11,12 +11,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use util;
 use util::send;
 
-lazy_static! {
-    pub static ref GRAPHITE_NEW_PEER: sync::Arc<AtomicUsize> = sync::Arc::new(AtomicUsize::new(0));
-    pub static ref GRAPHITE_GOOD_PACKET: sync::Arc<AtomicUsize> = sync::Arc::new(AtomicUsize::new(0));
-    pub static ref GRAPHITE_TELEM: sync::Arc<AtomicUsize> = sync::Arc::new(AtomicUsize::new(0));
-    pub static ref GRAPHITE_BAD_PACKET: sync::Arc<AtomicUsize> = sync::Arc::new(AtomicUsize::new(0));
-}
+pub static GRAPHITE_NEW_PEER: AtomicUsize = AtomicUsize::new(0);
+pub static GRAPHITE_GOOD_PACKET: AtomicUsize = AtomicUsize::new(0);
+pub static GRAPHITE_TELEM: AtomicUsize = AtomicUsize::new(0);
+pub static GRAPHITE_BAD_PACKET: AtomicUsize = AtomicUsize::new(0);
 
 /// Configured for the `metric::Telemetry` source.
 #[derive(Debug, Deserialize, Clone)]

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -6,16 +6,13 @@ use protocols::native::{AggregationMethod, Payload};
 use source::{BufferedPayload, PayloadErr, TCPConfig, TCPStreamHandler, TCP};
 use std::net;
 use std::str;
-use std::sync;
-use std::sync::atomic;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use util;
 
-lazy_static! {
-    /// Total payloads processed.
-    pub static ref NATIVE_PAYLOAD_SUCCESS_SUM: sync::Arc<atomic::AtomicUsize> = sync::Arc::new(atomic::AtomicUsize::new(0));
-    /// Total fatal parse failures.
-    pub static ref NATIVE_PAYLOAD_PARSE_FAILURE_SUM: sync::Arc<atomic::AtomicUsize> = sync::Arc::new(atomic::AtomicUsize::new(0));
-}
+/// Total payloads processed.
+pub static NATIVE_PAYLOAD_SUCCESS_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total fatal parse failures.
+pub static NATIVE_PAYLOAD_PARSE_FAILURE_SUM: AtomicUsize = AtomicUsize::new(0);
 
 /// The native source
 ///
@@ -94,17 +91,12 @@ impl TCPStreamHandler for NativeStreamHandler {
                                                 );
                                             if handle_res.is_err() {
                                                 NATIVE_PAYLOAD_PARSE_FAILURE_SUM
-                                                    .fetch_add(
-                                                        1,
-                                                        atomic::Ordering::Relaxed,
-                                                    );
+                                                    .fetch_add(1, Ordering::Relaxed);
                                                 streaming = false;
                                                 break;
                                             }
-                                            NATIVE_PAYLOAD_SUCCESS_SUM.fetch_add(
-                                                1,
-                                                atomic::Ordering::Relaxed,
-                                            );
+                                            NATIVE_PAYLOAD_SUCCESS_SUM
+                                                .fetch_add(1, Ordering::Relaxed);
                                         }
                                         Err(PayloadErr::WouldBlock) => {
                                             // Not enough data yet.  Try again.

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -8,15 +8,12 @@ use std::io::ErrorKind;
 use std::net::ToSocketAddrs;
 use std::str;
 use std::sync;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use util;
 use util::send;
 
-lazy_static! {
-    pub static ref STATSD_GOOD_PACKET: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    pub static ref STATSD_BAD_PACKET: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-}
+pub static STATSD_GOOD_PACKET: AtomicUsize = AtomicUsize::new(0);
+pub static STATSD_BAD_PACKET: AtomicUsize = AtomicUsize::new(0);
 
 /// The statsd source
 ///

--- a/src/time.rs
+++ b/src/time.rs
@@ -6,11 +6,10 @@
 
 use chrono::offset::Utc;
 use std::{thread, time};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 lazy_static! {
-    static ref NOW: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(Utc::now().timestamp() as usize));
+    static ref NOW: AtomicUsize = AtomicUsize::new(Utc::now().timestamp() as usize);
 }
 
 /// Return the current time in epoch seconds

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,13 +8,10 @@ use slab;
 use std::collections;
 use std::hash;
 use std::ops::{Index, IndexMut};
-use std::sync;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-lazy_static! {
-    /// Number of dropped events due to channel being totally full
-    pub static ref UTIL_SEND_HOPPER_ERROR_FULL: sync::Arc<AtomicUsize> = sync::Arc::new(AtomicUsize::new(0));
-}
+/// Number of dropped events due to channel being totally full
+pub static UTIL_SEND_HOPPER_ERROR_FULL: AtomicUsize = AtomicUsize::new(0);
 
 /// Cernan hashmap
 ///


### PR DESCRIPTION
Turns out our use of lazy_static is kind of anachronistic. There's
more that can be done in current stable with regard to static
initialization than there used to be. To that end, most of the
use of lazy_static is now gone and we rely on statically initializable
AtomicUsizes.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>