### PR TITLE
Add error handling to calling lua functions

### DIFF
--- a/resources/tests/scripts/lua_error.lua
+++ b/resources/tests/scripts/lua_error.lua
@@ -1,0 +1,9 @@
+function process_metric(pyld)
+    error("boom")
+end
+
+function process_log(pyld)
+end
+
+function tick(pyld)
+end

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -26,17 +26,21 @@ pub enum FilterError {
     /// Specific to a ProgrammableFilter, means no function is available as
     /// called in the script
     NoSuchFunction(&'static str, metric::Event),
+    /// Specific to a ProgrammableFilter, means the lua code errored
+    LuaError(String, metric::Event),
 }
 
-fn name_in_fe(fe: &FilterError) -> &'static str {
-    match *fe {
-        FilterError::NoSuchFunction(n, _) => n,
+fn msg_in_fe(fe: &FilterError) -> &str {
+    match fe {
+        &FilterError::NoSuchFunction(n, _) => n,
+        &FilterError::LuaError(ref n, _) => n,
     }
 }
 
 fn event_in_fe(fe: FilterError) -> metric::Event {
     match fe {
         FilterError::NoSuchFunction(_, m) => m,
+        FilterError::LuaError(_, m) => m,
     }
 }
 
@@ -95,7 +99,7 @@ pub trait Filter {
                         Err(fe) => {
                             error!(
                                 "Failed to run filter with error: {:?}",
-                                name_in_fe(&fe)
+                                msg_in_fe(&fe)
                             );
                             let event = event_in_fe(fe);
                             util::send(&mut chans, event);

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -39,8 +39,7 @@ fn msg_in_fe(fe: &FilterError) -> &str {
 
 fn event_in_fe(fe: FilterError) -> metric::Event {
     match fe {
-        FilterError::NoSuchFunction(_, m) => m,
-        FilterError::LuaError(_, m) => m,
+        FilterError::NoSuchFunction(_, m) | FilterError::LuaError(_, m) => m,
     }
 }
 

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -554,6 +554,7 @@ impl filter::Filter for ProgrammableFilter {
                 if result.is_ok() {
                     self.last_flush_idx = flush_idx;
                 }
+                res.push(event);
                 result
             }
             metric::Event::Log(l) => {

--- a/tests/programmable_filter.rs
+++ b/tests/programmable_filter.rs
@@ -316,6 +316,39 @@ mod integration {
         }
 
         #[test]
+        fn test_lua_error() {
+            let mut script = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            script.push("resources/tests/scripts");
+            let script_dir = script.clone();
+            script.push("lua_error.lua");
+
+            let config = ProgrammableFilterConfig {
+                scripts_directory: Some(script_dir),
+                script: Some(script),
+                forwards: Vec::new(),
+                config_path: Some("filters.lua_error".to_string()),
+                tags: Default::default(),
+            };
+            let mut cs = ProgrammableFilter::new(config);
+
+            let orig_metric = metric::Telemetry::new()
+                .name("identity")
+                .value(12.0)
+                .kind(metric::AggregationMethod::Set)
+                .harden()
+                .unwrap()
+                .overlay_tag("foo", "bar")
+                .overlay_tag("bizz", "bazz");
+
+            let orig_event = metric::Event::new_telemetry(orig_metric);
+
+            let mut events = Vec::new();
+            let res = cs.process(orig_event, &mut events);
+            assert!(res.is_err());
+            assert!(events.is_empty());
+        }
+
+        #[test]
         fn test_demo_require() {
             let mut script = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             script.push("resources/tests/scripts");


### PR DESCRIPTION
Without this, errors in lua cause the C lua code to abort().

I found it was easier to refactor the repeated
process_metric/process_log/tick code than to make the change in three
places.