### PR TITLE
Add a context that ignores "Receive failed: Disconnected" error logs

### DIFF
--- a/src/filter/json_encode_filter.rs
+++ b/src/filter/json_encode_filter.rs
@@ -3,9 +3,10 @@
 //! This filter takes `LogLines` and encodes them into JSON, emitting the
 //! encoded event as a Raw event. This allows further filters or sinks to
 //! operate on the JSON without needing to understand a `LogLine` event in
-//! particular.  If the ``LogLine`` value is a valid JSON object and `parse_line`
-//! config option is true, then the JSON will be merged with `LogLine`
-//! metadata. Otherwise, the original line will be included simply as a string.
+//! particular.  If the `LogLine` value is a valid JSON object and
+//! `parse_line` config option is true, then the JSON will be merged with
+//! `LogLine` metadata. Otherwise, the original line will be included simply as
+//! a string.
 
 use chrono::DateTime;
 use chrono::naive::NaiveDateTime;

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -581,11 +581,7 @@ fn run_lua_func(
     mut pyld: Payload,
 ) -> Result<(), filter::FilterError> {
     let filter_telem = metric::Telemetry::new()
-        .name(format!(
-            "cernan.filter.{}.{}.failure",
-            pyld.path,
-            func_name
-        ))
+        .name(format!("cernan.filter.{}.{}.failure", pyld.path, func_name))
         .value(1.0)
         .kind(metric::AggregationMethod::Sum)
         .harden()
@@ -594,10 +590,7 @@ fn run_lua_func(
 
     state.get_global(func_name);
     if !state.is_fn(-1) {
-        return Err(filter::FilterError::NoSuchFunction(
-            func_name,
-            fail,
-        ));
+        return Err(filter::FilterError::NoSuchFunction(func_name, fail));
     }
 
     unsafe {
@@ -616,13 +609,11 @@ fn run_lua_func(
         }
         Ok(())
     } else {
-        let error =
-            if let Some(error) = state.to_str(-1) {
-                error
-            } else {
-                "While handling a lua error, lua error message was not a string"
-            };
+        let error = if let Some(error) = state.to_str(-1) {
+            error
+        } else {
+            "While handling a lua error, lua error message was not a string"
+        };
         Err(filter::FilterError::LuaError(error.to_owned(), fail))
     }
 }
-

--- a/src/sink/kafka.rs
+++ b/src/sink/kafka.rs
@@ -9,20 +9,18 @@ use rdkafka::producer::FutureProducer;
 use rdkafka::producer::future_producer::DeliveryFuture;
 use sink::Sink;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use util::Valve;
 
-lazy_static! {
-    /// Total records published.
-    pub static ref KAFKA_PUBLISH_SUCCESS_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total record publish retries.
-    pub static ref KAFKA_PUBLISH_RETRY_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total record publish failures.
-    pub static ref KAFKA_PUBLISH_FAILURE_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    /// Total record publish retry failures. This occurs when the error signal does not include the original message.
-    pub static ref KAFKA_PUBLISH_RETRY_FAILURE_SUM: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-}
+/// Total records published.
+pub static KAFKA_PUBLISH_SUCCESS_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total record publish retries.
+pub static KAFKA_PUBLISH_RETRY_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total record publish failures.
+pub static KAFKA_PUBLISH_FAILURE_SUM: AtomicUsize = AtomicUsize::new(0);
+/// Total record publish retry failures. This occurs when the error signal does
+/// not include the original message.
+pub static KAFKA_PUBLISH_RETRY_FAILURE_SUM: AtomicUsize = AtomicUsize::new(0);
 
 struct STFUContext;
 


### PR DESCRIPTION
Adds a context that overrides the default impls for emitting errors. Also, I ran rustfmt on the code, but it failed to format `internal.rs`.