### PR TITLE
Format code with rustfmt and run rustfmt in Travis

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,7 +1,3 @@
-chain_one_line_max = 80
-error_on_line_overflow = false
-format_strings = false
 max_width = 87
-reorder_imports = true 
-reorder_imported_names = true
+format_strings = false
 wrap_comments = true 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ rust:
   - beta
   - nightly
 
+before_script:
+  - rustup component add rustfmt
 script:
+  - cargo fmt --all -- --check
   - cargo clean
   - cargo test
 

--- a/benches/buckets.rs
+++ b/benches/buckets.rs
@@ -10,13 +10,15 @@ extern crate rand;
 use cernan::buckets;
 use cernan::metric::{AggregationMethod, Telemetry};
 use chrono::{TimeZone, Utc};
-use rand::{Rng, SeedableRng, XorShiftRng};
 use rand::distributions::Alphanumeric;
+use rand::{Rng, SeedableRng, XorShiftRng};
 
 fn experiment(input: &ExperimentInput) {
     let total_adds = input.total_adds;
     let name_pool_size = input.name_pool_size;
-    let mut rng: XorShiftRng = SeedableRng::from_seed([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+    let mut rng: XorShiftRng = SeedableRng::from_seed([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]);
     let aggregations = [
         AggregationMethod::Histogram,
         AggregationMethod::Set,

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -11,8 +11,10 @@ extern crate mio;
 extern crate log;
 extern crate openssl_probe;
 
-use cernan::filter::{DelayFilterConfig, Filter, FlushBoundaryFilterConfig,
-                     JSONEncodeFilterConfig, ProgrammableFilterConfig};
+use cernan::filter::{
+    DelayFilterConfig, Filter, FlushBoundaryFilterConfig, JSONEncodeFilterConfig,
+    ProgrammableFilterConfig,
+};
 use cernan::matrix;
 use cernan::metric;
 use cernan::sink::Sink;
@@ -64,8 +66,11 @@ fn join_all(workers: HashMap<String, cernan::thread::ThreadHandle>) {
 
 macro_rules! cfg_conf {
     ($config:ident) => {
-        $config.config_path.clone().expect("[INTERNAL ERROR] no config_path")
-    }
+        $config
+            .config_path
+            .clone()
+            .expect("[INTERNAL ERROR] no config_path")
+    };
 }
 
 #[allow(cyclomatic_complexity)]
@@ -148,7 +153,8 @@ fn main() {
             args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
             args.max_hopper_queue_files,
-        ).unwrap();
+        )
+        .unwrap();
         senders.insert(config.config_path.clone(), send);
         receivers.insert(config.config_path.clone(), recv);
         config_topology.insert(config.config_path.clone(), Default::default());
@@ -161,7 +167,8 @@ fn main() {
             args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
             args.max_hopper_queue_files,
-        ).unwrap();
+        )
+        .unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
         config_topology.insert(config_path.clone(), Default::default());
@@ -174,7 +181,8 @@ fn main() {
             args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
             args.max_hopper_queue_files,
-        ).unwrap();
+        )
+        .unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
         config_topology.insert(config_path.clone(), Default::default());
@@ -187,7 +195,8 @@ fn main() {
             args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
             args.max_hopper_queue_files,
-        ).unwrap();
+        )
+        .unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
         config_topology.insert(config_path.clone(), Default::default());
@@ -200,7 +209,8 @@ fn main() {
             args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
             args.max_hopper_queue_files,
-        ).unwrap();
+        )
+        .unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
         config_topology.insert(config_path.clone(), Default::default());
@@ -213,7 +223,8 @@ fn main() {
             args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
             args.max_hopper_queue_files,
-        ).unwrap();
+        )
+        .unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
         config_topology.insert(config_path.clone(), Default::default());
@@ -226,7 +237,8 @@ fn main() {
             args.max_hopper_in_memory_bytes,
             args.max_hopper_queue_bytes,
             args.max_hopper_queue_files,
-        ).unwrap();
+        )
+        .unwrap();
         senders.insert(config_path.clone(), send);
         receivers.insert(config_path.clone(), recv);
         config_topology.insert(config_path.clone(), Default::default());
@@ -240,7 +252,8 @@ fn main() {
                 args.max_hopper_in_memory_bytes,
                 args.max_hopper_queue_bytes,
                 args.max_hopper_queue_files,
-            ).unwrap();
+            )
+            .unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), Default::default());
@@ -255,7 +268,8 @@ fn main() {
                 args.max_hopper_in_memory_bytes,
                 args.max_hopper_queue_bytes,
                 args.max_hopper_queue_files,
-            ).unwrap();
+            )
+            .unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), config.forwards.clone());
@@ -274,7 +288,8 @@ fn main() {
                 args.max_hopper_in_memory_bytes,
                 args.max_hopper_queue_bytes,
                 args.max_hopper_queue_files,
-            ).unwrap();
+            )
+            .unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), config.forwards.clone());
@@ -293,7 +308,8 @@ fn main() {
                 args.max_hopper_in_memory_bytes,
                 args.max_hopper_queue_bytes,
                 args.max_hopper_queue_files,
-            ).unwrap();
+            )
+            .unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), config.forwards.clone());
@@ -312,7 +328,8 @@ fn main() {
                 args.max_hopper_in_memory_bytes,
                 args.max_hopper_queue_bytes,
                 args.max_hopper_queue_files,
-            ).unwrap();
+            )
+            .unwrap();
             senders.insert(config_path.clone(), send);
             receivers.insert(config_path.clone(), recv);
             config_topology.insert(config_path.clone(), config.forwards.clone());

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,8 +3,8 @@
 //! Used to parse the argv/config file into a struct that
 //! the server can consume and use as configuration data.
 
-use clap::{App, Arg};
 use crate::metric::TagMap;
+use clap::{App, Arg};
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
@@ -156,9 +156,11 @@ fn parse_flush_interval(table: &toml::Value, key: &str) -> Option<u64> {
         Some(value) => match value {
             toml::Value::Float(f) => Some((f * flushes_per_second() as f64) as u64),
             toml::Value::Integer(i) => Some(*i as u64 * flushes_per_second()),
-            _ => panic!("Expected number of seconds for flush_interval config parameter.")
+            _ => panic!(
+                "Expected number of seconds for flush_interval config parameter."
+            ),
         },
-        _ => None
+        _ => None,
     }
 }
 
