### PR TITLE
Fix clippy violations and run clippy in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ rust:
 
 before_script:
   - rustup component add rustfmt
+  - rustup component add clippy
 script:
   - cargo fmt --all -- --check
+  - cargo clippy -- -A clippy::redundant_field_names
   - cargo clean
   - cargo test
 

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -73,7 +73,7 @@ macro_rules! cfg_conf {
     };
 }
 
-#[allow(cyclomatic_complexity)]
+#[allow(clippy::cyclomatic_complexity)]
 fn main() {
     openssl_probe::init_ssl_cert_env_vars();
 

--- a/src/bin/cernan.rs
+++ b/src/bin/cernan.rs
@@ -505,7 +505,7 @@ fn main() {
 
     // FILTERS
     //
-    mem::replace(&mut args.programmable_filters, None).map(|cfg_map| {
+    if let Some(cfg_map) = mem::replace(&mut args.programmable_filters, None) {
         for config in cfg_map.values() {
             let c: ProgrammableFilterConfig = (*config).clone();
             let recv = receivers
@@ -539,9 +539,9 @@ fn main() {
                 }),
             );
         }
-    });
+    };
 
-    mem::replace(&mut args.delay_filters, None).map(|cfg_map| {
+    if let Some(cfg_map) = mem::replace(&mut args.delay_filters, None) {
         for config in cfg_map.values() {
             let c: DelayFilterConfig = (*config).clone();
             let recv = receivers
@@ -576,9 +576,9 @@ fn main() {
                 }),
             );
         }
-    });
+    };
 
-    mem::replace(&mut args.json_encode_filters, None).map(|cfg_map| {
+    if let Some(cfg_map) = mem::replace(&mut args.json_encode_filters, None) {
         for config in cfg_map.values() {
             let c: JSONEncodeFilterConfig = (*config).clone();
             let recv = receivers
@@ -613,9 +613,9 @@ fn main() {
                 }),
             );
         }
-    });
+    };
 
-    mem::replace(&mut args.flush_boundary_filters, None).map(|cfg_map| {
+    if let Some(cfg_map) = mem::replace(&mut args.flush_boundary_filters, None) {
         for config in cfg_map.values() {
             let c: FlushBoundaryFilterConfig = (*config).clone();
             let recv = receivers
@@ -649,11 +649,11 @@ fn main() {
                 }),
             );
         }
-    });
+    };
 
     // SOURCES
     //
