### PR TITLE
Adds synchronous acknowledge to the avro->kafka path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,6 +2011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ slab = "0.4"
 tiny_http = "0.6"
 toml = "0.4"
 url = "1.6"
-uuid = {version = "0.6", features = ["v4"]}
+uuid = {version = "0.6", features = ["v4", "serde"]}
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/filter/json_encode_filter.rs
+++ b/src/filter/json_encode_filter.rs
@@ -113,6 +113,7 @@ impl filter::Filter for JSONEncodeFilter {
                     order_by: random(),
                     encoding: metric::Encoding::JSON,
                     bytes: serde_json::to_string(&value).unwrap().into(), /* serde_json::Value will never fail to encode */
+                    connection_id: None,
                 });
                 JSON_ENCODE_LOG_PROCESSED.fetch_add(1, Ordering::Relaxed);
             }

--- a/src/metric/ackbag.rs
+++ b/src/metric/ackbag.rs
@@ -1,3 +1,4 @@
+use std::cmp::min;
 use std::sync::{Arc, Mutex};
 use std::{thread, time};
 use util;
@@ -8,15 +9,17 @@ pub struct SyncAckProps {
     acks_received: usize
 }
 
-impl SyncAckProps {
-    pub fn new() -> Self {
+impl Default for SyncAckProps {
+    fn default() -> SyncAckProps {
         SyncAckProps {
             acks_received: 0,
         }
     }
+}
 
+impl SyncAckProps {
     pub fn ack(&mut self) {
-        self.acks_received.saturating_add(1);
+        self.acks_received = self.acks_received.saturating_add(1);
     }
 
     pub fn acks_received(&self) -> usize {
@@ -30,15 +33,16 @@ pub struct SyncAckBag {
     waiting_syncs: Arc<Mutex<SyncAckBagMap>>
 }
 
-
-impl SyncAckBag {
-    /// Creates a SyncAckBag
-    pub fn new() -> Self {
+impl Default for SyncAckBag {
+    fn default() -> SyncAckBag {
         SyncAckBag {
             waiting_syncs: Arc::new(Mutex::new(SyncAckBagMap::default()))
         }
     }
+}
 
+
+impl SyncAckBag {
     /// Return a clone of the SyncAckProps for the given key
     pub fn props_for(&self, key: Uuid) -> Option<SyncAckProps> {
         let bag = self.waiting_syncs.lock().unwrap();
@@ -51,7 +55,7 @@ impl SyncAckBag {
     /// Insert an empty-initialized SyncAckProps for the given key
     pub fn prepare_wait(&self, key: Uuid) {
         let mut bag = self.waiting_syncs.lock().unwrap();
-        bag.insert(key, SyncAckProps::new());
+        bag.insert(key, SyncAckProps::default());
     }
 
     /// Remove the given key from the internal bag
@@ -72,6 +76,11 @@ impl SyncAckBag {
 
     /// Wait until the number of acks in the specified key becomes non-zero.
     pub fn wait_for(&self, key: Uuid) {
+        self.wait_for_callback(key, thread::sleep);
+    }
+
+    /// Testability driver for wait_for
+    pub fn wait_for_callback<F: Fn(time::Duration)>(&self, key: Uuid, cb: F) {
         let max_nap_time = time::Duration::from_millis(250);
         let mut current_nap_time = time::Duration::from_millis(5);
         let mut wait = true;
@@ -81,18 +90,15 @@ impl SyncAckBag {
                 _ => wait = false
             }
             if wait {
-                thread::sleep(current_nap_time);
-                current_nap_time = current_nap_time * 2;
-                if current_nap_time > max_nap_time {
-                    current_nap_time = max_nap_time;
-                }
+                cb(current_nap_time);
+                current_nap_time = min(max_nap_time, current_nap_time * 2);
             }
         }
     }
 }
 
 lazy_static! {
-    static ref SINGLETON: SyncAckBag = SyncAckBag::new();
+    static ref SINGLETON: SyncAckBag = SyncAckBag::default();
 }
 
 /// Returns the singleton ack bag.
@@ -101,4 +107,79 @@ lazy_static! {
 /// of properties and only serialize a key into the bag.
 pub fn global_ack_bag() -> &'static SyncAckBag {
     &SINGLETON
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    #[test]
+    fn test_prepare_wait_adds_default_entry() {
+        let ack_bag = SyncAckBag::default();
+        let key = Uuid::new_v4();
+        ack_bag.prepare_wait(key);
+
+        let value = ack_bag.props_for(key).unwrap();
+        assert_eq!(value.acks_received(), 0);
+    }
+
+    #[test]
+    fn test_remove_works() {
+        let ack_bag = SyncAckBag::default();
+        let key = Uuid::new_v4();
+        ack_bag.prepare_wait(key);
+        ack_bag.remove(key);
+
+        assert_eq!(ack_bag.props_for(key).is_some(), false);
+
+        // Removing a non-existent key is fine.
+        let other_key = Uuid::new_v4();
+        ack_bag.remove(other_key);
+    }
+
+    #[test]
+    fn test_ack_adds_one_to_tally() {
+        let ack_bag = SyncAckBag::default();
+        let key = Uuid::new_v4();
+        ack_bag.prepare_wait(key);
+        ack_bag.with_props(key, |props| {
+            props.ack();
+        });
+
+        assert_eq!(ack_bag.props_for(key).unwrap().acks_received(), 1);
+    }
+
+    #[test]
+    fn test_wait_for_returns_when_there_are_acks() {
+        let ack_bag = SyncAckBag::default();
+        let key = Uuid::new_v4();
+        ack_bag.prepare_wait(key);
+        ack_bag.with_props(key, |props| {
+            props.ack();
+        });
+
+        ack_bag.wait_for(key);
+    }
+
+    #[test]
+    fn test_wait_for_sleeps_when_there_are_no_acks() {
+        let callback_count = RefCell::new(0);
+        let ack_bag = SyncAckBag::default();
+        let key = Uuid::new_v4();
+        ack_bag.prepare_wait(key);
+        ack_bag.wait_for_callback(key, |_| {
+            *callback_count.borrow_mut() += 1;
+            ack_bag.with_props(key, |props| {
+                props.ack();
+            })
+        });
+        assert_eq!(*callback_count.borrow(), 1);
+    }
+
+    #[test]
+    fn test_waiting_for_nonexistent_key_returns() {
+        let ack_bag = SyncAckBag::default();
+        ack_bag.wait_for(Uuid::new_v4());        
+    }
 }

--- a/src/metric/ackbag.rs
+++ b/src/metric/ackbag.rs
@@ -1,0 +1,104 @@
+use std::sync::{Arc, Mutex};
+use std::{thread, time};
+use util;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct SyncAckProps {
+    acks_received: usize
+}
+
+impl SyncAckProps {
+    pub fn new() -> Self {
+        SyncAckProps {
+            acks_received: 0,
+        }
+    }
+
+    pub fn ack(&mut self) {
+        self.acks_received.saturating_add(1);
+    }
+
+    pub fn acks_received(&self) -> usize {
+        self.acks_received
+    }
+}
+
+type SyncAckBagMap = util::HashMap<Uuid, SyncAckProps>;
+
+pub struct SyncAckBag {
+    waiting_syncs: Arc<Mutex<SyncAckBagMap>>
+}
+
+
+impl SyncAckBag {
+    /// Creates a SyncAckBag
+    pub fn new() -> Self {
+        SyncAckBag {
+            waiting_syncs: Arc::new(Mutex::new(SyncAckBagMap::default()))
+        }
+    }
+
+    /// Return a clone of the SyncAckProps for the given key
+    pub fn props_for(&self, key: Uuid) -> Option<SyncAckProps> {
+        let bag = self.waiting_syncs.lock().unwrap();
+        match bag.get(&key) {
+            Some(v) => Some((*v).clone()),
+            None => None
+        }
+    }
+
+    /// Insert an empty-initialized SyncAckProps for the given key
+    pub fn prepare_wait(&self, key: Uuid) {
+        let mut bag = self.waiting_syncs.lock().unwrap();
+        bag.insert(key, SyncAckProps::new());
+    }
+
+    /// Remove the given key from the internal bag
+    pub fn remove(&self, key: Uuid) {
+        let mut bag = self.waiting_syncs.lock().unwrap();
+        bag.remove(&key);
+    }
+
+    /// Retrieve a mutable reference to the SyncAckProps for the key and invoke a callback
+    /// if it exists. If the key is not present, then the callback is not called.
+    pub fn with_props<F: FnOnce(&mut SyncAckProps)>(&self, key: Uuid, f: F) {
+        let mut bag = self.waiting_syncs.lock().unwrap();
+        match bag.get_mut(&key) {
+            Some(v) => Some(f(v)),
+            None => None
+        };
+    }
+
+    /// Wait until the number of acks in the specified key becomes non-zero.
+    pub fn wait_for(&self, key: Uuid) {
+        let max_nap_time = time::Duration::from_millis(250);
+        let mut current_nap_time = time::Duration::from_millis(5);
+        let mut wait = true;
+        while wait {
+            match self.props_for(key) {
+                Some(props) => wait = props.acks_received() == 0,
+                _ => wait = false
+            }
+            if wait {
+                thread::sleep(current_nap_time);
+                current_nap_time = current_nap_time * 2;
+                if current_nap_time > max_nap_time {
+                    current_nap_time = max_nap_time;
+                }
+            }
+        }
+    }
+}
+
+lazy_static! {
+    static ref SINGLETON: SyncAckBag = SyncAckBag::new();
+}
+
+/// Returns the singleton ack bag.
+/// The ack bag is necessary because we need to protect concurrent access of raw events' data,
+/// but we can't Arc that enum due to serialization needs. Instead, we keep (and Arc) a global bag
+/// of properties and only serialize a key into the bag.
+pub fn global_ack_bag() -> &'static SyncAckBag {
+    &SINGLETON
+}

--- a/src/metric/event.rs
+++ b/src/metric/event.rs
@@ -1,4 +1,5 @@
 use metric::{LogLine, Telemetry};
+use uuid::Uuid;
 
 /// Supported event encodings.
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
@@ -40,6 +41,8 @@ pub enum Event {
         encoding: Encoding,
         /// Encoded payload.
         bytes: Vec<u8>,
+        /// Connection ID of the source on which this raw event was received
+        connection_id: Option<Uuid>
     },
 }
 

--- a/src/metric/mod.rs
+++ b/src/metric/mod.rs
@@ -1,10 +1,12 @@
 //! `metric` is a collection of the abstract datatypes that cernan operates
 //! over, plus related metadata. The main show here is
 //! `metric::Event`. Everything branches down from that.
+mod ackbag;
 mod logline;
 mod event;
 mod telemetry;
 
+pub use self::ackbag::global_ack_bag;
 pub use self::event::{Encoding, Event};
 pub use self::logline::LogLine;
 pub use self::telemetry::{AggregationMethod, Telemetry};

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -10,6 +10,7 @@ use std::marker::PhantomData;
 use thread;
 use time;
 use util::Valve;
+use uuid::Uuid;
 
 mod console;
 mod null;
@@ -151,8 +152,9 @@ where
                             order_by,
                             encoding,
                             bytes,
+                            connection_id
                         } => {
-                            self.state.deliver_raw(order_by, encoding, bytes);
+                            self.state.deliver_raw(order_by, encoding, bytes, connection_id);
                             break;
                         }
                         Event::Shutdown => {
@@ -234,6 +236,7 @@ where
         _order_by: u64,
         _encoding: Encoding,
         _bytes: Vec<u8>,
+        _connection_id: Option<Uuid>,
     ) -> () {
         // Not all sinks accept raw events.  By default, we do nothing.
     }


### PR DESCRIPTION
This changes the avro source to wait for sink acknowledgement of messages that are marked as synchronous. For now, this means that at least one sink has acknowledged the message.

Highlights:
* Each tcp stream connected to an avro source generates a UUID to serve as a connection ID.
* Connection IDs serve as keys into a bag of ack properties. 
* The ack bag is a singleton and stored externally from events. It needs to be accessible from multiple threads, but Arcs are not serializable which would break the metric::Event enum traits.
* After sending raw events to the upstream sinks, the avro source waits until the acknowledge count becomes nonzero. The wait method is abstracted into the ack bag to allow future implementation changes w/o changing the semantics. 
* The wait method is currently a sleep-and-check loop with sane sleep values, however it may be possible to make it mio evented in a future change.
