### PR TITLE
Update FlushTimer and flush_interval related code to support sub-second flushing of sinks.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cernan"
-version = "0.9.0-pre"
+version = "0.9.1-pre"
 dependencies = [
  "base64 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -6,6 +6,7 @@ use chrono::naive::NaiveDateTime;
 use chrono::offset::Utc;
 use metric::{AggregationMethod, LogLine, TagMap, Telemetry};
 use sink::{Sink, Valve};
+use source::flushes_per_second;
 
 /// The 'console' sink exists for development convenience. The sink will
 /// aggregate according to [buckets](../buckets/struct.Buckets.html) method and
@@ -39,7 +40,7 @@ impl Default for ConsoleConfig {
     fn default() -> ConsoleConfig {
         ConsoleConfig {
             bin_width: 1,
-            flush_interval: 60,
+            flush_interval: 60 * flushes_per_second(),
             config_path: None,
             tags: TagMap::default(),
         }

--- a/src/sink/elasticsearch.rs
+++ b/src/sink/elasticsearch.rs
@@ -9,6 +9,7 @@ use elastic::error::Result;
 use elastic::prelude::*;
 use metric::{LogLine, TagMap};
 use sink::{Sink, Valve};
+use source::flushes_per_second;
 use std::cmp;
 use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -94,7 +95,7 @@ impl Default for ElasticsearchConfig {
             index_type: "payload".to_string(),
             delivery_attempt_limit: 10,
             port: 9200,
-            flush_interval: 1,
+            flush_interval: 1 * flushes_per_second(),
             tags: TagMap::default(),
         }
     }

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -4,6 +4,7 @@ use metric::{TagIter, TagMap, Telemetry};
 use quantiles::histogram::Bound;
 use reqwest;
 use sink::{Sink, Valve};
+use source::flushes_per_second;
 use std::cmp;
 use std::string;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -68,7 +69,7 @@ impl Default for InfluxDBConfig {
             db: "cernan".to_string(),
             config_path: None,
             tags: Default::default(),
-            flush_interval: 60,
+            flush_interval: 60 * flushes_per_second(),
         }
     }
 }
@@ -303,7 +304,7 @@ mod test {
             port: 1987,
             config_path: Some("sinks.influxdb".to_string()),
             tags: tags,
-            flush_interval: 60,
+            flush_interval: 60 * flushes_per_second(),
         };
         let mut influxdb = InfluxDB::init(config);
         let dt_0 = Utc.ymd(1990, 6, 12).and_hms_milli(9, 10, 11, 00);

--- a/src/sink/kafka.rs
+++ b/src/sink/kafka.rs
@@ -9,6 +9,7 @@ use rdkafka::producer::FutureProducer;
 use rdkafka::producer::future_producer::DeliveryFuture;
 use rdkafka::util::current_time_millis;
 use sink::Sink;
+use source;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use util::Valve;
@@ -95,7 +96,7 @@ impl Default for KafkaConfig {
             brokers: None,
             rdkafka_config: None,
             max_message_bytes: 10 * (1 << 20),
-            flush_interval: 1,
+            flush_interval: 1 * source::flushes_per_second(),
         }
     }
 }

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -131,7 +131,7 @@ where
                                 if let Some(flush_interval) =
                                     self.state.flush_interval()
                                 {
-                                    if idx % flush_interval == 0 {
+                                    if flush_interval == 0 || idx % flush_interval == 0 {
                                         self.state.flush();
                                     }
                                 }

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -7,6 +7,7 @@ use protobuf::repeated::RepeatedField;
 use protobuf::stream::CodedOutputStream;
 use protocols::native::{AggregationMethod, LogLine, Payload, Telemetry};
 use sink::Sink;
+use source::flushes_per_second;
 use std::collections::HashMap;
 use std::io::BufWriter;
 use std::mem::replace;
@@ -54,7 +55,7 @@ impl Default for NativeConfig {
             port: 1972,
             host: "localhost".to_string(),
             config_path: None,
-            flush_interval: 60,
+            flush_interval: 60 * flushes_per_second(),
             tags: metric::TagMap::default(),
         }
     }

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -3,6 +3,7 @@
 use buckets;
 use metric::{AggregationMethod, TagIter, TagMap, Telemetry};
 use sink::{Sink, Valve};
+use source::flushes_per_second;
 use std::cmp;
 use std::collections::{HashMap, HashSet};
 use std::io::Write as IoWrite;
@@ -130,7 +131,7 @@ impl Default for WavefrontConfig {
             config_path: Some("sinks.wavefront".to_string()),
             percentiles,
             tags: TagMap::default(),
-            flush_interval: 60,
+            flush_interval: 60 * flushes_per_second(),
             pad_control: PadControl::default(),
             age_threshold: None,
         }

--- a/src/source/flush.rs
+++ b/src/source/flush.rs
@@ -13,6 +13,14 @@ pub struct FlushTimer;
 #[derive(Clone, Debug, Deserialize)]
 pub struct FlushTimerConfig;
 
+/// Returns the number of discrete flushes per second.
+pub fn flushes_per_second() -> u64 {
+    // With 100 flushes per second, we have a maximum precision of 10ms.
+    // Anything more than this is probably asking for the hopper queues to be
+    // filled more by flushes than metrics.
+    100
+}
+
 impl source::Source<FlushTimerConfig> for FlushTimer {
     /// Create a new FlushTimer. This will not produce a new thread, that must
     /// be managed by the end-user.
@@ -21,12 +29,10 @@ impl source::Source<FlushTimerConfig> for FlushTimer {
     }
 
     fn run(self, mut chans: util::Channel, _poller: mio::Poll) -> () {
-        let one_second = Duration::new(1, 0);
+        let flush_duration = Duration::from_millis(1000 / flushes_per_second());
         // idx will _always_ increase. If it's kept at u64 or greater it will
-        // overflow long past the collapse of our industrial civilization only
-        // so long as the intervals we sleep are kept to once a second or so.
-        //
-        // Heh, even past the length of the universe, really.
+        // overflow long past the collapse of our industrial civilization even
+        // if the flush interval is set to a millisecond.
         //
         // Point being, there's a theoretical overflow problem here but it's not
         // going to be hit in practice.
@@ -36,7 +42,7 @@ impl source::Source<FlushTimerConfig> for FlushTimer {
             // TimerFlush(0). This will update their last_flush_idx seen at
             // system boot.
             idx += 1;
-            sleep(one_second);
+            sleep(flush_duration);
             send(&mut chans, metric::Event::TimerFlush(idx));
         }
     }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -20,7 +20,7 @@ mod tcp;
 
 pub use self::avro::Avro;
 pub use self::file::{FileServer, FileServerConfig};
-pub use self::flush::{FlushTimer, FlushTimerConfig};
+pub use self::flush::{FlushTimer, FlushTimerConfig, flushes_per_second};
 pub use self::graphite::{Graphite, GraphiteConfig};
 pub use self::internal::{report_full_telemetry, Internal, InternalConfig};
 pub use self::native::{NativeServer, NativeServerConfig};


### PR DESCRIPTION
This introduces a flushes_per_second() public function, accessible through the source module. This PR increases the flush frequency from 1hz to 100hz. Old configuration files remain backwards compatible. The new code will continue to accept flush_interval values that are integers, but will also now accept floating point values in order to specify sub-second flush intervals. At 100hz, the lowest delay is 10ms.