-    mem::replace(&mut args.native_server_config, None).map(|cfg_map| {
+    if let Some(cfg_map) = mem::replace(&mut args.native_server_config, None) {
         for (config_path, config) in cfg_map {
             populate_forwards(
                 Some(&mut flush_sends),
@@ -670,7 +670,7 @@ fn main() {
                     .run(),
             );
         }
-    });
+    };
 
     let internal_config = mem::replace(&mut args.internal, Default::default());
     let internal_config_path = internal_config.config_path.clone().unwrap();
@@ -688,7 +688,7 @@ fn main() {
         cernan::source::Internal::new(internal_send, internal_config).run(),
     );
 
-    mem::replace(&mut args.statsds, None).map(|cfg_map| {
+    if let Some(cfg_map) = mem::replace(&mut args.statsds, None) {
         for (config_path, config) in cfg_map {
             populate_forwards(
                 Some(&mut flush_sends),
@@ -704,9 +704,9 @@ fn main() {
                 cernan::source::Statsd::new(statsd_sends, config).run(),
             );
         }
-    });
+    };
 
-    mem::replace(&mut args.graphites, None).map(|cfg_map| {
+    if let Some(cfg_map) = mem::replace(&mut args.graphites, None) {
         for (config_path, config) in cfg_map {
             populate_forwards(
                 Some(&mut flush_sends),
@@ -722,9 +722,9 @@ fn main() {
                 cernan::source::Graphite::new(graphite_sends, config.into()).run(),
             );
         }
-    });
+    };
 
-    mem::replace(&mut args.avros, None).map(|cfg_map| {
+    if let Some(cfg_map) = mem::replace(&mut args.avros, None) {
         for (config_path, config) in cfg_map {
             populate_forwards(
                 Some(&mut flush_sends),
@@ -740,9 +740,9 @@ fn main() {
                 cernan::source::Avro::new(avro_sends, config).run(),
             );
         }
-    });
+    };
 
-    mem::replace(&mut args.files, None).map(|cfg| {
+    if let Some(cfg) = mem::replace(&mut args.files, None) {
         for config in cfg {
             let config_path = config.config_path.clone().unwrap();
             populate_forwards(
@@ -759,7 +759,7 @@ fn main() {
                 cernan::source::FileServer::new(fp_sends, config).run(),
             );
         }
-    });
+    };
 
     // BACKGROUND
     //

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -34,8 +34,8 @@ pub enum FilterError {
 
 fn msg_in_fe(fe: &FilterError) -> &str {
     match fe {
-        &FilterError::NoSuchFunction(n, _) => n,
-        &FilterError::LuaError(ref n, _) => n,
+        FilterError::NoSuchFunction(n, _) => n,
+        FilterError::LuaError(ref n, _) => n,
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -32,8 +32,7 @@ fn http_server<H>(
     poller: &thread::Poll,
     tiny_http_server: &tiny_http::Server,
     handler: &H,
-) -> ()
-where
+) where
     H: Handler,
 {
     loop {

--- a/src/metric/ackbag.rs
+++ b/src/metric/ackbag.rs
@@ -64,12 +64,11 @@ impl SyncAckBag {
     /// Retrieve a mutable reference to the SyncAckProps for the key and invoke
     /// a callback if it exists. If the key is not present, then the
     /// callback is not called.
-    pub fn with_props<F: FnOnce(&mut SyncAckProps)>(&self, key: Uuid, f: F) {
+    pub fn with_props<F: FnOnce(&mut SyncAckProps)>(&self, key: Uuid, callback: F) {
         let mut bag = self.waiting_syncs.lock().unwrap();
-        match bag.get_mut(&key) {
-            Some(v) => Some(f(v)),
-            None => None,
-        };
+        if let Some(v) = bag.get_mut(&key) {
+            callback(v);
+        }
     }
 
     /// Wait until the number of acks in the specified key becomes non-zero.

--- a/src/metric/event.rs
+++ b/src/metric/event.rs
@@ -21,6 +21,7 @@ pub type Metadata = HashMap<Vec<u8>, Vec<u8>>;
 /// Event is the heart of cernan, the enumeration that cernan works on in all
 /// cases. The enumeration fields drive sink / source / filter operations
 /// depending on their implementation.
+#[allow(clippy::large_enum_variant)]
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
 pub enum Event {
     /// A wrapper for `metric::Telemetry`. See its documentation for more

--- a/src/metric/telemetry.rs
+++ b/src/metric/telemetry.rs
@@ -512,7 +512,7 @@ pub enum Error {
 impl Telemetry {
     /// Make a builder for metrics
     ///
-    /// This function returns a TelemetryBuidler with a name set. A metric must
+    /// This function returns a TelemetryBuilder with a name set. A metric must
     /// have _at least_ a name and a value but values may be delayed behind
     /// names.
     ///
@@ -527,6 +527,7 @@ impl Telemetry {
     /// assert_eq!(m.name, "foo");
     /// assert_eq!(m.set(), Some(1.1));
     /// ```
+    #[allow(clippy::new_ret_no_self)]
     pub fn new() -> SoftTelemetry {
         SoftTelemetry {
             name: None,

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -1,5 +1,8 @@
 //! The input protocols that cernan must parse. Not all sources are reflected
 //! here. These modules are used by the sources to do their work.
+
+#![allow(renamed_and_removed_lints)]
+
 pub mod graphite;
 pub mod native;
 pub mod prometheus;

--- a/src/protocols/statsd.rs
+++ b/src/protocols/statsd.rs
@@ -53,7 +53,7 @@ pub fn parse_statsd(
                         metric = metric.name(name);
                         metric = metric.value(val);
                         metric = metric.timestamp(time::now());
-                        let signed = match &src[offset..(offset + 1)] {
+                        let signed = match &src[offset..=offset] {
                             "+" | "-" => true,
                             _ => false,
                         };

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -78,11 +78,11 @@ impl Sink<ConsoleConfig> for Console {
         Valve::Open
     }
 
-    fn deliver(&mut self, point: Telemetry) -> () {
+    fn deliver(&mut self, point: Telemetry) {
         self.aggrs.add(point);
     }
 
-    fn deliver_line(&mut self, line: LogLine) -> () {
+    fn deliver_line(&mut self, line: LogLine) {
         self.buffer.append(&mut vec![line]);
     }
 
@@ -195,7 +195,7 @@ impl Sink<ConsoleConfig> for Console {
         self.aggrs.reset();
     }
 
-    fn shutdown(mut self) -> () {
+    fn shutdown(mut self) {
         self.flush();
     }
 }

--- a/src/sink/elasticsearch.rs
+++ b/src/sink/elasticsearch.rs
@@ -123,7 +123,7 @@ pub struct Elasticsearch {
 }
 
 impl Elasticsearch {
-    fn bulk_body(&self, buffer: &mut String) -> () {
+    fn bulk_body(&self, buffer: &mut String) {
         assert!(!self.buffer.is_empty());
         use serde_json::{to_string, Value};
         for m in &self.buffer {
@@ -334,11 +334,11 @@ impl Sink<ElasticsearchConfig> for Elasticsearch {
         }
     }
 
-    fn shutdown(mut self) -> () {
+    fn shutdown(mut self) {
         self.flush();
     }
 
-    fn deliver_line(&mut self, line: LogLine) -> () {
+    fn deliver_line(&mut self, line: LogLine) {
         let uuid = uuid::Uuid::new_v4();
         self.buffer.push(Line {
             uuid: uuid,

--- a/src/sink/elasticsearch.rs
+++ b/src/sink/elasticsearch.rs
@@ -176,7 +176,7 @@ impl Sink<ElasticsearchConfig> for Elasticsearch {
         Some(self.flush_interval)
     }
 
-    #[allow(cyclomatic_complexity)]
+    #[allow(clippy::cyclomatic_complexity)]
     fn flush(&mut self) {
         if self.buffer.is_empty() {
             return;

--- a/src/sink/elasticsearch.rs
+++ b/src/sink/elasticsearch.rs
@@ -95,7 +95,7 @@ impl Default for ElasticsearchConfig {
             index_type: "payload".to_string(),
             delivery_attempt_limit: 10,
             port: 9200,
-            flush_interval: 1 * flushes_per_second(),
+            flush_interval: flushes_per_second(),
             tags: TagMap::default(),
         }
     }

--- a/src/sink/influxdb.rs
+++ b/src/sink/influxdb.rs
@@ -75,7 +75,7 @@ impl Default for InfluxDBConfig {
 }
 
 #[inline]
-fn fmt_tags(tags: TagIter, s: &mut String) -> () {
+fn fmt_tags(tags: TagIter, s: &mut String) {
     for (k, v) in tags {
         s.push_str(",");
         s.push_str(k);
@@ -101,7 +101,7 @@ where
 
 impl InfluxDB {
     /// Convert the slice into a payload that can be sent to InfluxDB
-    fn format_stats(&self, buffer: &mut String, telems: &[Telemetry]) -> () {
+    fn format_stats(&self, buffer: &mut String, telems: &[Telemetry]) {
         use crate::metric::AggregationMethod;
         let mut time_cache: Vec<(u64, String)> = Vec::with_capacity(128);
         let mut value_cache: Vec<(f64, String)> = Vec::with_capacity(128);
@@ -278,11 +278,11 @@ impl Sink<InfluxDBConfig> for InfluxDB {
         self.aggrs.clear();
     }
 
-    fn shutdown(mut self) -> () {
+    fn shutdown(mut self) {
         self.flush();
     }
 
-    fn deliver(&mut self, point: Telemetry) -> () {
+    fn deliver(&mut self, point: Telemetry) {
         self.aggrs.push(point);
     }
 

--- a/src/sink/kafka.rs
+++ b/src/sink/kafka.rs
@@ -371,7 +371,7 @@ impl Sink<KafkaConfig> for Kafka {
         Some(self.flush_interval)
     }
 
-    fn shutdown(mut self) -> () {
+    fn shutdown(mut self) {
         self.flush();
     }
 }

--- a/src/sink/kafka.rs
+++ b/src/sink/kafka.rs
@@ -33,7 +33,7 @@ impl STFUContext {
         // Don't emit noisy errors about idle connection disconnects.
         let matches: Vec<_> =
             message.matches("Receive failed: Disconnected").collect();
-        matches.len() == 0
+        matches.is_empty()
     }
 }
 

--- a/src/sink/kafka.rs
+++ b/src/sink/kafka.rs
@@ -239,7 +239,7 @@ impl FailedMessageWrapper {
                     let (k, v) = h.get(idx).unwrap();
                     hash_map.insert(k.as_bytes().to_vec(), v.to_vec());
                 }
-                return Some(hash_map);
+                Some(hash_map)
             }
             None => None,
         }

--- a/src/sink/kafka.rs
+++ b/src/sink/kafka.rs
@@ -1,7 +1,7 @@
 //! Kafka sink for Raw events.
 use crate::metric::{global_ack_bag, Encoding, Metadata};
 use crate::sink::Sink;
-use crate::source;
+use crate::source::flushes_per_second;
 use crate::util::Valve;
 use futures::future::Future;
 use rdkafka::client::ClientContext;
@@ -98,7 +98,7 @@ impl Default for KafkaConfig {
             brokers: None,
             rdkafka_config: None,
             max_message_bytes: 10 * (1 << 20),
-            flush_interval: 1 * source::flushes_per_second(),
+            flush_interval: flushes_per_second(),
         }
     }
 }

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -77,7 +77,7 @@ where
         })
     }
 
-    fn consume(mut self) -> () {
+    fn consume(mut self) {
         let mut attempts = 0;
         let mut recv = self.recv.into_iter();
         let mut last_flush_idx = 0;
@@ -233,12 +233,12 @@ where
     }
     /// Deliver a `Telemetry` to the `Sink`. Exact behaviour varies by
     /// implementation.
-    fn deliver(&mut self, _telem: Telemetry) -> () {
+    fn deliver(&mut self, _telem: Telemetry) {
         // nothing, intentionally
     }
     /// Deliver a `LogLine` to the `Sink`. Exact behaviour varies by
     /// implementation.
-    fn deliver_line(&mut self, _line: LogLine) -> () {
+    fn deliver_line(&mut self, _line: LogLine) {
         // nothing, intentionally
     }
     /// Deliver a 'Raw' series of encoded bytes to the sink.
@@ -249,7 +249,7 @@ where
         _bytes: Vec<u8>,
         _metadata: Option<Metadata>,
         _connection_id: Option<Uuid>,
-    ) -> () {
+    ) {
         // Not all sinks accept raw events.  By default, we do nothing.
     }
     /// Provide a hook to shutdown a sink. This is necessary for sinks which

--- a/src/sink/native.rs
+++ b/src/sink/native.rs
@@ -102,11 +102,11 @@ impl Sink<NativeConfig> for Native {
         }
     }
 
-    fn deliver(&mut self, telemetry: metric::Telemetry) -> () {
+    fn deliver(&mut self, telemetry: metric::Telemetry) {
         self.buffer.push(metric::Event::Telemetry(telemetry));
     }
 
-    fn deliver_line(&mut self, line: metric::LogLine) -> () {
+    fn deliver_line(&mut self, line: metric::LogLine) {
         self.buffer.push(metric::Event::Log(line));
     }
 
@@ -202,7 +202,7 @@ impl Sink<NativeConfig> for Native {
         }
     }
 
-    fn shutdown(mut self) -> () {
+    fn shutdown(mut self) {
         self.flush();
     }
 }

--- a/src/sink/null.rs
+++ b/src/sink/null.rs
@@ -38,7 +38,7 @@ impl Sink<NullConfig> for Null {
         // do nothing
     }
 
-    fn shutdown(mut self) -> () {
+    fn shutdown(mut self) {
         self.flush();
     }
 }

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -433,7 +433,7 @@ impl http::Handler for PrometheusHandler {
     }
 }
 
-#[allow(cyclomatic_complexity)]
+#[allow(clippy::cyclomatic_complexity)]
 #[inline]
 fn fmt_tags<W>(mut iter: TagIter, s: &mut GzEncoder<W>) -> ()
 where

--- a/src/sink/prometheus.rs
+++ b/src/sink/prometheus.rs
@@ -390,7 +390,7 @@ struct PrometheusHandler {
 }
 
 impl http::Handler for PrometheusHandler {
-    fn handle(&self, request: http::Request) -> () {
+    fn handle(&self, request: http::Request) {
         let mut buffer = Vec::with_capacity(2048);
         if let Ok(ref aggr) = self.aggr.try_lock() {
             PROMETHEUS_AGGR_REPORTABLE.store(aggr.count(), Ordering::Relaxed);
@@ -435,7 +435,7 @@ impl http::Handler for PrometheusHandler {
 
 #[allow(clippy::cyclomatic_complexity)]
 #[inline]
-fn fmt_tags<W>(mut iter: TagIter, s: &mut GzEncoder<W>) -> ()
+fn fmt_tags<W>(mut iter: TagIter, s: &mut GzEncoder<W>)
 where
     W: Write,
 {
@@ -644,7 +644,7 @@ impl Sink<PrometheusConfig> for Prometheus {
         PROMETHEUS_AGGR_WINDOWED_PURGED.store(total_purged, Ordering::Relaxed);
     }
 
-    fn deliver(&mut self, telem: metric::Telemetry) -> () {
+    fn deliver(&mut self, telem: metric::Telemetry) {
         if let Some(age_threshold) = self.age_threshold {
             if (telem.timestamp - time::now()).abs() <= (age_threshold as i64) {
                 self.aggrs.lock().unwrap().insert(telem);
@@ -654,7 +654,7 @@ impl Sink<PrometheusConfig> for Prometheus {
         }
     }
 
-    fn shutdown(mut self) -> () {
+    fn shutdown(mut self) {
         self.flush();
         self.http_srv.shutdown();
     }

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -180,7 +180,7 @@ impl<'a> Pad<'a> {
         }
     }
 
-    pub fn skip_pad(&self, pad_control: &PadControl) -> bool {
+    pub fn skip_pad(&self, pad_control: PadControl) -> bool {
         match *self {
             Pad::Zero(_, _) => true,
             Pad::Telem(x) => match x.kind() {
@@ -252,7 +252,7 @@ impl<'a> Iterator for Padding<'a> {
                 // is not part of our current sequence and it requires no
                 // padding.
                 if x.hash() == y.hash() {
-                    if x.skip_pad(&self.pad_control) {
+                    if x.skip_pad(self.pad_control) {
                         self.emit_q.push(y);
                         return Some(x);
                     }
@@ -315,7 +315,7 @@ impl<'a> Iterator for Padding<'a> {
             (Some(x), None) => {
                 self.last_hash = x.hash();
                 // end of sequence
-                if x.skip_pad(&self.pad_control) {
+                if x.skip_pad(self.pad_control) {
                     return Some(x);
                 }
                 let flush_padded = self.flush_padded.contains(&x.hash());

--- a/src/sink/wavefront.rs
+++ b/src/sink/wavefront.rs
@@ -139,7 +139,7 @@ impl Default for WavefrontConfig {
 }
 
 #[inline]
-fn fmt_tags(mut iter: TagIter, s: &mut String) -> () {
+fn fmt_tags(mut iter: TagIter, s: &mut String) {
     if let Some((fk, fv)) = iter.next() {
         s.push_str(fk);
         s.push_str("=");
@@ -386,7 +386,7 @@ fn connect(host: &str, port: u16) -> Option<TcpStream> {
 impl Wavefront {
     /// Convert the buckets into a String that
     /// can be sent to the the wavefront proxy
-    pub fn format_stats(&mut self) -> () {
+    pub fn format_stats(&mut self) {
         let mut time_cache: Vec<(i64, String)> = Vec::with_capacity(128);
         let mut count_cache: Vec<(usize, String)> = Vec::with_capacity(128);
         let mut value_cache: Vec<(f64, String)> = Vec::with_capacity(128);
@@ -462,7 +462,7 @@ impl Wavefront {
         mut time_cache: &mut Vec<(i64, String)>,
         mut count_cache: &mut Vec<(usize, String)>,
         mut value_cache: &mut Vec<(f64, String)>,
-    ) -> () {
+    ) {
         let mut tag_buf = String::with_capacity(1_024);
         match value.kind() {
             AggregationMethod::Histogram => {
@@ -636,11 +636,11 @@ impl Sink<WavefrontConfig> for Wavefront {
         }
     }
 
-    fn shutdown(mut self) -> () {
+    fn shutdown(mut self) {
         self.flush();
     }
 
-    fn deliver(&mut self, telem: Telemetry) -> () {
+    fn deliver(&mut self, telem: Telemetry) {
         if let Some(age_threshold) = self.age_threshold {
             if (telem.timestamp - time::now()).abs() <= (age_threshold as i64) {
                 self.aggrs.add(telem);

--- a/src/source/avro.rs
+++ b/src/source/avro.rs
@@ -171,7 +171,7 @@ impl TCPStreamHandler for AvroStreamHandler {
         chans: util::Channel,
         poller: &mio::Poll,
         stream: mio::net::TcpStream,
-    ) -> () {
+    ) {
         let connection_id = Uuid::new_v4();
         let mut streaming = true;
         let mut reader = BufferedPayload::new(stream.try_clone().unwrap(), 1_048_576);

--- a/src/source/file/file_server.rs
+++ b/src/source/file/file_server.rs
@@ -74,7 +74,7 @@ impl source::Source<FileServerConfig> for FileServer {
         }
     }
 
-    fn run(self, mut chans: util::Channel, poller: mio::Poll) -> () {
+    fn run(self, mut chans: util::Channel, poller: mio::Poll) {
         let mut buffer = String::new();
 
         let mut fp_map: util::HashMap<PathBuf, FileWatcher> = Default::default();

--- a/src/source/file/file_watcher.rs
+++ b/src/source/file/file_watcher.rs
@@ -76,7 +76,7 @@ impl FileWatcher {
         }
     }
 
-    fn open_at_start(&mut self) -> () {
+    fn open_at_start(&mut self) {
         if let Ok(f) = fs::File::open(&self.path) {
             let metadata = f.metadata().unwrap(); // we _must_ be able to read the metadata
             let dev = metadata.dev();

--- a/src/source/file/mod.rs
+++ b/src/source/file/mod.rs
@@ -199,7 +199,7 @@ mod test {
     // What we can do, though, is drive our FWFile model and the SUT at the same
     // time, recording the total number of reads/writes. The SUT reads should be
     // bounded below by the model reads, bounded above by the writes.
-    fn experiment(actions: Vec<FWAction>) -> () {
+    fn experiment(actions: Vec<FWAction>) {
         let dir = tempdir::TempDir::new("file_watcher_qc").unwrap();
         let path = dir.path().join("a_file.log");
         let mut fp = fs::File::create(&path).expect("could not create");
@@ -300,7 +300,7 @@ mod test {
     // This interpretation is the happy case. When there are no truncations our
     // model and SUT should agree exactly. To that end, we confirm that every
     // read from SUT exactly matches the reads from the model.
-    fn experiment_no_truncations(actions: Vec<FWAction>) -> () {
+    fn experiment_no_truncations(actions: Vec<FWAction>) {
         let dir = tempdir::TempDir::new("file_watcher_qc").unwrap();
         let path = dir.path().join("a_file.log");
         let mut fp = fs::File::create(&path).expect("could not create");

--- a/src/source/flush.rs
+++ b/src/source/flush.rs
@@ -28,7 +28,7 @@ impl source::Source<FlushTimerConfig> for FlushTimer {
         FlushTimer {}
     }
 
-    fn run(self, mut chans: util::Channel, _poller: mio::Poll) -> () {
+    fn run(self, mut chans: util::Channel, _poller: mio::Poll) {
         let flush_duration = Duration::from_millis(1000 / flushes_per_second());
         // idx will _always_ increase. If it's kept at u64 or greater it will
         // overflow long past the collapse of our industrial civilization even

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -47,7 +47,7 @@ pub fn report_full_telemetry(
     name: &str,
     value: f64,
     metadata: Option<Vec<(&str, &str)>>,
-) -> () {
+) {
     use crate::metric::AggregationMethod;
     let mut telem = metric::Telemetry::new()
         .name(name)
@@ -109,7 +109,7 @@ impl source::Source<InternalConfig> for Internal {
     }
 
     #[allow(clippy::cyclomatic_complexity)]
-    fn run(self, mut chans: util::Channel, poller: mio::Poll) -> () {
+    fn run(self, mut chans: util::Channel, poller: mio::Poll) {
         let slp = std::time::Duration::from_millis(1_000);
         loop {
             let mut events = mio::Events::with_capacity(1024);

--- a/src/source/internal.rs
+++ b/src/source/internal.rs
@@ -108,7 +108,7 @@ impl source::Source<InternalConfig> for Internal {
         Internal {}
     }
 
-    #[allow(cyclomatic_complexity)]
+    #[allow(clippy::cyclomatic_complexity)]
     fn run(self, mut chans: util::Channel, poller: mio::Poll) -> () {
         let slp = std::time::Duration::from_millis(1_000);
         loop {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -88,5 +88,5 @@ where
 
     /// Run method invoked by RunnableSource.
     /// It is from this method that Sources produce metric::Events.
-    fn run(self, chans: util::Channel, poller: mio::Poll) -> ();
+    fn run(self, chans: util::Channel, poller: mio::Poll);
 }

--- a/src/source/native.rs
+++ b/src/source/native.rs
@@ -66,7 +66,7 @@ impl TCPStreamHandler for NativeStreamHandler {
         chans: util::Channel,
         poller: &mio::Poll,
         stream: mio::net::TcpStream,
-    ) -> () {
+    ) {
         let mut streaming = true;
         let mut reader = BufferedPayload::new(stream.try_clone().unwrap(), 1_048_576);
         while streaming {

--- a/src/source/statsd.rs
+++ b/src/source/statsd.rs
@@ -160,7 +160,7 @@ impl source::Source<StatsdConfig> for Statsd {
         }
     }
 
-    fn run(self, mut chans: util::Channel, poller: mio::Poll) -> () {
+    fn run(self, mut chans: util::Channel, poller: mio::Poll) {
         for (idx, socket) in self.conns.iter() {
             if let Err(e) = poller.register(
                 socket,

--- a/src/source/tcp.rs
+++ b/src/source/tcp.rs
@@ -160,18 +160,13 @@ where
                                         "Removed {:?} terminated stream handlers.",
                                         ready.len()
                                     );
-                                } else {
-                                    if let Err(e) = self
-                                        .spawn_stream_handlers(&chans, listener_token)
-                                    {
-                                        let listener = &self.listeners[listener_token];
-                                        error!(
-                                            "Failed to spawn stream handlers! {:?}",
-                                            e
-                                        );
-                                        error!("Deregistering listener for {:?} due to unrecoverable error!", *listener);
-                                        let _ = poll.deregister(listener);
-                                    }
+                                } else if let Err(e) =
+                                    self.spawn_stream_handlers(&chans, listener_token)
+                                {
+                                    let listener = &self.listeners[listener_token];
+                                    error!("Failed to spawn stream handlers! {:?}", e);
+                                    error!("Deregistering listener for {:?} due to unrecoverable error!", *listener);
+                                    let _ = poll.deregister(listener);
                                 }
                             }
                         }

--- a/src/source/tcp.rs
+++ b/src/source/tcp.rs
@@ -108,7 +108,7 @@ where
     }
 
     /// Starts the accept loop.
-    fn run(self, chans: util::Channel, poller: mio::Poll) -> () {
+    fn run(self, chans: util::Channel, poller: mio::Poll) {
         for (idx, listener) in self.listeners.iter() {
             if let Err(e) = poller.register(
                 listener,
@@ -137,7 +137,7 @@ impl<H> TCP<H>
 where
     H: TCPStreamHandler,
 {
-    fn accept_loop(mut self, mut chans: util::Channel, poll: &mio::Poll) -> () {
+    fn accept_loop(mut self, mut chans: util::Channel, poll: &mio::Poll) {
         loop {
             let mut events = mio::Events::with_capacity(1024);
             match poll.poll(&mut events, None) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -85,8 +85,8 @@ pub enum Valve {
 }
 
 #[inline]
-fn token_to_idx(token: &mio::Token) -> usize {
-    match *token {
+fn token_to_idx(token: mio::Token) -> usize {
+    match token {
         mio::Token(idx) => idx,
     }
 }
@@ -108,13 +108,13 @@ impl<E: mio::Evented> Index<mio::Token> for TokenSlab<E> {
 
     /// Returns Evented object corresponding to Token.
     fn index(&self, token: mio::Token) -> &E {
-        &self.tokens[token_to_idx(&token)]
+        &self.tokens[token_to_idx(token)]
     }
 }
 
 impl<E: mio::Evented> IndexMut<mio::Token> for TokenSlab<E> {
     fn index_mut(&mut self, token: mio::Token) -> &mut E {
-        &mut self.tokens[token_to_idx(&token)]
+        &mut self.tokens[token_to_idx(token)]
     }
 }
 
@@ -127,7 +127,7 @@ impl<E: mio::Evented> TokenSlab<E> {
     pub fn new() -> TokenSlab<E> {
         TokenSlab {
             token_count: 0,
-            tokens: slab::Slab::with_capacity(token_to_idx(&constants::SYSTEM)),
+            tokens: slab::Slab::with_capacity(token_to_idx(constants::SYSTEM)),
         }
     }
 


### PR DESCRIPTION
This changeset fixes each of the clippy lints (per commit to make review easier).
Additionally clippy will now run in CI.

I chose to disable the redundant field names in structs lint for now as we do this everywhere in the codebase. I am not opposed to changing the style but figured I would leave as is for now.