### PR TITLE
Fix TCP Stream Handler State Leak

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -81,6 +81,10 @@ impl thread::Stoppable for Server {
         self.thread.join();
     }
 
+    fn ready(&self) -> bool {
+        self.thread.ready()
+    }
+
     fn shutdown(self) {
         self.thread.shutdown();
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -81,10 +81,6 @@ impl thread::Stoppable for Server {
         self.thread.join();
     }
 
-    fn ready(&self) -> bool {
-        self.thread.ready()
-    }
-
     fn shutdown(self) {
         self.thread.shutdown();
     }

--- a/src/source/tcp.rs
+++ b/src/source/tcp.rs
@@ -4,6 +4,7 @@ use metric;
 use mio;
 use source::Source;
 use std;
+use std::collections;
 use std::io::ErrorKind;
 use std::marker::PhantomData;
 use std::net::ToSocketAddrs;
@@ -43,6 +44,11 @@ pub trait TCPStreamHandler: 'static + Default + Clone + Sync + Send {
         Default::default()
     }
 
+    /// Invokes handle_stream, toggling readiness if the function returns control.
+    fn run(&mut self, chan: util::Channel, poll: &mio::Poll, stream: mio::net::TcpStream) -> () {
+        self.handle_stream(chan, poll, stream);
+    }
+
     /// Handler for a single HTTP request.
     fn handle_stream(&mut self, util::Channel, &mio::Poll, mio::net::TcpStream) -> ();
 }
@@ -50,7 +56,10 @@ pub trait TCPStreamHandler: 'static + Default + Clone + Sync + Send {
 /// State for a TCP backed source.
 pub struct TCP<H> {
     listeners: util::TokenSlab<mio::net::TcpListener>,
-    handlers: Vec<thread::ThreadHandle>,
+    stream_events: mio::Registration,
+    stream_events_token: mio::Token,
+    stream_events_readiness: mio::SetReadiness,
+    handlers: collections::HashMap<usize, thread::ThreadHandle>,
     phantom: PhantomData<H>,
 }
 
@@ -60,6 +69,11 @@ where
 {
     /// Constructs and starts a new TCP source.
     fn init(config: TCPConfig) -> Self {
+        /// Create registrations and for all TCP interfaces and stream handlers.
+        ///
+        /// Note - Due to restrictions in mio, we must construct these registrations
+        /// here as we are assuming this function is called directly from the main
+        /// process.  Registrations must be bound to a mio poller by the subordiante thread.
         let addrs = (config.host.as_str(), config.port).to_socket_addrs();
         let mut listeners = util::TokenSlab::<mio::net::TcpListener>::new();
         match addrs {
@@ -83,9 +97,14 @@ where
             }
         };
 
+        let (stream_events, stream_events_readiness) = mio::Registration::new2();
+        let stream_events_token = mio::Token::from(listeners.count());
         TCP {
             listeners: listeners,
-            handlers: Vec::new(),
+            stream_events: stream_events,
+            stream_events_token: stream_events_token,
+            stream_events_readiness: stream_events_readiness,
+            handlers: collections::HashMap::new(),
             phantom: PhantomData,
         }
     }
@@ -101,7 +120,16 @@ where
             ) {
                 error!("Failed to register {:?} - {:?}!", listener, e);
             }
-        }
+        };
+
+        if let Err(e) = poller.register(
+            &self.stream_events,
+            self.stream_events_token,
+            mio::Ready::readable(),
+            mio::PollOpt::edge(),
+            ) {
+                error!("Failed to register stream events - {:?}!", e);
+            };
 
         self.accept_loop(chans, &poller)
     }
