### PR TITLE
fix(sink/influxdb): update influxdb port to 8086

### DIFF
--- a/examples/configs/basic.toml
+++ b/examples/configs/basic.toml
@@ -59,7 +59,7 @@ source = "cernan"
   # bin_width = 1
 
   [sinks.influxdb]
-  port = 8089
+  port = 8086
   host = "127.0.0.1"
   bin_width = 1
 

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -63,7 +63,7 @@ pub struct InfluxDBConfig {
 impl Default for InfluxDBConfig {
     fn default() -> Self {
         InfluxDBConfig {
-            port: 8089,
+            port: 8086,
             secure: true,
             host: "localhost".to_string(),
             db: "cernan".to_string(),


### PR DESCRIPTION
Hey there, I'm a new rustacean but have been working for influx for a bit and have been looking around at what rust programs there are using the db.  cernan is cool !

I thought I'd send in a tiny patch;  This just corrects InfluxDB's default port to be  8086.