### PR TITLE
cernan.sinks.prometheus.aggregation.reportable as SET, not SUM

### DIFF
--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -347,7 +347,7 @@ impl source::Source<InternalConfig> for Internal {
                             
                             chans
                         );
-                        atom_telem!(
+                        atom_set_telem!(
                             "cernan.sinks.prometheus.aggregation.reportable",
                             sink::prometheus::PROMETHEUS_AGGR_REPORTABLE,
                             chans


### PR DESCRIPTION
In the Prometheus sink we have PROMETHEUS_AGGR_REPORTABLE as a
store, rather than a summation. We previously reported this out
as a SUM from the internal source. This commit corrects that
mistake.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>