@@ -119,21 +147,36 @@ where
                 Ok(_num_events) => for event in events {
                     match event.token() {
                         constants::SYSTEM => {
-                            for handler in self.handlers {
-                                handler.shutdown();
-                            }
-
+                            self.handlers.into_iter().for_each(|(_, h)| h.shutdown());
                             util::send(&mut chans, metric::Event::Shutdown);
                             return;
                         }
                         listener_token => {
-                            if let Err(e) =
-                                self.spawn_stream_handlers(&chans, listener_token)
-                            {
-                                let listener = &self.listeners[listener_token];
-                                error!("Failed to spawn stream handlers! {:?}", e);
-                                error!("Deregistering listener for {:?} due to unrecoverable error!", *listener);
-                                let _ = poll.deregister(listener);
+                            if listener_token == self.stream_events_token {
+                                // Mio event corresponding to a StreamHandler.
+                                // Currently, the only StreamHandler event flags
+                                // the StreamHandler as terminated.  Cleanup state.
+                                //
+                                // TODO - This could be made more performant by making a custom
+                                // future type which includes the id of the terminated
+                                // StreamHandler.
+                                let (ready, running) : (collections::HashMap<usize, thread::ThreadHandle>, collections::HashMap<usize, thread::ThreadHandle>) =
+                                    self.handlers
+                                        .into_iter()
+                                        .partition(|&(_, ref h)| h.ready());
+                                trace!("Removed {:?} terminated stream handlers.", ready.len());
+                                ready.into_iter().for_each(|(_, h)| h.join());
+                                self.handlers = running
+
+                            } else {
+                                if let Err(e) =
+                                    self.spawn_stream_handlers(&chans, listener_token)
+                                {
+                                    let listener = &self.listeners[listener_token];
+                                    error!("Failed to spawn stream handlers! {:?}", e);
+                                    error!("Deregistering listener for {:?} due to unrecoverable error!", *listener);
+                                    let _ = poll.deregister(listener);
+                                }
                             }
                         }
                     }
@@ -151,23 +194,28 @@ where
         loop {
             match listener.accept() {
                 Ok((stream, _addr)) => {
+                    // Actually spawn the stream handler
                     let rchans = chans.to_owned();
-                    let new_stream = thread::spawn(move |poller| {
-                        // Note - Stream handlers are allowed to crash without
-                        // compromising Cernan's ability to gracefully shutdown.
-                        poller
-                            .register(
-                                &stream,
-                                mio::Token(0),
-                                mio::Ready::readable(),
-                                mio::PollOpt::edge(),
-                            )
-                            .unwrap();
+                    let stream_events_readiness = self.stream_events_readiness.clone();
+                    let new_stream = thread::spawn2(
+                        stream_events_readiness,
+                        move |poller| {
+                            // Note - Stream handlers are allowed to crash without
+                            // compromising Cernan's ability to gracefully shutdown.
+                            poller
+                                .register(
+                                    &stream,
+                                    mio::Token(0),
+                                    mio::Ready::readable(),
+                                    mio::PollOpt::edge(),
+                                )
+                                .unwrap();
 
-                        let mut handler = H::new();
-                        handler.handle_stream(rchans, &poller, stream);
-                    });
-                    self.handlers.push(new_stream);
+                            let mut handler = H::new();
+                            handler.run(rchans, &poller, stream);
+                        });
+                    let handler_id = self.handlers.len();
+                    self.handlers.insert(handler_id, new_stream);
                 }
                 Err(e) => match e.kind() {
                     ErrorKind::ConnectionAborted

--- a/src/source/tcp.rs
+++ b/src/source/tcp.rs
@@ -4,12 +4,10 @@ use metric;
 use mio;
 use source::Source;
 use std;
-use std::collections;
 use std::io::ErrorKind;
 use std::marker::PhantomData;
 use std::net::ToSocketAddrs;
 use thread;
-use thread::Stoppable;
 use util;
 
 /// Configured for the `metric::Telemetry` source.
@@ -58,8 +56,7 @@ pub struct TCP<H> {
     listeners: util::TokenSlab<mio::net::TcpListener>,
     stream_events: mio::Registration,
     stream_events_token: mio::Token,
-    stream_events_readiness: mio::SetReadiness,
-    handlers: collections::HashMap<usize, thread::ThreadHandle>,
+    handlers: thread::ThreadPool,
     phantom: PhantomData<H>,
 }
 
@@ -69,11 +66,11 @@ where
 {
     /// Constructs and starts a new TCP source.
     fn init(config: TCPConfig) -> Self {
-        /// Create registrations and for all TCP interfaces and stream handlers.
-        ///
-        /// Note - Due to restrictions in mio, we must construct these registrations
-        /// here as we are assuming this function is called directly from the main
-        /// process.  Registrations must be bound to a mio poller by the subordiante thread.
+        // Create registrations and for all TCP interfaces and stream handlers.
+        //
+        // Note - Due to restrictions in mio, we must construct these registrations
+        // here as we are assuming this function is called directly from the main
+        // process.  Registrations must be bound to a mio poller by the subordiante thread.
         let addrs = (config.host.as_str(), config.port).to_socket_addrs();
         let mut listeners = util::TokenSlab::<mio::net::TcpListener>::new();
         match addrs {
@@ -99,12 +96,12 @@ where
 
         let (stream_events, stream_events_readiness) = mio::Registration::new2();
         let stream_events_token = mio::Token::from(listeners.count());
+        let thread_pool = thread::ThreadPool::new(Some(stream_events_readiness));
         TCP {
             listeners: listeners,
             stream_events: stream_events,
             stream_events_token: stream_events_token,
-            stream_events_readiness: stream_events_readiness,
-            handlers: collections::HashMap::new(),
+            handlers: thread_pool,
             phantom: PhantomData,
         }
     }
@@ -147,7 +144,7 @@ where
                 Ok(_num_events) => for event in events {
                     match event.token() {
                         constants::SYSTEM => {
-                            self.handlers.into_iter().for_each(|(_, h)| h.shutdown());
+                            self.handlers.shutdown();
                             util::send(&mut chans, metric::Event::Shutdown);
                             return;
                         }
@@ -156,17 +153,8 @@ where
                                 // Mio event corresponding to a StreamHandler.
                                 // Currently, the only StreamHandler event flags
                                 // the StreamHandler as terminated.  Cleanup state.
-                                //
-                                // TODO - This could be made more performant by making a custom
-                                // future type which includes the id of the terminated
-                                // StreamHandler.
-                                let (ready, running) : (collections::HashMap<usize, thread::ThreadHandle>, collections::HashMap<usize, thread::ThreadHandle>) =
-                                    self.handlers
-                                        .into_iter()
-                                        .partition(|&(_, ref h)| h.ready());
+                                let ready = self.handlers.join_ready();
                                 trace!("Removed {:?} terminated stream handlers.", ready.len());
-                                ready.into_iter().for_each(|(_, h)| h.join());
-                                self.handlers = running
 
                             } else {
                                 if let Err(e) =
@@ -196,9 +184,7 @@ where
                 Ok((stream, _addr)) => {
                     // Actually spawn the stream handler
                     let rchans = chans.to_owned();
-                    let stream_events_readiness = self.stream_events_readiness.clone();
-                    let new_stream = thread::spawn2(
-                        stream_events_readiness,
+                    self.handlers.spawn(
                         move |poller| {
                             // Note - Stream handlers are allowed to crash without
                             // compromising Cernan's ability to gracefully shutdown.
@@ -214,8 +200,6 @@ where
                             let mut handler = H::new();
                             handler.run(rchans, &poller, stream);
                         });
-                    let handler_id = self.handlers.len();
-                    self.handlers.insert(handler_id, new_stream);
                 }
                 Err(e) => match e.kind() {
                     ErrorKind::ConnectionAborted

--- a/src/source/tcp.rs
+++ b/src/source/tcp.rs
@@ -42,11 +42,6 @@ pub trait TCPStreamHandler: 'static + Default + Clone + Sync + Send {
         Default::default()
     }
 
-    /// Invokes handle_stream, toggling readiness if the function returns control.
-    fn run(&mut self, chan: util::Channel, poll: &mio::Poll, stream: mio::net::TcpStream) -> () {
-        self.handle_stream(chan, poll, stream);
-    }
-
     /// Handler for a single HTTP request.
     fn handle_stream(&mut self, util::Channel, &mio::Poll, mio::net::TcpStream) -> ();
 }
@@ -198,7 +193,7 @@ where
                                 .unwrap();
 
                             let mut handler = H::new();
-                            handler.run(rchans, &poller, stream);
+                            handler.handle_stream(rchans, &poller, stream);
                         });
                 }
                 Err(e) => match e.kind() {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -151,7 +151,7 @@ impl ThreadPool {
         joined
     }
 
-    /// Signal shutdown and block for their completion.
+    /// Serially signal shutdown and block for completion of all threads.
     pub fn shutdown(mut self) -> Vec<usize>
     {
         self.threads.drain().for_each(|(_, h)| h.shutdown());

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,6 +1,7 @@
 //! Mio enabled threading library.
 use constants;
 use mio;
+use std::option;
 use std::thread;
 
 /// Event polling structure. Alias of `mio::Poll`.
@@ -15,13 +16,20 @@ pub struct ThreadHandle {
 
     /// Readiness signal used to notify the given thread when an event is ready
     /// to be consumed on the SYSTEM channel.
-    readiness: mio::SetReadiness,
+    shutdown_event: mio::SetReadiness,
+
+    /// Poller used by the parent to poll for child events.  Currently,
+    /// the only event emitted by child threads signals that they are joinable.
+    joinable: option::Option<mio::SetReadiness>,
 }
 
 /// Trait for stoppable processes.
 pub trait Stoppable {
     /// Join the given process, blocking until it exits.
     fn join(self) -> ();
+
+    /// Is the given thread joinable?
+    fn ready(&self) -> bool;
 
     /// Gracefully shutdown the process, blocking until exit.
     fn shutdown(self) -> ();
@@ -33,12 +41,21 @@ impl Stoppable for ThreadHandle {
         self.handle.join().expect("Failed to join child thread!");
     }
 
+    fn ready(&self) -> bool {
+        if let Some(joinable) = self.joinable.clone() {
+            joinable.readiness().is_readable()
+        } else {
+            trace!("Only threads started with spawn2 are compatible with ready().");
+            false
+        }
+    }
+
     /// Gracefully shutdown the given Thread, blocking until it exists.
     ///
     /// Note - It is the responsability of the developer to ensure
     /// that thread logic polls for events occuring on the SYSTEM token.
     fn shutdown(self) {
-        self.readiness
+        self.shutdown_event
             .set_readiness(mio::Ready::readable())
             .expect("Failed to notify child thread of shutdown!");
         self.join();
@@ -50,23 +67,53 @@ pub fn spawn<F>(f: F) -> ThreadHandle
 where
     F: Send + 'static + FnOnce(mio::Poll) -> (),
 {
-    let poller = mio::Poll::new().unwrap();
-    let (registration, readiness) = mio::Registration::new2();
-
+    let child_poller = mio::Poll::new().unwrap();
+    let (shutdown_event_registration, shutdown_event) = mio::Registration::new2();
     ThreadHandle {
-        readiness: readiness,
+        shutdown_event: shutdown_event,
+        joinable: None,
 
         handle: thread::spawn(move || {
-            poller
+            child_poller
                 .register(
-                    &registration,
+                    &shutdown_event_registration,
                     constants::SYSTEM,
                     mio::Ready::readable(),
                     mio::PollOpt::edge(),
                 )
                 .expect("Failed to register system pipe");
 
-            f(poller);
+            f(child_poller);
         }),
     }
+}
+
+/// As spawn() exception the given SetReadiness will be set readable
+/// when the thread returns normally.
+pub fn spawn2<F>(joinable: mio::SetReadiness, f: F) -> ThreadHandle
+where
+    F: Send + 'static + FnOnce(mio::Poll) -> (),
+{
+    let child_poller = mio::Poll::new().unwrap();
+    let (shutdown_event_registration, shutdown_event) = mio::Registration::new2();
+    ThreadHandle {
+        shutdown_event: shutdown_event,
+        joinable: Some(joinable.clone()),
+
+        handle: thread::spawn(move || {
+            child_poller
+                .register(
+                    &shutdown_event_registration,
+                    constants::SYSTEM,
+                    mio::Ready::readable(),
+                    mio::PollOpt::edge(),
+                )
+                .expect("Failed to register system pipe");
+
+            f(child_poller);
+            joinable.set_readiness(mio::Ready::readable()).expect("Failed to set joinable!");
+        }),
+
+    }
+
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -143,8 +143,9 @@ impl ThreadPool {
         let mut joinable = self.joinable.lock().unwrap();
         let mut joined = Vec::new();
         while let Some(id) = joinable.pop() {
-            let handle = self.threads.remove(&id).unwrap();
-            handle.join();
+            if let Some(handle) = self.threads.remove(&id) {
+                handle.join();
+            }
             joined.push(id);
         }
         joined

--- a/src/util.rs
+++ b/src/util.rs
@@ -93,6 +93,7 @@ fn token_to_idx(token: &mio::Token) -> usize {
 
 /// Wrapper around Slab
 pub struct TokenSlab<E: mio::Evented> {
+    token_count: usize,
     tokens: slab::Slab<E>,
 }
 
@@ -125,6 +126,7 @@ impl<E: mio::Evented> TokenSlab<E> {
     /// of constants::SYSTEM.
     pub fn new() -> TokenSlab<E> {
         TokenSlab {
+            token_count: 0,
             tokens: slab::Slab::with_capacity(token_to_idx(&constants::SYSTEM)),
         }
     }
@@ -134,10 +136,16 @@ impl<E: mio::Evented> TokenSlab<E> {
         self.tokens.iter()
     }
 
+    /// Return the number of tokens stored in the TokenSlab.
+    pub fn count(&self) -> usize {
+        self.token_count
+    }
+
     /// Inserts a new Evented into the slab, returning a mio::Token
     /// corresponding to the index of the newly inserted type.
     pub fn insert(&mut self, thing: E) -> mio::Token {
         let idx = self.tokens.insert(thing);
+        self.token_count += 1;
         mio::Token::from(idx)
     }
 }


### PR DESCRIPTION
TCP stream handler state was never garbage collected on disconnect
resulting in memory exhaustion after sufficient TCP life cycles.

The following changes have been made to enable this garbage collection:

* source/tcp now creates a special registration and token which
corresponds to all stream handler events.

* src/thread has been extended with a new `spawn2` function which operates
as `spawn`, but takes an additional `mio::SetReadiness` which is flagged
readable after the given closure returns control.

* thread::Stoppable has been extended to include a new `ready` function
which returns true when joining the given thread is guaranteed not block.
`ready` always returns false on threads created with `spawn`.