@@ -245,7 +247,8 @@ fn parse_config_file(buffer: &str) -> Args {
     args.data_directory = value
         .get("data-directory")
         .map(|s| {
-            let s = s.as_str()
+            let s = s
+                .as_str()
                 .expect("data-directory value must be valid string");
             Path::new(s).to_path_buf()
         })
@@ -254,14 +257,15 @@ fn parse_config_file(buffer: &str) -> Args {
     args.scripts_directory = value
         .get("scripts-directory")
         .map(|s| {
-            let s = s.as_str()
+            let s = s
+                .as_str()
                 .expect("scripts-directory value must be valid string");
             Path::new(s).to_path_buf()
         })
         .unwrap_or(args.scripts_directory);
 
-    args.flush_interval = parse_flush_interval(&value, "flush-interval")
-        .unwrap_or(args.flush_interval);
+    args.flush_interval =
+        parse_flush_interval(&value, "flush-interval").unwrap_or(args.flush_interval);
 
     let global_tags: TagMap = match value.get("tags") {
         Some(tbl) => {
@@ -273,10 +277,12 @@ fn parse_config_file(buffer: &str) -> Args {
                     None => {
                         let ktbl =
                             v.as_table().expect("tag must be a string or a table");
-                        if ktbl.get("environment")
+                        if ktbl
+                            .get("environment")
                             .map_or(false, |ev| ev.as_bool().unwrap_or(false))
                         {
-                            let env_key = ktbl.get("value")
+                            let env_key = ktbl
+                                .get("value")
                                 .expect("must have a value key")
                                 .as_str()
                                 .expect("value key must be string");
@@ -313,7 +319,8 @@ fn parse_config_file(buffer: &str) -> Args {
                         let tolerance =
                             tol.as_integer().expect("tolerance must be an integer");
                         let fwds = match tbl.get("forwards") {
-                            Some(fwds) => fwds.as_array()
+                            Some(fwds) => fwds
+                                .as_array()
                                 .expect("forwards must be an array")
                                 .to_vec()
                                 .iter()
@@ -346,7 +353,8 @@ fn parse_config_file(buffer: &str) -> Args {
                     false
                 };
                 let fwds = match tbl.get("forwards") {
-                    Some(fwds) => fwds.as_array()
+                    Some(fwds) => fwds
+                        .as_array()
                         .expect("forwards must be an array")
                         .to_vec()
                         .iter()
@@ -375,7 +383,8 @@ fn parse_config_file(buffer: &str) -> Args {
                         let tolerance =
                             tol.as_integer().expect("tolerance must be an integer");
                         let fwds = match tbl.get("forwards") {
-                            Some(fwds) => fwds.as_array()
+                            Some(fwds) => fwds
+                                .as_array()
                                 .expect("forwards must be an array")
                                 .to_vec()
                                 .iter()
@@ -405,7 +414,8 @@ fn parse_config_file(buffer: &str) -> Args {
                     Some(pth) => {
                         let path = Path::new(pth.as_str().unwrap());
                         let fwds = match tbl.get("forwards") {
-                            Some(fwds) => fwds.as_array()
+                            Some(fwds) => fwds
+                                .as_array()
                                 .expect("forwards must be an array")
                                 .to_vec()
                                 .iter()
@@ -443,14 +453,16 @@ fn parse_config_file(buffer: &str) -> Args {
             let mut res = ConsoleConfig::default();
             res.config_path = Some("sinks.console".to_string());
 
-            res.bin_width = snk.get("bin_width")
+            res.bin_width = snk
+                .get("bin_width")
                 .map(|bw| {
                     bw.as_integer()
                         .expect("could not parse sinks.console.bin_width")
                 })
                 .unwrap_or(res.bin_width);
 
-            res.flush_interval = parse_flush_interval(snk, "flush_interval").unwrap_or(args.flush_interval);
+            res.flush_interval = parse_flush_interval(snk, "flush_interval")
+                .unwrap_or(args.flush_interval);
             res.tags = global_tags.clone();
 
             res
@@ -538,17 +550,20 @@ fn parse_config_file(buffer: &str) -> Args {
             let mut res = InfluxDBConfig::default();
             res.config_path = Some("sinks.influxdb".to_string());
 
-            res.port = snk.get("port")
+            res.port = snk
+                .get("port")
                 .map(|p| {
                     p.as_integer().expect("could not parse sinks.influxdb.port") as u16
                 })
                 .unwrap_or(res.port);
 
-            res.secure = snk.get("secure")
+            res.secure = snk
+                .get("secure")
                 .map(|p| p.as_bool().expect("could not parse sinks.influxdb.secure"))
                 .unwrap_or(res.secure);
 
-            res.host = snk.get("host")
+            res.host = snk
+                .get("host")
                 .map(|p| {
                     p.as_str()
                         .expect("could not parse sinks.influxdb.host")
@@ -556,7 +571,8 @@ fn parse_config_file(buffer: &str) -> Args {
                 })
                 .unwrap_or(res.host);
 
-            res.db = snk.get("db")
+            res.db = snk
+                .get("db")
                 .map(|p| {
                     p.as_str()
                         .expect("could not parse sinks.influxdb.db")
@@ -564,58 +580,65 @@ fn parse_config_file(buffer: &str) -> Args {
                 })
                 .unwrap_or(res.db);
 
-            res.flush_interval = parse_flush_interval(snk, "flush_interval").unwrap_or(args.flush_interval);
+            res.flush_interval = parse_flush_interval(snk, "flush_interval")
+                .unwrap_or(args.flush_interval);
             res.tags = global_tags.clone();
 
             res
         });
 
-        args.prometheus = sinks.get("prometheus").map(|snk| {
-            let mut res = PrometheusConfig::default();
-            res.config_path = Some("sinks.prometheus".to_string());
+        args.prometheus =
+            sinks.get("prometheus").map(|snk| {
+                let mut res = PrometheusConfig::default();
+                res.config_path = Some("sinks.prometheus".to_string());
 
-            res.age_threshold = snk.get("age_threshold")
-                .map(|p| {
-                    Some(p.as_integer()
-                        .expect("could not parse sinks.prometheus.age_threshold")
-                        as u64)
-                })
-                .unwrap_or(res.age_threshold);
+                res.age_threshold =
+                    snk.get("age_threshold")
+                        .map(|p| {
+                            Some(p.as_integer().expect(
+                                "could not parse sinks.prometheus.age_threshold",
+                            ) as u64)
+                        })
+                        .unwrap_or(res.age_threshold);
 
-            res.port = snk.get("port")
-                .map(|p| {
-                    p.as_integer()
-                        .expect("could not parse sinks.prometheus.port")
-                        as u16
-                })
-                .unwrap_or(res.port);
+                res.port = snk
+                    .get("port")
+                    .map(|p| {
+                        p.as_integer()
+                            .expect("could not parse sinks.prometheus.port")
+                            as u16
+                    })
+                    .unwrap_or(res.port);
 
-            res.host = snk.get("host")
-                .map(|p| {
-                    p.as_str()
-                        .expect("could not parse sinks.prometheus.host")
-                        .to_string()
-                })
-                .unwrap_or(res.host);
+                res.host = snk
+                    .get("host")
+                    .map(|p| {
+                        p.as_str()
+                            .expect("could not parse sinks.prometheus.host")
+                            .to_string()
+                    })
+                    .unwrap_or(res.host);
 
-            res.capacity_in_seconds = snk.get("capacity_in_seconds")
-                .map(|p| {
-                    p.as_integer()
-                        .expect("could not parse sinks.prometheus.capacity_in_seconds")
-                        as usize
-                })
-                .unwrap_or(res.capacity_in_seconds);
+                res.capacity_in_seconds = snk
+                    .get("capacity_in_seconds")
+                    .map(|p| {
+                        p.as_integer().expect(
+                            "could not parse sinks.prometheus.capacity_in_seconds",
+                        ) as usize
+                    })
+                    .unwrap_or(res.capacity_in_seconds);
 
-            res.tags = global_tags.clone();
+                res.tags = global_tags.clone();
 
-            res
-        });
+                res
+            });
 
         args.elasticsearch = sinks.get("elasticsearch").map(|snk| {
             let mut res = ElasticsearchConfig::default();
             res.config_path = Some("sinks.elasticsearch".to_string());
 
-            res.delivery_attempt_limit = snk.get("delivery_attempt_limit")
+            res.delivery_attempt_limit = snk
+                .get("delivery_attempt_limit")
                 .map(|p| {
                     p.as_integer().expect(
                         "could not parse sinks.elasticsearch.delivery_attempt_limit",
@@ -623,7 +646,8 @@ fn parse_config_file(buffer: &str) -> Args {
                 })
                 .unwrap_or(res.delivery_attempt_limit);
 
-            res.port = snk.get("port")
+            res.port = snk
+                .get("port")
                 .map(|p| {
                     p.as_integer()
                         .expect("could not parse sinks.elasticsearch.port")
@@ -631,7 +655,8 @@ fn parse_config_file(buffer: &str) -> Args {
                 })
                 .unwrap_or(res.port);
 
-            res.host = snk.get("host")
+            res.host = snk
+                .get("host")
                 .map(|p| {
                     p.as_str()
                         .expect("could not parse sinks.elasticsearch.host")
@@ -639,7 +664,8 @@ fn parse_config_file(buffer: &str) -> Args {
                 })
                 .unwrap_or(res.host);
 
-            res.index_prefix = snk.get("index-prefix")
+            res.index_prefix = snk
+                .get("index-prefix")
                 .map(|p| {
                     Some(
                         p.as_str()
@@ -649,14 +675,16 @@ fn parse_config_file(buffer: &str) -> Args {
                 })
                 .unwrap_or(res.index_prefix);
 
-            res.secure = snk.get("secure")
+            res.secure = snk
+                .get("secure")
                 .map(|bw| {
                     bw.as_bool()
                         .expect("could not parse sinks.elasticsearch.secure")
                 })
                 .unwrap_or(res.secure);
 
-            res.index_type = snk.get("index_type")
+            res.index_type = snk
+                .get("index_type")
                 .map(|bw| {
                     bw.as_str()
                         .expect("could not parse sinks.elasticsearch.index_type")
@@ -664,7 +692,8 @@ fn parse_config_file(buffer: &str) -> Args {
                 })
                 .unwrap_or(res.index_type);
 
-            res.flush_interval = parse_flush_interval(snk, "flush_interval").unwrap_or(args.flush_interval);
+            res.flush_interval = parse_flush_interval(snk, "flush_interval")
+                .unwrap_or(args.flush_interval);
             res.tags = global_tags.clone();
 
             res
@@ -674,13 +703,15 @@ fn parse_config_file(buffer: &str) -> Args {
             let mut res = NativeConfig::default();
             res.config_path = Some("sinks.native".to_string());
 
-            res.port = snk.get("port")
+            res.port = snk
+                .get("port")
                 .map(|p| {
                     p.as_integer().expect("could not parse sinks.native.port") as u16
                 })
                 .unwrap_or(res.port);
 
-            res.host = snk.get("host")
+            res.host = snk
+                .get("host")
                 .map(|p| {
                     p.as_str()
                         .expect("could not parse sinks.native.host")
@@ -688,7 +719,8 @@ fn parse_config_file(buffer: &str) -> Args {
                 })
                 .unwrap_or(res.host);
 
-            res.flush_interval = parse_flush_interval(snk, "flush_interval").unwrap_or(args.flush_interval);
+            res.flush_interval = parse_flush_interval(snk, "flush_interval")
+                .unwrap_or(args.flush_interval);
             res.tags = global_tags.clone();
 
             res
@@ -697,7 +729,8 @@ fn parse_config_file(buffer: &str) -> Args {
         args.kafkas = sinks.get("kafka").map(|snk| {
             let mut kafkas = Vec::new();
             for (name, tbl) in snk.as_table().unwrap().iter() {
-                let is_enabled = tbl.get("enabled")
+                let is_enabled = tbl
+                    .get("enabled")
                     .unwrap_or(&toml::Value::Boolean(true))
                     .as_bool()
                     .expect("must be a bool");
@@ -709,7 +742,8 @@ fn parse_config_file(buffer: &str) -> Args {
                 let config_path = &format!("sinks.kafka.{}", name)[..];
                 res.config_path = Some(config_path.to_string());
 
-                let topic = tbl.get("topic")
+                let topic = tbl
+                    .get("topic")
                     .map(|x| x.as_str().expect("topic must be a string").to_string());
                 if topic.is_none() {
                     warn!(
@@ -738,23 +772,16 @@ fn parse_config_file(buffer: &str) -> Args {
                 // Sooo many options:
                 // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
                 res.rdkafka_config = tbl.get("librdkafka").map(|x| {
-                    let tbl = x.as_table()
+                    let tbl = x
+                        .as_table()
                         .expect("librdkafka configuration should be a table");
                     let mut map = HashMap::new();
                     for (key, value) in tbl.iter() {
                         match *value {
-                            toml::Value::Integer(i) => {
-                                map.insert(key.clone(), format!("{}", i))
-                            }
-                            toml::Value::String(ref s) => {
-                                map.insert(key.clone(), s.clone())
-                            }
-                            toml::Value::Float(f) => {
-                                map.insert(key.clone(), format!("{}", f))
-                            }
-                            toml::Value::Boolean(b) => {
-                                map.insert(key.clone(), format!("{}", b))
-                            }
+                            toml::Value::Integer(i) => map.insert(key.clone(), format!("{}", i)),
+                            toml::Value::String(ref s) => map.insert(key.clone(), s.clone()),
+                            toml::Value::Float(f) => map.insert(key.clone(), format!("{}", f)),
+                            toml::Value::Boolean(b) => map.insert(key.clone(), format!("{}", b)),
                             _ => {
                                 warn!(
                                     "ignoring {:?} in {}.librdkafka: unusable type {}",
@@ -769,8 +796,10 @@ fn parse_config_file(buffer: &str) -> Args {
                     map
                 });
 
-                res.flush_interval = parse_flush_interval(tbl, "flush_interval").unwrap_or(args.flush_interval);
-                res.max_message_bytes = tbl.get("max_message_bytes")
+                res.flush_interval =
+                    parse_flush_interval(tbl, "flush_interval").unwrap_or(args.flush_interval);
+                res.max_message_bytes = tbl
+                    .get("max_message_bytes")
                     .map(|fi| {
                         fi.as_integer()
                             .expect("could not parse sinks.kafka.max_message_bytes")
@@ -798,7 +827,8 @@ fn parse_config_file(buffer: &str) -> Args {
                         fl.path = Some(Path::new(pth.as_str().unwrap()).to_path_buf());
                         fl.config_path = Some(format!("sources.files.{}", pth));
 
-                        fl.forwards = tbl.get("forwards")
+                        fl.forwards = tbl
+                            .get("forwards")
                             .map(|fwd| {
                                 fwd.as_array()
                                     .expect("forwards must be an array")
@@ -818,7 +848,8 @@ fn parse_config_file(buffer: &str) -> Args {
                         //
                         // Someday a static analysis system will flag this as
                         // unsafe. Welcome.
-                        fl.max_read_bytes = tbl.get("max_read_bytes")
+                        fl.max_read_bytes = tbl
+                            .get("max_read_bytes")
                             .map(|mrl| {
                                 mrl.as_integer()
                                     .expect("could not parse max_read_bytes")
@@ -837,7 +868,8 @@ fn parse_config_file(buffer: &str) -> Args {
         args.statsds = sources.get("statsd").map(|src| {
             let mut statsds = HashMap::default();
             for (name, tbl) in src.as_table().unwrap().iter() {
-                let is_enabled = tbl.get("enabled")
+                let is_enabled = tbl
+                    .get("enabled")
                     .unwrap_or(&toml::Value::Boolean(true))
                     .as_bool()
                     .expect("must be a bool");
@@ -845,13 +877,15 @@ fn parse_config_file(buffer: &str) -> Args {
                     let mut res = StatsdConfig::default();
                     res.config_path = Some(name.clone());
 
-                    res.port = tbl.get("port")
+                    res.port = tbl
+                        .get("port")
                         .map(|p| {
                             p.as_integer().expect("could not parse statsd port") as u16
                         })
                         .unwrap_or(res.port);
 
-                    res.host = tbl.get("host")
+                    res.host = tbl
+                        .get("host")
                         .map(|p| {
                             p.as_str()
                                 .expect("could not parse statsd host")
@@ -859,7 +893,8 @@ fn parse_config_file(buffer: &str) -> Args {
                         })
                         .unwrap_or(res.host);
 
-                    res.forwards = tbl.get("forwards")
+                    res.forwards = tbl
+                        .get("forwards")
                         .map(|fwd| {
                             fwd.as_array()
                                 .expect("forwards must be an array")
@@ -870,7 +905,8 @@ fn parse_config_file(buffer: &str) -> Args {
                         })
                         .unwrap_or(res.forwards);
 
-                    res.parse_config = tbl.get("mapping")
+                    res.parse_config = tbl
+                        .get("mapping")
                         .map(|cfg| {
                             let mut masks = Vec::new();
                             for (_, tbl) in
@@ -879,9 +915,11 @@ fn parse_config_file(buffer: &str) -> Args {
                                 if let Some(mask) = tbl.get("mask") {
                                     let re = ::regex::Regex::new(
                                         mask.as_str().expect("mask must be a string"),
-                                    ).expect("mask is not a valid regex");
+                                    )
+                                    .expect("mask is not a valid regex");
                                     if let Some(bnds) = tbl.get("bounds") {
-                                        let bounds = bnds.as_array()
+                                        let bounds = bnds
+                                            .as_array()
                                             .expect("bounds must be an array")
                                             .to_vec()
                                             .iter()
@@ -902,7 +940,8 @@ fn parse_config_file(buffer: &str) -> Args {
                         })
                         .unwrap_or(res.parse_config);
 
-                    let error_bound = tbl.get("summarize_error_bound")
+                    let error_bound = tbl
+                        .get("summarize_error_bound")
                         .map(|p| {
                             p.as_float()
                                 .expect("summarize_error_bound must be a flaot")
@@ -923,7 +962,8 @@ fn parse_config_file(buffer: &str) -> Args {
         args.graphites = sources.get("graphite").map(|src| {
             let mut graphites = HashMap::default();
             for (name, tbl) in src.as_table().unwrap().iter() {
-                let is_enabled = tbl.get("enabled")
+                let is_enabled = tbl
+                    .get("enabled")
                     .unwrap_or(&toml::Value::Boolean(true))
                     .as_bool()
                     .expect("must be a bool");
@@ -931,14 +971,16 @@ fn parse_config_file(buffer: &str) -> Args {
                     let mut res = GraphiteConfig::default();
                     res.config_path = Some(name.clone());
 
-                    res.port = tbl.get("port")
+                    res.port = tbl
+                        .get("port")
                         .map(|p| {
                             p.as_integer().expect("could not parse graphite port")
                                 as u16
                         })
                         .unwrap_or(res.port);
 
-                    res.host = tbl.get("host")
+                    res.host = tbl
+                        .get("host")
                         .map(|p| {
                             p.as_str()
                                 .expect("could not parse graphite host")
@@ -946,7 +988,8 @@ fn parse_config_file(buffer: &str) -> Args {
                         })
                         .unwrap_or(res.host);
 
-                    res.forwards = tbl.get("forwards")
+                    res.forwards = tbl
+                        .get("forwards")
                         .map(|fwd| {
                             fwd.as_array()
                                 .expect("forwards must be an array")
@@ -969,7 +1012,8 @@ fn parse_config_file(buffer: &str) -> Args {
         args.avros = sources.get("avro").map(|src| {
             let mut avros = HashMap::default();
             for (name, tbl) in src.as_table().unwrap().iter() {
-                let is_enabled = tbl.get("enabled")
+                let is_enabled = tbl
+                    .get("enabled")
                     .unwrap_or(&toml::Value::Boolean(true))
                     .as_bool()
                     .expect("must be a bool");
@@ -980,19 +1024,22 @@ fn parse_config_file(buffer: &str) -> Args {
                     // If the user doesn't provide a port, we assume 2002.
                     // This default value has been selected to commemorate the year
                     // Buzz Aldrin punched Bart Sibrel in the face.
-                    res.port = tbl.get("port")
+                    res.port = tbl
+                        .get("port")
                         .map(|p| {
                             p.as_integer().expect("could not parse avro port") as u16
                         })
                         .unwrap_or(2002);
 
-                    res.host = tbl.get("host")
+                    res.host = tbl
+                        .get("host")
                         .map(|p| {
                             p.as_str().expect("could not parse avro host").to_string()
                         })
                         .unwrap_or(res.host);
 
-                    res.forwards = tbl.get("forwards")
+                    res.forwards = tbl
+                        .get("forwards")
                         .map(|fwd| {
                             fwd.as_array()
                                 .expect("forwards must be an array")
@@ -1015,7 +1062,8 @@ fn parse_config_file(buffer: &str) -> Args {
         args.native_server_config = sources.get("native").map(|src| {
             let mut native_server_config = HashMap::default();
             for (name, tbl) in src.as_table().unwrap().iter() {
-                let is_enabled = tbl.get("enabled")
+                let is_enabled = tbl
+                    .get("enabled")
                     .unwrap_or(&toml::Value::Boolean(true))
                     .as_bool()
                     .expect("must be a bool");
@@ -1023,19 +1071,22 @@ fn parse_config_file(buffer: &str) -> Args {
                     let mut res = NativeServerConfig::default();
                     res.config_path = Some(format!("sources.native.{}", name));
 
-                    res.port = tbl.get("port")
+                    res.port = tbl
+                        .get("port")
                         .map(|p| {
                             p.as_integer().expect("could not parse native port") as u16
                         })
                         .unwrap_or(res.port);
 
-                    res.ip = tbl.get("ip")
+                    res.ip = tbl
+                        .get("ip")
                         .map(|p| {
                             p.as_str().expect("could not parse native ip").to_string()
                         })
                         .unwrap_or(res.ip);
 
-                    res.forwards = tbl.get("forwards")
+                    res.forwards = tbl
+                        .get("forwards")
                         .map(|fwd| {
                             fwd.as_array()
                                 .expect("forwards must be an array")
@@ -1061,7 +1112,8 @@ fn parse_config_file(buffer: &str) -> Args {
                 let mut res = InternalConfig::default();
                 res.config_path = Some("sources.internal".to_string());
 
-                res.forwards = src.get("forwards")
+                res.forwards = src
+                    .get("forwards")
                     .map(|fwd| {
                         fwd.as_array()
                             .expect("forwards must be an array")
@@ -1243,9 +1295,10 @@ scripts-directory = "/foo/bar"
             (String::from("setting.four.five"), String::from("4.5")),
             (String::from("setting.six"), String::from("true")),
             (String::from("setting.seven"), String::from("false")),
-        ].iter()
-            .cloned()
-            .collect();
+        ]
+        .iter()
+        .cloned()
+        .collect();
 
         let k = &kafkas[0];
         assert_eq!(k.topic_name, Some(String::from("foobar")));
@@ -1331,7 +1384,10 @@ scripts-directory = "/foo/bar"
         let native_sink_config = args.native_sink_config.unwrap();
         assert_eq!(native_sink_config.host, String::from("foo.example.com"));
         assert_eq!(native_sink_config.port, 1972);
-        assert_eq!(native_sink_config.flush_interval, 120 * flushes_per_second());
+        assert_eq!(
+            native_sink_config.flush_interval,
+            120 * flushes_per_second()
+        );
     }
 
     #[test]
@@ -1901,6 +1957,9 @@ scripts-directory = "/foo/bar"
         "#;
 
         let args_f = parse_config_file(config_f);
-        assert_eq!(args_f.flush_interval, (1.5 * flushes_per_second() as f64) as u64);
+        assert_eq!(
+            args_f.flush_interval,
+            (1.5 * flushes_per_second() as f64) as u64
+        );
     }
 }

--- a/src/filter/delay_filter.rs
+++ b/src/filter/delay_filter.rs
@@ -7,8 +7,8 @@
 
 use crate::filter;
 use crate::metric;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use crate::time;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Total number of telemetry rejected for age
 pub static DELAY_TELEM_REJECT: AtomicUsize = AtomicUsize::new(0);

--- a/src/filter/json_encode_filter.rs
+++ b/src/filter/json_encode_filter.rs
@@ -8,15 +8,15 @@
 //! `LogLine` metadata. Otherwise, the original line will be included simply as
 //! a string.
 
-use chrono::DateTime;
-use chrono::naive::NaiveDateTime;
-use chrono::offset::Utc;
 use crate::filter;
 use crate::metric;
+use chrono::naive::NaiveDateTime;
+use chrono::offset::Utc;
+use chrono::DateTime;
 use rand::random;
 use serde_json;
-use serde_json::Value;
 use serde_json::map::Map;
+use serde_json::Value;
 use std::iter::FromIterator;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -112,7 +112,9 @@ impl filter::Filter for JSONEncodeFilter {
                 res.push(metric::Event::Raw {
                     order_by: random(),
                     encoding: metric::Encoding::JSON,
-                    bytes: serde_json::to_string(&value).unwrap().into(), /* serde_json::Value will never fail to encode */
+                    bytes: serde_json::to_string(&value).unwrap().into(), /* serde_json::Value
+                                                                           * will never fail to
+                                                                           * encode */
                     connection_id: None,
                 });
                 JSON_ENCODE_LOG_PROCESSED.fetch_add(1, Ordering::Relaxed);
@@ -126,8 +128,8 @@ impl filter::Filter for JSONEncodeFilter {
     }
 }
 
-/// Convenience helper to take a json!() macro you know is an object and get back a
-/// Map<String, Value>, instead of a generic Value.
+/// Convenience helper to take a json!() macro you know is an object and get
+/// back a Map<String, Value>, instead of a generic Value.
 fn json_to_object(v: Value) -> Map<String, Value> {
     if let Value::Object(obj) = v {
         obj
@@ -136,9 +138,9 @@ fn json_to_object(v: Value) -> Map<String, Value> {
     }
 }
 
-/// Merge JSON objects, with values from earlier objects in the list overriding later
-/// ones. Note this is not a recursive merge - if the same key is in many objects, we
-/// simply take the value from the earliest one.
+/// Merge JSON objects, with values from earlier objects in the list overriding
+/// later ones. Note this is not a recursive merge - if the same key is in many
+/// objects, we simply take the value from the earliest one.
 fn merge_objects(objs: Vec<Map<String, Value>>) -> Map<String, Value> {
     let mut result = Map::new();
     for obj in objs {
@@ -159,8 +161,8 @@ mod test {
     use crate::filter::Filter;
     use crate::metric;
     use quickcheck::QuickCheck;
-    use serde_json::Value;
     use serde_json::map::Map;
+    use serde_json::Value;
 
     fn process_event(parse_line: bool, event: metric::Event) -> Value {
         let mut filter = JSONEncodeFilter {
@@ -304,9 +306,11 @@ mod test {
             let result = merge_objects(objs.clone());
             for (key, result_value) in result {
                 match objs.iter().find(|obj| obj.contains_key(&key)) {
-                    Some(obj) => if obj[&key] != result_value {
-                        return false; // result value did not match first obj containing key
-                    },
+                    Some(obj) => {
+                        if obj[&key] != result_value {
+                            return false; // result value did not match first obj containing key
+                        }
+                    }
                     None => return false, // key in result was not in any input objs
                 }
             }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -5,18 +5,20 @@
 //! stream members as they come through. Exact behaviour varies by filters. The
 //! filter receives on an input channel and outputs over its forwards.
 
-use hopper;
 use crate::metric;
 use crate::time;
 use crate::util;
+use hopper;
 
-mod programmable_filter;
 pub mod delay_filter;
 mod flush_boundary_filter;
 pub mod json_encode_filter;
+mod programmable_filter;
 
 pub use self::delay_filter::{DelayFilter, DelayFilterConfig};
-pub use self::flush_boundary_filter::{FlushBoundaryFilter, FlushBoundaryFilterConfig};
+pub use self::flush_boundary_filter::{
+    FlushBoundaryFilter, FlushBoundaryFilterConfig,
+};
 pub use self::json_encode_filter::{JSONEncodeFilter, JSONEncodeFilterConfig};
 pub use self::programmable_filter::{ProgrammableFilter, ProgrammableFilterConfig};
 
@@ -92,9 +94,11 @@ pub trait Filter {
                 Some(event) => {
                     attempts = 0;
                     match self.process(event, &mut events) {
-                        Ok(()) => for ev in events.drain(..) {
-                            util::send(&mut chans, ev)
-                        },
+                        Ok(()) => {
+                            for ev in events.drain(..) {
+                                util::send(&mut chans, ev)
+                            }
+                        }
                         Err(fe) => {
                             error!(
                                 "Failed to run filter with error: {:?}",

--- a/src/filter/programmable_filter.rs
+++ b/src/filter/programmable_filter.rs
@@ -1,9 +1,9 @@
 use crate::filter;
-use libc::c_int;
 use crate::metric;
+use libc::c_int;
 use mond;
-use mond::{Function, State, ThreadStatus};
 use mond::ffi::lua_State;
+use mond::{Function, State, ThreadStatus};
 use std::path::PathBuf;
 
 struct Payload<'a> {
@@ -539,7 +539,8 @@ impl filter::Filter for ProgrammableFilter {
     ) -> Result<(), filter::FilterError> {
         match event {
             metric::Event::Telemetry(m) => {
-                let pyld = Payload::from_metric(m, &self.global_tags, self.path.as_str());
+                let pyld =
+                    Payload::from_metric(m, &self.global_tags, self.path.as_str());
                 run_lua_func(&mut self.state, "process_metric", res, pyld)
             }
             metric::Event::TimerFlush(flush_idx)

--- a/src/http.rs
+++ b/src/http.rs
@@ -2,8 +2,8 @@
 
 extern crate tiny_http;
 
-use std;
 use crate::thread;
+use std;
 
 /// HTTP request. Alias of `tiny_http::Request`.
 pub type Request = tiny_http::Request;
@@ -46,9 +46,11 @@ where
             Ok(_) => match tiny_http_server
                 .recv_timeout(std::time::Duration::from_millis(1000))
             {
-                Ok(maybe_a_request) => if let Some(request) = maybe_a_request {
-                    handler.handle(request);
-                },
+                Ok(maybe_a_request) => {
+                    if let Some(request) = maybe_a_request {
+                        handler.handle(request);
+                    }
+                }
 
                 Err(e) => {
                     panic!(format!("Failed during recv_timeout {:?}", e));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,12 @@
 //! If you'd like to learn more, please do have a look in
 //! our [wiki](https://github.com/postmates/cernan/wiki/).
 #![allow(unknown_lints)]
-#![deny(trivial_numeric_casts, missing_docs, unstable_features, unused_import_braces)]
+#![deny(
+    trivial_numeric_casts,
+    missing_docs,
+    unstable_features,
+    unused_import_braces
+)]
 extern crate base64;
 extern crate byteorder;
 extern crate chrono;
@@ -57,16 +62,16 @@ extern crate serde_derive;
 #[cfg(test)]
 extern crate quickcheck;
 
-pub mod sink;
 pub mod buckets;
 pub mod config;
-pub mod metric;
-pub mod time;
-pub mod source;
-pub mod filter;
-pub mod util;
 pub mod constants;
-pub mod thread;
-pub mod protocols;
+pub mod filter;
 pub mod http;
 pub mod matrix;
+pub mod metric;
+pub mod protocols;
+pub mod sink;
+pub mod source;
+pub mod thread;
+pub mod time;
+pub mod util;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,9 +1,9 @@
 //! Collection of matrix implementations.
 
+use crate::util;
 use std;
 use std::fmt::Debug;
 use std::str::FromStr;
-use crate::util;
 
 type AdjacencyMap<T> = util::HashMap<String, Option<T>>;
 
@@ -112,7 +112,8 @@ impl<M: Clone + Debug> Adjacency<M> {
     /// Option values will be unwrapped and None values filtered.
     pub fn pop_metadata(&mut self, id: &str) -> Vec<M> {
         match self.pop(id) {
-            Some(map) => map.into_iter()
+            Some(map) => map
+                .into_iter()
                 .filter(|&(ref _k, ref option_v)| option_v.is_some())
                 .map(|(_, some_v)| some_v.unwrap())
                 .collect(),

--- a/src/metric/event.rs
+++ b/src/metric/event.rs
@@ -42,7 +42,7 @@ pub enum Event {
         /// Encoded payload.
         bytes: Vec<u8>,
         /// Connection ID of the source on which this raw event was received
-        connection_id: Option<Uuid>
+        connection_id: Option<Uuid>,
     },
 }
 

--- a/src/metric/logline.rs
+++ b/src/metric/logline.rs
@@ -1,6 +1,6 @@
 use crate::metric::{TagIter, TagMap};
-use std::collections::HashSet;
 use crate::time;
+use std::collections::HashSet;
 
 /// An unstructured piece of text, plus associated metadata
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]

--- a/src/metric/mod.rs
+++ b/src/metric/mod.rs
@@ -2,19 +2,19 @@
 //! over, plus related metadata. The main show here is
 //! `metric::Event`. Everything branches down from that.
 mod ackbag;
-mod logline;
 mod event;
+mod logline;
 mod telemetry;
 
 pub use self::ackbag::global_ack_bag;
 pub use self::event::{Encoding, Event};
 pub use self::logline::LogLine;
-pub use self::telemetry::{AggregationMethod, Telemetry};
 #[cfg(test)]
 pub use self::telemetry::Value;
+pub use self::telemetry::{AggregationMethod, Telemetry};
+use crate::util;
 use std::cmp;
 use std::collections::{hash_map, HashSet};
-use crate::util;
 
 /// A common type in cernan, a map from string to string
 pub type TagMap = util::HashMap<String, String>;

--- a/src/protocols/graphite.rs
+++ b/src/protocols/graphite.rs
@@ -49,14 +49,13 @@ pub fn parse_graphite(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{TimeZone, Utc};
     use crate::metric::{AggregationMethod, Telemetry};
+    use chrono::{TimeZone, Utc};
     use std::sync;
 
     #[test]
     fn test_parse_graphite() {
-        let pyld =
-            "fst 1 101\nsnd -2.0 202\nthr 3 303\nfth@fth 4 404\nfv%fv 5 505\ns-th 6 606\n";
+        let pyld = "fst 1 101\nsnd -2.0 202\nthr 3 303\nfth@fth 4 404\nfv%fv 5 505\ns-th 6 606\n";
         let mut res = Vec::new();
         let metric = sync::Arc::new(Some(Telemetry::default()));
         assert!(parse_graphite(pyld, &mut res, &metric));

--- a/src/protocols/statsd.rs
+++ b/src/protocols/statsd.rs
@@ -5,9 +5,9 @@
 use crate::metric;
 use crate::metric::AggregationMethod;
 use crate::source::StatsdParseConfig;
+use crate::time;
 use std::str::FromStr;
 use std::sync;
-use crate::time;
 
 /// Valid message formats are:
 ///
@@ -45,11 +45,11 @@ pub fn parse_statsd(
                                 Ok(f) => f,
                                 Err(_) => return false,
                             };
-                        let mut metric = sync::Arc::make_mut(&mut sync::Arc::clone(
-                            metric,
-                        )).take()
-                            .unwrap()
-                            .thaw();
+                        let mut metric =
+                            sync::Arc::make_mut(&mut sync::Arc::clone(metric))
+                                .take()
+                                .unwrap()
+                                .thaw();
                         metric = metric.name(name);
                         metric = metric.value(val);
                         metric = metric.timestamp(time::now());
@@ -319,7 +319,8 @@ mod tests {
                         assert!(
                             (sline.value * (1.0 / sline.sample_rate)
                                 - telem.value().unwrap())
-                                .abs() < 0.0001
+                            .abs()
+                                < 0.0001
                         );
                     } else {
                         assert!((sline.value - telem.value().unwrap()).abs() < 0.0001);

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -1,12 +1,12 @@
 //! Console Event logger.
 
 use crate::buckets::Buckets;
-use chrono::DateTime;
-use chrono::naive::NaiveDateTime;
-use chrono::offset::Utc;
 use crate::metric::{AggregationMethod, LogLine, TagMap, Telemetry};
 use crate::sink::{Sink, Valve};
 use crate::source::flushes_per_second;
+use chrono::naive::NaiveDateTime;
+use chrono::offset::Utc;
+use chrono::DateTime;
 
 /// The 'console' sink exists for development convenience. The sink will
 /// aggregate according to [buckets](../buckets/struct.Buckets.html) method and

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -4,22 +4,22 @@
 //! and log lines it receives, other than to receive them. Individual sinks make
 //! different choices.
 
-use hopper;
 use crate::metric::{Encoding, Event, LogLine, Telemetry};
-use std::marker::PhantomData;
 use crate::thread;
 use crate::time;
 use crate::util::Valve;
+use hopper;
+use std::marker::PhantomData;
 use uuid::Uuid;
 
 mod console;
-mod null;
-pub mod wavefront;
-mod native;
-pub mod influxdb;
-pub mod prometheus;
 pub mod elasticsearch;
+pub mod influxdb;
 pub mod kafka;
+mod native;
+mod null;
+pub mod prometheus;
+pub mod wavefront;
 
 pub use self::console::{Console, ConsoleConfig};
 pub use self::elasticsearch::{Elasticsearch, ElasticsearchConfig};
@@ -132,7 +132,8 @@ where
                                 if let Some(flush_interval) =
                                     self.state.flush_interval()
                                 {
-                                    if flush_interval == 0 || idx % flush_interval == 0 {
+                                    if flush_interval == 0 || idx % flush_interval == 0
+                                    {
                                         self.state.flush();
                                     }
                                 }
@@ -152,9 +153,14 @@ where
                             order_by,
                             encoding,
                             bytes,
-                            connection_id
+                            connection_id,
                         } => {
-                            self.state.deliver_raw(order_by, encoding, bytes, connection_id);
+                            self.state.deliver_raw(
+                                order_by,
+                                encoding,
+                                bytes,
+                                connection_id,
+                            );
                             break;
                         }
                         Event::Shutdown => {
@@ -169,7 +175,10 @@ where
                             // upstream sources/filters.
                             total_shutdowns += 1;
                             if total_shutdowns >= self.sources.len() {
-                                trace!("Received shutdown from every configured source: {:?}", self.sources);
+                                trace!(
+                                    "Received shutdown from every configured source: {:?}",
+                                    self.sources
+                                );
                                 self.state.shutdown();
                                 return;
                             }

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -1,18 +1,18 @@
 //! Sink for Cernan's native protocol.
 
-use byteorder::{BigEndian, ByteOrder};
 use crate::metric;
-use protobuf::Message;
-use protobuf::repeated::RepeatedField;
-use protobuf::stream::CodedOutputStream;
 use crate::protocols::native::{AggregationMethod, LogLine, Payload, Telemetry};
 use crate::sink::Sink;
 use crate::source::flushes_per_second;
+use crate::time;
+use byteorder::{BigEndian, ByteOrder};
+use protobuf::repeated::RepeatedField;
+use protobuf::stream::CodedOutputStream;
+use protobuf::Message;
 use std::collections::HashMap;
 use std::io::BufWriter;
 use std::mem::replace;
 use std::net::{TcpStream, ToSocketAddrs};
-use crate::time;
 
 /// The native sink
 ///

--- a/src/source/file/file_server.rs
+++ b/src/source/file/file_server.rs
@@ -1,15 +1,15 @@
-use glob::glob;
 use crate::metric;
-use mio;
 use crate::source;
 use crate::source::file::file_watcher::FileWatcher;
 use crate::source::internal::report_full_telemetry;
+use crate::util;
+use crate::util::send;
+use glob::glob;
+use mio;
 use std::mem;
 use std::path::PathBuf;
 use std::str;
 use std::time;
-use crate::util;
-use crate::util::send;
 
 /// `FileServer` is a Source which cooperatively schedules reads over files,
 /// converting the lines of said files into `LogLine` structures. As
@@ -66,7 +66,6 @@ impl Default for FileServerConfig {
 /// problem but your intrepid authors know of no generic solution.
 impl source::Source<FileServerConfig> for FileServer {
     /// Make a FileServer
-    ///
     fn init(config: FileServerConfig) -> Self {
         let pattern = config.path.expect("must specify a 'path' for FileServer");
         FileServer {
@@ -124,9 +123,10 @@ impl source::Source<FileServerConfig> for FileServer {
                 report_full_telemetry(
                     "cernan.sources.file.bytes_read",
                     bytes_read as f64,
-                    Some(vec![
-                        ("file_path", path.to_str().expect("not a valid path")),
-                    ]),
+                    Some(vec![(
+                        "file_path",
+                        path.to_str().expect("not a valid path"),
+                    )]),
                 );
                 // A FileWatcher is dead when the underlying file has
                 // disappeared. If the FileWatcher is dead we don't stick it in

--- a/src/source/file/file_watcher.rs
+++ b/src/source/file/file_watcher.rs
@@ -93,12 +93,10 @@ impl FileWatcher {
                 report_full_telemetry(
                     "cernan.sources.file.switch",
                     1.0,
-                    Some(vec![
-                        (
-                            "file_path",
-                            self.path.to_str().expect("could not make path"),
-                        ),
-                    ]),
+                    Some(vec![(
+                        "file_path",
+                        self.path.to_str().expect("could not make path"),
+                    )]),
                 );
             }
         } else {
@@ -151,12 +149,10 @@ impl FileWatcher {
                 report_full_telemetry(
                     "cernan.sources.file.truncation",
                     (self.previous_size - current_size) as f64,
-                    Some(vec![
-                        (
-                            "file_path",
-                            self.path.to_str().expect("could not make path"),
-                        ),
-                    ]),
+                    Some(vec![(
+                        "file_path",
+                        self.path.to_str().expect("could not make path"),
+                    )]),
                 );
             }
             self.previous_size = current_size;

--- a/src/source/file/mod.rs
+++ b/src/source/file/mod.rs
@@ -9,12 +9,12 @@ mod test {
 
     use self::file_watcher::FileWatcher;
     use super::*;
+    use crate::time;
     use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
     use std::fs;
     use std::io::Write;
     use std::os::unix::fs::MetadataExt;
     use std::str;
-    use crate::time;
     // Welcome.
     //
     // This suite of tests is structured as an interpreter of file system

--- a/src/source/flush.rs
+++ b/src/source/flush.rs
@@ -1,10 +1,10 @@
 use crate::metric;
-use mio;
 use crate::source;
-use std::thread::sleep;
-use std::time::Duration;
 use crate::util;
 use crate::util::send;
+use mio;
+use std::thread::sleep;
+use std::time::Duration;
 
 /// The source of all flush pulses.
 pub struct FlushTimer;

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -1,14 +1,14 @@
-use coco::Stack;
 use crate::filter;
 use crate::metric;
 use crate::metric::{AggregationMethod, Telemetry};
-use mio;
 use crate::sink;
 use crate::source;
-use std;
-use std::sync::atomic::Ordering;
 use crate::time;
 use crate::util;
+use coco::Stack;
+use mio;
+use std;
+use std::sync::atomic::Ordering;
 
 lazy_static! {
     static ref Q: Stack<metric::Telemetry> = Stack::new();
@@ -76,7 +76,7 @@ macro_rules! atom_telem {
                 .unwrap();
             util::send(&mut $chans, metric::Event::new_telemetry(telem));
         }
-    }
+    };
 }
 
 macro_rules! atom_set_telem {
@@ -93,7 +93,7 @@ macro_rules! atom_set_telem {
                 .unwrap();
             util::send(&mut $chans, metric::Event::new_telemetry(telem));
         }
-    }
+    };
 }
 
 /// Internal as Source
@@ -250,21 +250,18 @@ impl source::Source<InternalConfig> for Internal {
                             chans
                         );
                         atom_telem!(
-                           "cernan.sinks.elasticsearch.error.api.action_request_validation",
-                           sink::elasticsearch::ELASTIC_ERROR_API_ACTION_REQUEST_VALIDATION,
-                           
-                           chans
-                       );
+                            "cernan.sinks.elasticsearch.error.api.action_request_validation",
+                            sink::elasticsearch::ELASTIC_ERROR_API_ACTION_REQUEST_VALIDATION,
+                            chans
+                        );
                         atom_telem!(
                             "cernan.sinks.elasticsearch.error.api.action_document_missing",
                             sink::elasticsearch::ELASTIC_ERROR_API_DOCUMENT_MISSING,
-                            
                             chans
                         );
                         atom_telem!(
                             "cernan.sinks.elasticsearch.error.api.index_already_exists",
                             sink::elasticsearch::ELASTIC_ERROR_API_INDEX_ALREADY_EXISTS,
-                            
                             chans
                         );
                         atom_telem!(
@@ -311,7 +308,6 @@ impl source::Source<InternalConfig> for Internal {
                         atom_telem!(
                             "cernan.sinks.wavefront.aggregation.summarize.total_percentiles",
                             sink::wavefront::WAVEFRONT_AGGR_TOT_PERCENT,
-                            
                             chans
                         );
                         atom_telem!(
@@ -338,13 +334,11 @@ impl source::Source<InternalConfig> for Internal {
                         atom_telem!(
                             "cernan.sinks.prometheus.aggregation.inside_baseball.windowed.purged",
                             sink::prometheus::PROMETHEUS_AGGR_WINDOWED_PURGED,
-                            
                             chans
                         );
                         atom_telem!(
                             "cernan.sinks.prometheus.exposition.inside_baseball.delay.sum",
                             sink::prometheus::PROMETHEUS_RESPONSE_DELAY_SUM,
-                            
                             chans
                         );
                         atom_set_telem!(

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -3,10 +3,10 @@
 //! In cernan a `Source` is a place where all `metric::Event` come from, feeding
 //! down into the source's forwards for further processing. Statsd is a source
 //! that creates `Telemetry`, `FileServer` is a source that creates `LogLine`s.
-use mio;
-use std::marker::PhantomData;
 use crate::thread;
 use crate::util;
+use mio;
+use std::marker::PhantomData;
 
 mod avro;
 mod file;
@@ -20,7 +20,7 @@ mod tcp;
 
 pub use self::avro::Avro;
 pub use self::file::{FileServer, FileServerConfig};
-pub use self::flush::{FlushTimer, FlushTimerConfig, flushes_per_second};
+pub use self::flush::{flushes_per_second, FlushTimer, FlushTimerConfig};
 pub use self::graphite::{Graphite, GraphiteConfig};
 pub use self::internal::{report_full_telemetry, Internal, InternalConfig};
 pub use self::native::{NativeServer, NativeServerConfig};

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -1,13 +1,13 @@
 use crate::constants;
 use crate::metric;
-use mio;
-use protobuf;
 use crate::protocols::native::{AggregationMethod, Payload};
 use crate::source::{BufferedPayload, PayloadErr, TCPConfig, TCPStreamHandler, TCP};
+use crate::util;
+use mio;
+use protobuf;
 use std::net;
 use std::str;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use crate::util;
 
 /// Total payloads processed.
 pub static NATIVE_PAYLOAD_SUCCESS_SUM: AtomicUsize = AtomicUsize::new(0);
@@ -84,8 +84,8 @@ impl TCPStreamHandler for NativeStreamHandler {
                                 while streaming {
                                     match reader.read() {
                                         Ok(mut raw) => {
-                                            let handle_res =
-                                                self.handle_stream_payload(
+                                            let handle_res = self
+                                                .handle_stream_payload(
                                                     chans.clone(),
                                                     &mut raw,
                                                 );

--- a/src/source/nonblocking.rs
+++ b/src/source/nonblocking.rs
@@ -2,8 +2,8 @@
 
 use byteorder::{BigEndian, ReadBytesExt};
 use mio;
-use std::{io, mem};
 use std::io::{Read, Write};
+use std::{io, mem};
 
 /// Like `std::net::TcpStream::write_all`, except it handles `WouldBlock` too.
 pub fn write_all(
@@ -137,8 +137,8 @@ impl BufferedPayload {
     }
 
     /// Attempts to read at least one payload worth of data.  If there
-    /// isn't enough data between the inner buffer and the underlying stream, then
-    /// PayloadErr::WouldBlock is returned.
+    /// isn't enough data between the inner buffer and the underlying stream,
+    /// then PayloadErr::WouldBlock is returned.
     fn read_payload(&mut self) -> Result<(), PayloadErr> {
         // At this point we can assume that we have successfully
         // read the length off the wire.
@@ -150,7 +150,8 @@ impl BufferedPayload {
         }
 
         loop {
-            match self.buffer
+            match self
+                .buffer
                 .read(&mut self.payload[self.payload_pos..payload_size])
             {
                 Ok(0) => return Err(PayloadErr::EOF),

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,8 +5,8 @@
 //! module for more details.
 
 use chrono::offset::Utc;
-use std::{thread, time};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{thread, time};
 
 lazy_static! {
     static ref NOW: AtomicUsize = AtomicUsize::new(Utc::now().timestamp() as usize);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 //! Utility module, a grab-bag of functionality
 use crate::constants;
-use hopper;
 use crate::metric;
+use hopper;
 use mio;
 use seahash::SeaHasher;
 use slab;

--- a/tests/programmable_filter.rs
+++ b/tests/programmable_filter.rs
@@ -3,8 +3,9 @@ mod integration {
 
         extern crate cernan;
 
-        use self::cernan::filter::{Filter, ProgrammableFilter,
-                                   ProgrammableFilterConfig};
+        use self::cernan::filter::{
+            Filter, ProgrammableFilter, ProgrammableFilterConfig,
+        };
         use self::cernan::metric;
         use self::cernan::metric::AggregationMethod;
         use std::path::PathBuf;
@@ -94,8 +95,9 @@ mod integration {
             let log = metric::LogLine::new(
                 "clear_me",
                 "i am the very model of the modern major general",
-            ).overlay_tag("foo", "bar")
-                .overlay_tag("bizz", "bazz");
+            )
+            .overlay_tag("foo", "bar")
+            .overlay_tag("bizz", "bazz");
             let event = metric::Event::new_log(log);
 
             let mut events: Vec<metric::Event> = Vec::new();
@@ -123,13 +125,15 @@ mod integration {
             let orig_log = metric::LogLine::new(
                 "identity",
                 "i am the very model of the modern major general",
-            ).overlay_tag("foo", "bar")
-                .overlay_tag("bizz", "bazz");
+            )
+            .overlay_tag("foo", "bar")
+            .overlay_tag("bizz", "bazz");
             let expected_log = metric::LogLine::new(
                 "identity",
                 "i am the very model of the modern major \
                  general",
-            ).overlay_tag("foo", "bar");
+            )
+            .overlay_tag("foo", "bar");
             let orig_event = metric::Event::new_log(orig_log);
             let expected_event = metric::Event::new_log(expected_log);
 
@@ -165,7 +169,8 @@ mod integration {
                 "identity",
                 "i am the very model of the modern major \
                  general",
-            ).insert_field("foo", "identity");
+            )
+            .insert_field("foo", "identity");
             let orig_event = metric::Event::new_log(orig_log);
             let expected_event = metric::Event::new_log(expected_log);
 
@@ -197,10 +202,7 @@ mod integration {
                 "identity",
                 "i am the very model of the modern major general",
             );
-            let expected_log = metric::LogLine::new(
-                "identity",
-                "foo"
-            );
+            let expected_log = metric::LogLine::new("identity", "foo");
             let orig_event = metric::Event::new_log(orig_log);
             let expected_event = metric::Event::new_log(expected_log);
 
@@ -368,12 +370,14 @@ mod integration {
                 "identity",
                 "i am the very model of the modern major \
                  general",
-            ).overlay_tag("foo", "bar")
-                .overlay_tag("bizz", "bazz");
+            )
+            .overlay_tag("foo", "bar")
+            .overlay_tag("bizz", "bazz");
             let orig_log = metric::LogLine::new(
                 "identity",
                 "i am the very model of the modern major general",
-            ).overlay_tag("foo", "bar");
+            )
+            .overlay_tag("foo", "bar");
             let orig_event = metric::Event::new_log(orig_log);
             let expected_event = metric::Event::new_log(expected_log);
 
@@ -405,12 +409,14 @@ mod integration {
                 "identity",
                 "i am the very model of the modern major \
                  general",
-            ).overlay_tag("foo", "bar")
-                .overlay_tag("bizz", "bazz");
+            )
+            .overlay_tag("foo", "bar")
+            .overlay_tag("bizz", "bazz");
             let orig_log = metric::LogLine::new(
                 "identity",
                 "i am the very model of the modern major general",
-            ).overlay_tag("foo", "bar");
+            )
+            .overlay_tag("foo", "bar");
             let orig_event = metric::Event::new_log(orig_log);
             let expected_event = metric::Event::new_log(expected_log);
 


### PR DESCRIPTION
* Upgrades `rustfmt` config to be post 1.0 (still nightly though) compatible
* Re-formats existing code
* Sets `rustfmt` up to run in Travis

Fixes #453