### PR TITLE
Avro source protocol v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
  "quantiles 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdkafka 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdkafka 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1310,7 +1310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rdkafka"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1593,7 +1593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1615,7 +1615,7 @@ dependencies = [
  "nalgebra 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2239,7 +2239,7 @@ dependencies = [
 "checksum rand 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a89abf8d34faf9783692392dca7bcdc6e82fa84eca86ccb6301ec87f3497185"
 "checksum rand_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7a5f27547c49e5ccf8a586db3f3782fd93cf849780b21853b9d981db203302"
 "checksum rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
-"checksum rdkafka 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aaa2501275d9cd748d3c7c4d401a670b15951599a950deb6fc160ca09e143376"
+"checksum rdkafka 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bbddabc62ecb65a9466fdceec212a8fc9b4cbd8475ef872a1af0c29886861b99"
 "checksum rdkafka-sys 0.11.4-0 (registry+https://github.com/rust-lang/crates.io-index)" = "2928cdf466033859cb1e38a828bee828c101967ee309e364b41d8a40767979bb"
 "checksum redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "0a12d51a5b5fd700e6c757f15877685bfa04fd7eb60c108f01d045cafa0073c2"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
@@ -2272,7 +2272,7 @@ dependencies = [
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
-"checksum smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f8266519bc1d17d0b5b16f6c21295625d562841c708f6376f49028a43e9c11e"
+"checksum smallvec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e143aeee11cc8ece23c8336394de5138e598b84f5720fb8e895e2c6096322d88"
 "checksum snap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "174451758f7045084ae92070f18e5d8e5c53a716f4172a9c6b17ce03e7b82573"
 "checksum spade 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7acaf24b56259a7215446640e34558e7329f6a23107dfc5168a9e9236528610"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ openssl-probe = "0.1"
 protobuf = "1.7"
 quantiles = { version = "0.7", features = ["serde_support"] }
 rand = "0.5"
-rdkafka = "0.16"
+rdkafka = "0.17.0"
 regex = "1.0"
 reqwest = "0.8"
 seahash = "3.0"

--- a/src/filter/json_encode_filter.rs
+++ b/src/filter/json_encode_filter.rs
@@ -115,6 +115,7 @@ impl filter::Filter for JSONEncodeFilter {
                     bytes: serde_json::to_string(&value).unwrap().into(), /* serde_json::Value
                                                                            * will never fail to
                                                                            * encode */
+                    metadata: None,
                     connection_id: None,
                 });
                 JSON_ENCODE_LOG_PROCESSED.fetch_add(1, Ordering::Relaxed);

--- a/src/metric/event.rs
+++ b/src/metric/event.rs
@@ -1,4 +1,5 @@
 use crate::metric::{LogLine, Telemetry};
+use crate::util::HashMap;
 use uuid::Uuid;
 
 /// Supported event encodings.
@@ -11,6 +12,9 @@ pub enum Encoding {
     /// JSON
     JSON,
 }
+
+/// Metadata: additional data attached to an event
+pub type Metadata = HashMap<Vec<u8>, Vec<u8>>;
 
 /// Event: the central cernan datastructure
 ///
@@ -41,6 +45,8 @@ pub enum Event {
         encoding: Encoding,
         /// Encoded payload.
         bytes: Vec<u8>,
+        /// Metadata used by some sinks
+        metadata: Option<Metadata>,
         /// Connection ID of the source on which this raw event was received
         connection_id: Option<Uuid>,
     },

--- a/src/metric/mod.rs
+++ b/src/metric/mod.rs
@@ -7,7 +7,7 @@ mod logline;
 mod telemetry;
 
 pub use self::ackbag::global_ack_bag;
-pub use self::event::{Encoding, Event};
+pub use self::event::{Encoding, Event, Metadata};
 pub use self::logline::LogLine;
 #[cfg(test)]
 pub use self::telemetry::Value;

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -4,7 +4,7 @@
 //! and log lines it receives, other than to receive them. Individual sinks make
 //! different choices.
 
-use crate::metric::{Encoding, Event, LogLine, Telemetry};
+use crate::metric::{Encoding, Event, LogLine, Metadata, Telemetry};
 use crate::thread;
 use crate::time;
 use crate::util::Valve;
@@ -153,12 +153,14 @@ where
                             order_by,
                             encoding,
                             bytes,
+                            metadata,
                             connection_id,
                         } => {
                             self.state.deliver_raw(
                                 order_by,
                                 encoding,
                                 bytes,
+                                metadata,
                                 connection_id,
                             );
                             break;
@@ -245,6 +247,7 @@ where
         _order_by: u64,
         _encoding: Encoding,
         _bytes: Vec<u8>,
+        _metadata: Option<Metadata>,
         _connection_id: Option<Uuid>,
     ) -> () {
         // Not all sinks accept raw events.  By default, we do nothing.


### PR DESCRIPTION
This introduces a new wire format version for the Avro source.

The existing version 1 Avro source doesn't provide any support
for extensible metadata.

Introduced in version 2 is a set of key value pairs in the header that
can be used to carry arbitrary metadata.

The protocol allows up to 255 key value pairs, each with a
key of up to 255 UTF-8 encoded bytes and a value of up to 65535 bytes in
length.

The new packet structure is described below in IETF RFC format:

```
 0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                             Length                            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                            Version                            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                            Control                            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                                                               |
+                               ID                              +
|                                                               |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                                                               |
+                            ShardBy                            +
|                                                               |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|   #KV Pairs   |   Key Length  |    Key (up to 255 bytes)      |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|          Value Length         |   Value (up to 65535 bytes)   |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                          Avro N Bytes                         |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

The source remains backwards compatible with version 1 clients.